### PR TITLE
Dual licensing model + auto-bootstrap support docs pack

### DIFF
--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -1,0 +1,101 @@
+# Statewave Commercial License
+
+Statewave is dual-licensed. You may use it under the terms of the
+[GNU Affero General Public License v3.0](LICENSE), **or** under a separate
+commercial license agreement with Statewave.
+
+This document is a plain-language overview of the commercial option. It is
+**not** the commercial license itself — the operative terms are contained in
+the signed agreement we provide on request.
+
+## When you need a commercial license
+
+You typically need a commercial license if any of the following apply:
+
+- You want to use Statewave inside a **proprietary or closed-source product**
+  without releasing your source code under AGPL.
+- You want to offer Statewave (or a derivative of it) as a **hosted, managed,
+  or SaaS service** to third parties.
+- You are building a **commercial SaaS** that uses Statewave as infrastructure
+  and you do not want the AGPL network-use obligations to apply to your
+  application code.
+- You need **enterprise terms** — SLA, indemnity, security review, support
+  contracts, custom contractual language, or procurement-friendly paperwork.
+- You want to **embed** Statewave in a distributed product (on-prem, edge,
+  appliance, OEM) without AGPL obligations flowing to your customers.
+
+If you only run Statewave for internal experiments, learning, research, local
+development, or in fully AGPL-compliant open-source projects, you do **not**
+need a commercial license — AGPLv3 is sufficient.
+
+## What the commercial license grants
+
+A Statewave commercial license is designed to remove AGPL obligations for
+qualifying commercial use cases. Typical grants include:
+
+- Right to use Statewave in **closed-source** software.
+- Right to operate Statewave as part of a **proprietary SaaS** without the
+  AGPL §13 source-disclosure obligation.
+- Right to **embed** Statewave in commercial products distributed to
+  customers.
+- Optional: support, SLA, security/compliance documentation, indemnity, and
+  managed-hosting options.
+
+Specific scope, term, territory, support, and pricing are defined in the
+signed commercial agreement.
+
+## Tiers (overview)
+
+The commercial offering is structured into tiers. Specific terms and
+pricing are confirmed in the signed agreement.
+
+| Tier        | Who it's for                                                        | Notes                                                                 |
+|-------------|----------------------------------------------------------------------|-----------------------------------------------------------------------|
+| Community   | Individuals, OSS projects, internal/local use under AGPLv3           | Free. Use AGPLv3 directly — no commercial license needed.             |
+| Startup     | Early-stage companies under a defined revenue/funding threshold      | Free or low-cost commercial license. Lightweight registration.        |
+| Growth      | Production SaaS / proprietary product use above the startup threshold | Paid commercial license. Removes AGPL obligations for covered use.    |
+| Enterprise  | Larger orgs needing SLA, indemnity, support, procurement, custom terms | Custom commercial agreement. Optional managed hosting.                |
+
+> The Startup tier exists so that small teams adopting Statewave early are
+> not blocked by AGPL obligations or by enterprise pricing. Qualifying
+> startups may not, however, offer Statewave itself as a competing hosted
+> memory/state service — see "Hosting & competition" below.
+
+See [docs/licensing.md](docs/licensing.md) for tier criteria and how to
+apply.
+
+## Hosting & competition
+
+Offering Statewave (or a substantially similar derivative) **as a hosted,
+managed, or SaaS service to third parties** requires either:
+
+1. Full compliance with AGPLv3 (including §13 network source-disclosure to
+   all users of the service), **and** compliance with the
+   [Statewave trademark policy](TRADEMARKS.md); or
+2. A separate commercial agreement with Statewave that explicitly grants
+   hosting/managed-service rights.
+
+The Startup commercial license **does not** include the right to operate a
+competing hosted Statewave service.
+
+## How to obtain a commercial license
+
+Contact:
+
+- **Email:** [licensing@statewave.ai](mailto:licensing@statewave.ai)
+- **General contact:** see the [statewave.ai](https://statewave.ai) site
+
+Please include:
+
+- Company name and a short description of intended use
+- Whether the use is internal, embedded, SaaS, or hosted-for-third-parties
+- Approximate scale (users, environments, revenue band)
+- Required terms (SLA, indemnity, support, procurement constraints)
+
+We will respond with the appropriate tier and a draft agreement.
+
+## Disclaimer
+
+This document describes Statewave's licensing model and is not legal
+advice. Consult qualified counsel before adopting Statewave in a
+commercial product.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,39 +45,31 @@ Please run `ruff` and the test suite locally before opening a PR.
 6. **Describe the change** in the PR body: motivation, approach, and any
    tradeoffs considered.
 
-## Licensing of contributions (important)
+## Licensing of contributions
 
-Statewave is **dual-licensed** under AGPLv3 and a separate Statewave
-Commercial License (see [LICENSING.md](LICENSING.md)).
+Statewave is dual-licensed under AGPLv3 and the Statewave Commercial
+License (see [LICENSING.md](LICENSING.md)). By contributing — opening a
+pull request, sending a patch, or otherwise submitting work — you agree
+that your contribution may be distributed under that same dual-license
+model: AGPLv3 **and** the Statewave Commercial License. You retain
+copyright in your work; we just need the right to ship it under both
+license tracks so the dual-licensing model keeps working.
 
-To keep this dual-licensing model viable, **contributions must be
-compatible with both licenses**. By submitting a pull request, issue patch,
-or any other contribution, you agree that:
+To keep that arrangement on a clean footing, we use a lightweight CLA
+workflow for non-trivial contributions:
 
-1. You are the original author of the contribution, or you have the right
-   to submit it under the terms below.
-2. Your contribution may be distributed under the GNU Affero General Public
-   License v3.0.
-3. Your contribution may **also** be distributed under the Statewave
-   Commercial License (and other future commercial licenses offered by the
-   Statewave project) without additional notice or compensation.
-4. You retain copyright in your contribution; you grant the Statewave
-   project the rights described above to license and re-license it under
-   both the open-source and commercial tracks.
-
-### CLA / DCO
-
-For non-trivial contributions, we may ask you to:
-
-- Sign a **Contributor License Agreement (CLA)** confirming the terms
-  above; or
-- Use the Linux Foundation–style **Developer Certificate of Origin (DCO)**
-  by adding a `Signed-off-by:` trailer to your commits (`git commit -s`).
-
-If a CLA is required for your PR, a maintainer will provide the exact
-language and link before merge. Trivial contributions (typo fixes, small
-doc edits) generally do not require a CLA, but we may still ask for a DCO
-sign-off.
+- **Non-trivial contributions** — new features, refactors, behavioral
+  changes, anything beyond a small fix — may require a **signed
+  Contributor License Agreement (CLA)** before merge. A maintainer will
+  share the CLA text and link when relevant; it's a one-time step per
+  contributor.
+- **Trivial patches** — typo fixes, documentation corrections, small
+  patches — may be accepted without a full CLA at the maintainers'
+  discretion.
+- **DCO** (`git commit -s`, Developer Certificate of Origin) may be used
+  as a lightweight interim process if a CLA workflow is not yet in place
+  for your contribution. DCO is not a long-term substitute for the CLA
+  where commercial relicensing is involved.
 
 If your employer has rights to your work, please make sure they have
 authorized the contribution before submitting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to Statewave
+
+Thanks for your interest in contributing — Statewave is built in the open and
+external contributions are very welcome.
+
+This document covers the contribution process and the licensing implications
+of contributing to a dual-licensed project.
+
+## Ways to contribute
+
+- **Bug reports** — open a [GitHub issue](https://github.com/smaramwbc/statewave/issues)
+  with reproduction steps, expected vs. actual behavior, and version info.
+- **Feature requests** — open an issue describing the use case and the
+  problem you are trying to solve. Concrete use cases beat abstract feature
+  ideas.
+- **Pull requests** — see "Pull request process" below.
+- **Documentation** — improvements to the [statewave-docs](https://github.com/smaramwbc/statewave-docs)
+  repo are equally valuable.
+
+## Development setup
+
+See the [Quick start](README.md#quick-start) section in the README for the
+canonical setup. In short:
+
+```bash
+docker compose up db -d
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev,llm]"
+alembic upgrade head
+pytest tests/ -v
+```
+
+Please run `ruff` and the test suite locally before opening a PR.
+
+## Pull request process
+
+1. **Open an issue first** for non-trivial changes so we can align on
+   approach before you invest in code.
+2. **Branch from `main`**, keep PRs focused, and prefer small commits with
+   clear messages.
+3. **Add tests** for new behavior. Statewave is infrastructure — coverage
+   matters more than feature volume.
+4. **Update docs** if you change public API, configuration, or behavior.
+5. **Pass CI** — lint, type checks, and tests must be green.
+6. **Describe the change** in the PR body: motivation, approach, and any
+   tradeoffs considered.
+
+## Licensing of contributions (important)
+
+Statewave is **dual-licensed** under AGPLv3 and a separate Statewave
+Commercial License (see [LICENSING.md](LICENSING.md)).
+
+To keep this dual-licensing model viable, **contributions must be
+compatible with both licenses**. By submitting a pull request, issue patch,
+or any other contribution, you agree that:
+
+1. You are the original author of the contribution, or you have the right
+   to submit it under the terms below.
+2. Your contribution may be distributed under the GNU Affero General Public
+   License v3.0.
+3. Your contribution may **also** be distributed under the Statewave
+   Commercial License (and other future commercial licenses offered by the
+   Statewave project) without additional notice or compensation.
+4. You retain copyright in your contribution; you grant the Statewave
+   project the rights described above to license and re-license it under
+   both the open-source and commercial tracks.
+
+### CLA / DCO
+
+For non-trivial contributions, we may ask you to:
+
+- Sign a **Contributor License Agreement (CLA)** confirming the terms
+  above; or
+- Use the Linux Foundation–style **Developer Certificate of Origin (DCO)**
+  by adding a `Signed-off-by:` trailer to your commits (`git commit -s`).
+
+If a CLA is required for your PR, a maintainer will provide the exact
+language and link before merge. Trivial contributions (typo fixes, small
+doc edits) generally do not require a CLA, but we may still ask for a DCO
+sign-off.
+
+If your employer has rights to your work, please make sure they have
+authorized the contribution before submitting.
+
+## Code style
+
+- Python 3.11+, formatted with `ruff` (settings in `pyproject.toml`).
+- Type hints on public APIs.
+- Match the surrounding code's conventions; prefer small, composable
+  functions; prefer clear names over comments.
+
+## Reporting security issues
+
+Please **do not** open a public issue for security vulnerabilities. See
+[SECURITY.md](SECURITY.md) for the coordinated disclosure process.
+
+## Questions
+
+- General questions: [GitHub Discussions](https://github.com/smaramwbc/statewave/discussions)
+- Licensing questions: [licensing@statewave.ai](mailto:licensing@statewave.ai)
+- Security: [security@statewave.ai](mailto:security@statewave.ai)

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,111 @@
+# Licensing
+
+Statewave is **dual-licensed**:
+
+1. **Open source** — [GNU Affero General Public License v3.0](LICENSE) (AGPLv3)
+2. **Commercial** — a separate [Statewave Commercial License](COMMERCIAL-LICENSE.md)
+   for proprietary, SaaS, embedded, hosted, or enterprise use.
+
+This structure keeps Statewave open and community-driven while allowing the
+project to sustain itself commercially. You can adopt Statewave under AGPLv3
+with no paperwork; you only need a commercial license if your use case
+conflicts with AGPL obligations or you need enterprise terms.
+
+## Quick decision guide
+
+| Use case                                                                              | License path                                                  |
+|---------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| Learning, local development, research                                                 | AGPLv3                                                        |
+| Open-source application that uses Statewave and complies with AGPL                    | AGPLv3                                                        |
+| Internal company use with no external SaaS exposure                                   | AGPLv3 — or commercial license if your legal team prefers     |
+| Proprietary SaaS that uses Statewave as infrastructure                                | Commercial license (recommended/required to avoid AGPL §13)   |
+| Hosting Statewave as a managed/SaaS service for third parties                         | Commercial license required                                   |
+| Embedding Statewave in closed-source software shipped to customers                    | Commercial license required                                   |
+| Early-stage startup under the qualifying threshold                                    | Startup commercial license                                    |
+| Larger company needing SLA, indemnity, support, procurement, custom terms             | Enterprise commercial license                                 |
+
+If you are unsure where you fit, contact
+[licensing@statewave.ai](mailto:licensing@statewave.ai) and we will help you
+pick the right path.
+
+## What AGPLv3 requires (in plain English)
+
+AGPLv3 is a strong copyleft license. The most important obligations:
+
+- If you **distribute** Statewave (or a modified version), you must make the
+  corresponding source available under AGPLv3.
+- If you **make Statewave available to users over a network** — for example,
+  as part of a SaaS or hosted product — AGPL §13 requires you to offer
+  those users the corresponding source of the version you are running,
+  including any modifications.
+- The whole work that combines with Statewave under copyleft terms must be
+  licensed under AGPLv3.
+
+If those obligations are acceptable to you, AGPLv3 is the right choice and
+no commercial license is required.
+
+If they are **not** acceptable — for example, you ship a closed-source SaaS
+product, or you embed Statewave in a proprietary distribution — use the
+commercial license.
+
+## What the commercial license offers
+
+The Statewave Commercial License is offered in tiers
+(see [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md) and
+[docs/licensing.md](docs/licensing.md)):
+
+- **Startup** — free or low-cost commercial license for qualifying
+  early-stage companies. Removes AGPL source-disclosure obligations for
+  covered use. Does not include the right to host Statewave as a competing
+  service.
+- **Growth** — paid commercial license for production SaaS / proprietary
+  product use above the startup threshold.
+- **Enterprise** — custom commercial agreement with SLA, indemnity, support,
+  optional managed hosting, and procurement-friendly terms.
+
+A commercial license is the right choice when you want closed-source, SaaS,
+embedded, or hosted use without AGPL obligations.
+
+## Commercial protection (what you may not do)
+
+The dual-license model is designed to be adoption-friendly while protecting
+the project. The following uses require either full AGPLv3 compliance **and**
+compliance with the [trademark policy](TRADEMARKS.md), or a commercial
+agreement:
+
+- Offering Statewave (or a substantially similar derivative) as a hosted,
+  managed, or SaaS service to third parties.
+- Distributing closed-source software that links, embeds, or otherwise
+  combines with Statewave in a way that triggers AGPL copyleft.
+- Using the Statewave name, logo, or branding to imply official hosting,
+  endorsement, or affiliation. See [TRADEMARKS.md](TRADEMARKS.md).
+
+Running Statewave for internal use, building open-source projects on top of
+it, contributing back, and sharing modifications under AGPLv3 are all
+explicitly welcome and require no agreement.
+
+## How to get a commercial license
+
+Email [licensing@statewave.ai](mailto:licensing@statewave.ai) with:
+
+- Company name and a short description of intended use
+- Whether the use is internal, embedded, SaaS, or hosted-for-third-parties
+- Approximate scale (users, environments, revenue band)
+- Any required contractual terms (SLA, indemnity, support, procurement)
+
+We will respond with the appropriate tier and a draft agreement.
+
+## Contributing under dual licensing
+
+External contributions must be compatible with this dual-licensing model.
+By submitting a contribution you agree that it can be distributed under
+AGPLv3 **and** under the Statewave Commercial License. We may ask
+contributors to sign a CLA or DCO before contributions are accepted. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
+## Disclaimer
+
+This repository describes Statewave's licensing model and is not legal
+advice. Consult qualified counsel before adopting Statewave in a
+commercial product. If you have questions about how AGPLv3 applies to
+your specific situation, please consult your own attorney.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,23 @@
+# NOTICE
+
+Statewave
+Copyright (c) Statewave contributors.
+
+This product includes software developed by the Statewave project and its
+contributors.
+
+Statewave is dual-licensed:
+
+- **Open source:** GNU Affero General Public License v3.0 — see [LICENSE](LICENSE).
+- **Commercial:** Statewave Commercial License — see
+  [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md).
+
+For a plain-language summary of when each license applies, see
+[LICENSING.md](LICENSING.md). For trademark and brand usage, see
+[TRADEMARKS.md](TRADEMARKS.md).
+
+## Third-party software
+
+Statewave depends on a number of third-party open-source libraries.
+Each is distributed under its own license. See `pyproject.toml` for the
+authoritative dependency list and the upstream projects for license terms.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Statewave
 
 [![CI](https://github.com/smaramwbc/statewave/workflows/CI/badge.svg)](https://github.com/smaramwbc/statewave/actions/workflows/ci.yml)
-[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
+[![License: AGPL-3.0 + Commercial](https://img.shields.io/badge/license-AGPL--3.0%20%2B%20Commercial-blue.svg)](LICENSING.md)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
 
 **Memory runtime for AI agents and AI-powered applications.**
@@ -204,6 +204,30 @@ See the [roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.
 | [statewave-web](https://github.com/smaramwbc/statewave-web) | Marketing website + embedded interactive demo ([statewave.ai](https://statewave.ai)) |
 | [statewave-admin](https://github.com/smaramwbc/statewave-admin) | Operator console (read-only) |
 
-## License
+## Licensing
 
-[AGPL-3.0](LICENSE)
+Statewave is **dual-licensed**:
+
+- **[AGPLv3](LICENSE)** — for open-source / community use.
+- **[Commercial license](COMMERCIAL-LICENSE.md)** — for proprietary, SaaS,
+  embedded, hosted, or enterprise use.
+
+This allows Statewave to stay open and community-driven while protecting
+the project from unmanaged commercial hosting or closed-source
+redistribution. If you want to use Statewave in a proprietary product,
+SaaS platform, managed service, or enterprise environment without AGPL
+obligations, contact us for a commercial license.
+
+A startup-friendly commercial tier is available for early-stage companies
+under a qualifying threshold.
+
+- **Quick decision guide:** [LICENSING.md](LICENSING.md)
+- **Commercial license overview:** [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md)
+- **Tiers (Community / Startup / Growth / Enterprise):** [docs/licensing.md](docs/licensing.md)
+- **Trademark policy:** [TRADEMARKS.md](TRADEMARKS.md)
+- **Contributing under dual licensing:** [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Contact:** [licensing@statewave.ai](mailto:licensing@statewave.ai)
+
+> This repository describes Statewave's licensing model and is not legal
+> advice. Consult qualified counsel before adopting Statewave in a
+> commercial product.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,90 @@
+# Statewave Trademark Policy
+
+The name **"Statewave"**, the Statewave logo, and related branding (the
+"Statewave Marks") are project and company marks. The open-source license
+that covers the source code of Statewave (AGPLv3) does **not** grant
+any rights to use the Statewave Marks. This policy describes the limited
+use we permit without a separate written agreement.
+
+We use trademark policy not to restrict the open-source community, but to
+keep "Statewave" a meaningful, trustworthy signal — so that when users see
+the name attached to a hosted service or product, they know what they are
+getting.
+
+## What you may do (no permission required)
+
+- Say truthfully that your software, service, or content is **"built with
+  Statewave"**, **"powered by Statewave"**, **"compatible with Statewave"**,
+  or **"based on Statewave"** — provided this accurately describes your
+  use, and you do not imply official endorsement, partnership, or hosting.
+- Use the name "Statewave" in **factual references**: documentation, blog
+  posts, talks, comparisons, tutorials, academic papers, and similar
+  educational or journalistic content.
+- Distribute **unmodified** copies of Statewave under AGPLv3 with the
+  original branding intact.
+- Use the unmodified Statewave logo in screenshots, slides, or comparison
+  charts that accurately depict the project.
+
+## What you may not do (without written permission)
+
+- Call your service **"Statewave Cloud"**, **"Official Statewave"**,
+  **"Statewave Hosted"**, **"Statewave Enterprise"**, or any similar name
+  that implies an official relationship with the Statewave project or
+  company.
+- Use the Statewave name or logo as a **primary brand** for your own
+  product, company, or service.
+- Use the Statewave Marks in a way that **implies endorsement,
+  certification, partnership, sponsorship, or affiliation** when none
+  exists.
+- Register domain names, social-media handles, package names, or
+  trademarks that incorporate "Statewave" in a way that is likely to cause
+  confusion about origin or endorsement.
+- Use modified versions of the Statewave logo, or alter the logo's
+  proportions, colors, or composition.
+- Sell merchandise (apparel, stickers, etc.) bearing the Statewave Marks
+  without permission.
+
+## Hosting providers and managed services
+
+This is the most important case for us, so we want to be explicit:
+
+- You may operate Statewave for your own users (internal use, embedded in
+  your product, or as part of an AGPLv3-compliant deployment) without
+  written permission, provided you do not brand the service with the
+  Statewave Marks.
+- If you wish to **offer Statewave as a hosted, managed, or SaaS service to
+  third parties under the Statewave brand**, you need a written commercial
+  and trademark agreement from us. This is true regardless of whether you
+  comply with AGPLv3 — copyright and trademark are separate rights.
+- "Built with Statewave" or "powered by Statewave" labels on a hosted
+  service are acceptable; "Statewave Cloud", "Hosted Statewave", or any
+  variant that suggests we run or endorse the service is not.
+
+## Modifications and forks
+
+If you fork Statewave and modify it materially, please **rename the fork**
+so that users are not confused about whose code they are running. You may
+still describe the fork as "based on Statewave" or "a fork of Statewave"
+in documentation. The name of your fork should not begin with "Statewave"
+or be confusable with it.
+
+## How to request permission
+
+Brand, hosting-with-the-name, partnership, or other use cases not covered
+above:
+
+- **Email:** [licensing@statewave.ai](mailto:licensing@statewave.ai)
+
+Please describe the intended use, the audience, the channel (website, app,
+event, merchandise, etc.), and any mockups.
+
+## Updates to this policy
+
+This policy may be updated as the project grows. The version in `main` is
+authoritative. Material changes will be announced in release notes.
+
+## Disclaimer
+
+This document describes the Statewave project's trademark policy; it is
+not legal advice. If you are unsure whether your intended use is covered,
+contact us before proceeding.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,18 @@ services:
       # inside the compose network, the database is reachable as `db`.
       STATEWAVE_DATABASE_URL: postgresql+asyncpg://statewave:statewave@db:5432/statewave
       STATEWAVE_DEBUG: "true"
+      # Auto-bootstrap the Statewave Support docs pack on first start so
+      # the docs-grounded persona in statewave-web answers from real
+      # content out of the box. Idempotent — re-runs are no-ops once the
+      # subject is populated. Set to "false" to skip.
+      STATEWAVE_BOOTSTRAP_DOCS_PACK: "true"
+      STATEWAVE_DOCS_PATH: /docs
+    volumes:
+      # Read-only mount of the sibling statewave-docs checkout. The
+      # bootstrap script reads the markdown corpus from here. If the
+      # sibling repo isn't checked out, this resolves to an empty dir
+      # and start.sh's bootstrap step silently skips.
+      - ../statewave-docs:/docs:ro
     depends_on:
       db:
         condition: service_healthy

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,135 @@
+# Statewave Commercial Licensing — Tiers
+
+This document describes the **structure** of Statewave's commercial
+license tiers. Specific pricing and qualifying thresholds are confirmed
+in the signed commercial agreement.
+
+For the open-source path (AGPLv3) and a quick decision guide, see
+[../LICENSING.md](../LICENSING.md).
+
+For the legal/contractual overview of the commercial license, see
+[../COMMERCIAL-LICENSE.md](../COMMERCIAL-LICENSE.md).
+
+---
+
+## Community
+
+**Audience:** Individuals, OSS projects, internal/local use under AGPLv3.
+
+**Cost:** Free — use the open-source AGPLv3 license directly.
+
+**What you get:**
+
+- Full Statewave under AGPLv3.
+- Community support via GitHub issues and discussions.
+- All documented features.
+
+**Constraints:**
+
+- AGPLv3 obligations apply, including §13 network-use source disclosure if
+  you make Statewave available to users over a network.
+- No SLA, indemnity, or commercial support.
+- No use of the Statewave brand for hosted services
+  (see [../TRADEMARKS.md](../TRADEMARKS.md)).
+
+---
+
+## Startup
+
+**Audience:** Early-stage companies under a defined revenue / funding
+threshold.
+
+**Cost:** Free or low-cost commercial license. Specific terms are
+confirmed in the signed agreement.
+
+**Indicative qualifying threshold:**
+
+- Annual recurring revenue below approximately **$50k–$100k ARR**, **and**
+- Total funding raised below an agreed cap, **and**
+- The company is not in the business of offering hosted memory/state
+  infrastructure as a primary product.
+
+**What you get:**
+
+- Commercial license that removes AGPL source-disclosure obligations for
+  covered use.
+- Right to use Statewave in proprietary or closed-source software.
+- Right to deploy Statewave as part of your own SaaS product without AGPL
+  §13 obligations.
+- Best-effort community support.
+
+**Constraints:**
+
+- Lightweight registration / written grant required — please email
+  [licensing@statewave.ai](mailto:licensing@statewave.ai).
+- May **not** offer Statewave (or a substantially similar derivative) as a
+  competing hosted memory/state service.
+- Brand restrictions in [../TRADEMARKS.md](../TRADEMARKS.md) still apply.
+- License re-qualification required if you exceed the threshold.
+
+---
+
+## Growth
+
+**Audience:** Production SaaS, proprietary products, or commercial
+deployments above the Startup threshold.
+
+**Cost:** Paid commercial license, typically monthly or annual.
+
+**What you get:**
+
+- Commercial license that removes AGPL source-disclosure obligations for
+  covered use.
+- Right to use Statewave in proprietary, embedded, or SaaS products.
+- Standard support response times (defined in the agreement).
+- Optional add-ons: priority bug fixes, security advisories, deployment
+  review.
+
+**Constraints:**
+
+- Hosting Statewave as a competing managed/SaaS service still requires a
+  separate hosting agreement.
+- Trademark policy applies.
+
+---
+
+## Enterprise
+
+**Audience:** Larger organizations needing SLA, indemnity, support,
+procurement-friendly terms, or managed hosting.
+
+**Cost:** Custom commercial agreement, negotiated.
+
+**What you get:**
+
+- All Growth-tier rights, plus:
+- **SLA** with defined response and resolution targets.
+- **Indemnity** and standard enterprise contractual protections.
+- **Support contract** with named contacts and escalation paths.
+- Optional **managed hosting** by Statewave.
+- Security review materials, compliance documentation, and procurement
+  paperwork as required.
+- Custom features and roadmap input where relevant.
+
+**Constraints:**
+
+- Defined per agreement.
+
+---
+
+## How to apply
+
+Email [licensing@statewave.ai](mailto:licensing@statewave.ai) with:
+
+- Company name and short description of intended use.
+- Whether the use is internal, embedded, SaaS, or hosted-for-third-parties.
+- Approximate scale (users, environments, revenue band).
+- Any required contractual terms (SLA, indemnity, support, procurement).
+
+We will respond with the appropriate tier and a draft agreement.
+
+## Disclaimer
+
+This document describes Statewave's licensing model and is not legal
+advice. Consult qualified counsel before adopting Statewave in a
+commercial product.

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -36,18 +36,20 @@ For the legal/contractual overview of the commercial license, see
 
 ## Startup
 
-**Audience:** Early-stage companies under a defined revenue / funding
-threshold.
+**Audience:** Early-stage companies and builders who want to use
+Statewave in a proprietary product without AGPL obligations.
 
 **Cost:** Free or low-cost commercial license. Specific terms are
 confirmed in the signed agreement.
 
-**Indicative qualifying threshold:**
+**Indicative qualification range:**
 
-- Annual recurring revenue below approximately **$50k–$100k ARR**, **and**
-- Total funding raised below an agreed cap, **and**
-- The company is not in the business of offering hosted memory/state
-  infrastructure as a primary product.
+- Pre-revenue or early revenue.
+- Typically below **$50k–$100k ARR**.
+- Not operating a competing hosted Statewave service.
+
+Final eligibility is determined by a signed Statewave commercial
+agreement.
 
 **What you get:**
 
@@ -65,7 +67,8 @@ confirmed in the signed agreement.
 - May **not** offer Statewave (or a substantially similar derivative) as a
   competing hosted memory/state service.
 - Brand restrictions in [../TRADEMARKS.md](../TRADEMARKS.md) still apply.
-- License re-qualification required if you exceed the threshold.
+- License re-qualification required if your scale grows beyond the
+  indicative range.
 
 ---
 

--- a/fly.toml
+++ b/fly.toml
@@ -10,6 +10,12 @@ primary_region = 'ord'
   STATEWAVE_LITELLM_MODEL = "gpt-4o-mini"
   STATEWAVE_LITELLM_EMBEDDING_MODEL = "text-embedding-3-small"
   STATEWAVE_EMBEDDING_DIMENSIONS = "1536"
+  # Production seeds the docs pack via the dedicated GitHub Actions
+  # refresh workflow (purge + rebuild on docs-repo push). The image
+  # itself doesn't bundle the corpus, so the start-time auto-bootstrap
+  # would silently skip — but disable it explicitly to avoid any
+  # confusion in the Fly logs.
+  STATEWAVE_BOOTSTRAP_DOCS_PACK = "false"
 
 [http_service]
   internal_port = 8100

--- a/infra/postgres-pgvector/README.md
+++ b/infra/postgres-pgvector/README.md
@@ -115,7 +115,7 @@ If something breaks, the migration is reversible:
 flyctl ssh console -a statewave-api -C "alembic downgrade 0012_add_health_cache"
 ```
 
-This casts the `vector` column back to `TEXT` and drops the HNSW index. The old code path (Python-side cosine compute) was already removed in this release — so for a full rollback you'd also need to deploy the previous `statewave-api` image (the one before commit XXXX).
+This casts the `vector` column back to `TEXT` and drops the HNSW index. The old code path (Python-side cosine compute) was already removed in this release — so for a full rollback you'd also need to deploy the previous `statewave-api` image (the one shipped before this migration).
 
 You can leave the pgvector-bundled Postgres image in place after a rollback — having pgvector available with no code using it is harmless.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "statewave"
 version = "0.7.1"
 description = "Memory OS — trusted context runtime for AI agents and applications"
 readme = "README.md"
-license = {text = "AGPL-3.0"}
+license = {text = "AGPL-3.0-only OR LicenseRef-Statewave-Commercial"}
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.111,<1",

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -48,9 +48,13 @@ def get_alembic_config() -> Config:
     import os
 
     cfg = Config(str(_ALEMBIC_INI))
-    # Allow DATABASE_URL override
-    if os.environ.get("DATABASE_URL"):
-        cfg.set_main_option("sqlalchemy.url", os.environ["DATABASE_URL"])
+    # STATEWAVE_DATABASE_URL is the first-class config name (matches the
+    # rest of the STATEWAVE_-prefixed env surface and the docker-compose
+    # `environment:` block); DATABASE_URL is kept as a generic fallback
+    # for hosts that prefer that convention.
+    db_url = os.environ.get("STATEWAVE_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    if db_url:
+        cfg.set_main_option("sqlalchemy.url", db_url)
     return cfg
 
 
@@ -80,9 +84,13 @@ async def check_migration_status(database_url: str | None = None) -> MigrationSt
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import create_async_engine
 
-    url = database_url or os.environ.get("DATABASE_URL", "")
+    url = (
+        database_url
+        or os.environ.get("STATEWAVE_DATABASE_URL")
+        or os.environ.get("DATABASE_URL", "")
+    )
     if not url:
-        return MigrationStatus(error="DATABASE_URL not set")
+        return MigrationStatus(error="STATEWAVE_DATABASE_URL / DATABASE_URL not set")
 
     status = MigrationStatus()
 

--- a/start.sh
+++ b/start.sh
@@ -73,5 +73,47 @@ PY
 echo "Running database migrations..."
 alembic upgrade head
 
+# ─── Auto-bootstrap: Statewave Support docs pack ────────────────────────
+#
+# Seeds the `statewave-support-docs` subject so the docs-grounded
+# "Statewave Support" persona answers from real content out of the box.
+# Triggers only when:
+#   1. STATEWAVE_BOOTSTRAP_DOCS_PACK is unset or true (default true), AND
+#   2. The docs corpus is reachable at STATEWAVE_DOCS_PATH (default /docs).
+#
+# Idempotent — the bootstrap script exits 2 when the subject already has
+# episodes, which we treat as "already seeded, nothing to do". Production
+# deploys (Fly) don't ship the corpus inside the image, so the path check
+# silently skips this. Operators who want to disable explicitly can set
+# STATEWAVE_BOOTSTRAP_DOCS_PACK=false.
+DOCS_PATH="${STATEWAVE_DOCS_PATH:-/docs}"
+BOOTSTRAP="${STATEWAVE_BOOTSTRAP_DOCS_PACK:-true}"
+if [ "$BOOTSTRAP" = "true" ] && [ -d "$DOCS_PATH" ]; then
+    echo "Auto-bootstrap: docs pack will seed after API is ready (DOCS_PATH=$DOCS_PATH)"
+    (
+        # Wait up to 60s for /healthz before attempting the seed. Falls
+        # back silently if the API never comes up — the user-visible
+        # error will be the failed startup itself, not a confusing
+        # bootstrap-side log.
+        for i in $(seq 1 60); do
+            if curl -sS -m 2 -o /dev/null http://127.0.0.1:8100/healthz 2>/dev/null; then
+                break
+            fi
+            sleep 1
+        done
+        STATEWAVE_DOCS_PATH="$DOCS_PATH" \
+        STATEWAVE_URL="http://127.0.0.1:8100" \
+            python -m scripts.bootstrap_docs_pack
+        rc=$?
+        case "$rc" in
+            0) echo "Auto-bootstrap: Statewave Support docs pack seeded." ;;
+            2) echo "Auto-bootstrap: docs pack already populated — skipped." ;;
+            *) echo "Auto-bootstrap: bootstrap exited with code $rc (server is still serving)." >&2 ;;
+        esac
+    ) &
+elif [ "$BOOTSTRAP" = "true" ]; then
+    echo "Auto-bootstrap: STATEWAVE_DOCS_PATH ($DOCS_PATH) not present in image — skipped. (Set STATEWAVE_BOOTSTRAP_DOCS_PACK=false to silence this notice.)"
+fi
+
 echo "Starting Statewave server..."
 exec uvicorn server.app:app --host 0.0.0.0 --port 8100

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -43,8 +43,10 @@ def test_get_all_revisions():
 
 
 @pytest.mark.asyncio
-async def test_check_migration_status_no_url():
-    """Should return error if no DATABASE_URL."""
+async def test_check_migration_status_no_url(monkeypatch):
+    """Should return error when no DB URL is supplied via arg or env."""
+    monkeypatch.delenv("STATEWAVE_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     status = await check_migration_status(database_url="")
     assert status.error is not None
 


### PR DESCRIPTION
This PR adds the Statewave Core dual-licensing documentation.

Summary:
- Keeps Statewave Core under AGPLv3 for open-source/community use
- Adds a commercial licensing path for proprietary, SaaS, hosted, embedded, and enterprise use
- Adds Startup / Growth / Enterprise commercial tier placeholders
- Adds trademark, notice, contribution, and legal-review guidance
- Updates README licensing section and pyproject license metadata

Not included:
- No change to LICENSE text
- No conversion to BSL
- No source-file headers
- No hard-coded pricing
- No unrelated infra/postgres-pgvector/README.md change

Validation:
- ruff clean
- pyproject.toml parses
- consistency sweep passed
- no SSPL references
- legal-review disclaimers present

Legal review still needed before public launch:
- Final Startup-tier threshold
- Final commercial pricing
- Operative commercial license agreement
- CLA vs. DCO decision
- Trademark registration/enforcement posture