### PR TITLE
feat(docs-pack): add subject-design.md to support-pack allowlist

### DIFF
--- a/scripts/docs_loader.py
+++ b/scripts/docs_loader.py
@@ -23,6 +23,7 @@ MANIFEST: tuple[str, ...] = (
     "README.md",
     "getting-started.md",
     "product.md",
+    "subject-design.md",
     "why-statewave.md",
     "SECURITY.md",
     "SUPPORT.md",


### PR DESCRIPTION
## Summary
- Adds \`subject-design.md\` to the support-docs MANIFEST in [scripts/docs_loader.py](scripts/docs_loader.py) so the chunker ingests it on the next refresh.
- The companion doc itself lands in a follow-up PR on \`statewave-docs\`. This PR ships first so the production loader knows about the path before the refresh workflow runs.

## Why
Subject design is the most common architectural question new users hit and the docs pack has zero coverage today. Adding the path here is a one-line change that unblocks Track A of the showcase plan.

## Test plan
- [x] \`pytest tests/test_admin_memory.py\` — pack-shape tests still pass (the MANIFEST is read at chunk time, not at startup, so this PR has no runtime effect until the file lands in statewave-docs)
- [x] After deploy + the statewave-docs PR merges, the refresh workflow rebuilds the support pack and the support widget can answer subject-design questions