### PR TITLE
feat(support-pack): version-aware auto-update with selective purge

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -1838,10 +1838,21 @@ class StarterPackImportRequest(BaseModel):
     target_display_name: Optional[str] = None
     target_tenant_id: Optional[str] = None
     conflict_strategy: Literal["create_copy", "merge", "cancel"] = "create_copy"
+    # Off by default — operators using the admin UI should never accidentally
+    # import a pack into the marketing widget's per-visitor namespace
+    # (`demo_web_*`). The marketing edge function flips this on when seeding
+    # a visitor's subject from the bundled showcase pack — that's the
+    # legitimate `demo_web_*` write path.
+    allow_reserved_target: bool = False
 
 
 class SupportReseedRequest(BaseModel):
     reason: Optional[str] = None
+    # When false (default), skip work if the live subject already carries
+    # the bundled pack's version — that's the no-op fast path used by
+    # container-restart auto-update. When true, the drawer's manual
+    # "Restore" button forces a reseed regardless of version state.
+    force: bool = False
 
 
 class CloneSubjectRequest(BaseModel):
@@ -1909,6 +1920,7 @@ async def import_starter_pack_endpoint(req: StarterPackImportRequest):
             target_display_name=req.target_display_name,
             target_tenant_id=req.target_tenant_id,
             conflict_strategy=req.conflict_strategy,
+            allow_reserved_target=req.allow_reserved_target,
         )
     except StarterPackError as e:
         raise HTTPException(status_code=e.status_code, detail=str(e))
@@ -1919,9 +1931,16 @@ async def support_reseed_endpoint(req: SupportReseedRequest | None = None):
     """Rebuild the shared Statewave Support docs subject (vendor-neutral).
 
     Imports the bundled `statewave-support-agent` starter pack into the
-    `statewave-support-docs` subject (purging prior content first so the
-    rebuild is idempotent). Per-visitor `demo_web_<uuid>__statewave-support`
-    subjects are not touched.
+    `statewave-support-docs` subject. Behaviour:
+
+      - Version-aware: when the live subject already carries the bundled
+        pack's version, the call is a no-op (returns `updated=false`).
+        Pass `force=true` to override and reseed unconditionally.
+      - Selective purge: only rows whose metadata identifies them as
+        belonging to the support pack are deleted before reimport. Rows
+        an operator added alongside ours survive untouched.
+      - Per-visitor `demo_web_<uuid>__statewave-support` subjects are not
+        touched.
     """
     from server.services.memory_packs import (
         StarterPackError,
@@ -1929,8 +1948,30 @@ async def support_reseed_endpoint(req: SupportReseedRequest | None = None):
     )
 
     reason = (req.reason if req and req.reason else "").strip()[:200] or None
+    force = bool(req.force) if req else False
     try:
-        return await reseed_support_subject(reason=reason)
+        return await reseed_support_subject(reason=reason, force=force)
+    except StarterPackError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+
+
+@router.get("/memory/support/state")
+async def support_state_endpoint():
+    """Snapshot of the support subject's reseed state.
+
+    Returns the bundled pack version, the version currently installed in
+    the live subject (read from row metadata), and counts of pack-owned vs
+    operator-added rows. The drawer uses this to render the
+    "installed v{x} → available v{y}" banner and gate the destructive
+    Restore action.
+    """
+    from server.services.memory_packs import (
+        StarterPackError,
+        get_support_subject_state,
+    )
+
+    try:
+        return await get_support_subject_state()
     except StarterPackError as e:
         raise HTTPException(status_code=e.status_code, detail=str(e))
 
@@ -1956,8 +1997,9 @@ async def docs_pack_reseed_alias(req: SupportReseedRequest | None = None):
     )
 
     reason = (req.reason if req and req.reason else "").strip()[:200] or None
+    force = bool(req.force) if req else False
     try:
-        return await reseed_support_subject(reason=reason)
+        return await reseed_support_subject(reason=reason, force=force)
     except StarterPackError as e:
         raise HTTPException(status_code=e.status_code, detail=str(e))
 

--- a/server/services/memory_packs.py
+++ b/server/services/memory_packs.py
@@ -352,12 +352,28 @@ async def import_starter_pack(
     target_display_name: str | None,
     target_tenant_id: str | None,
     conflict_strategy: ConflictStrategy = "create_copy",
+    allow_reserved_target: bool = False,
 ) -> dict[str, Any]:
+    """Import a starter pack into a target subject.
+
+    `allow_reserved_target` opts the caller into landing the pack on a
+    subject inside a reserved namespace (currently `demo_web_*`). The
+    default `False` matches the operator-facing admin UI's policy: an
+    admin who clicks "Import" should never accidentally fork into the
+    marketing widget's per-visitor namespace. The marketing edge
+    function — which is the legitimate caller for `demo_web_*` targets,
+    seeding a visitor's subject from the bundled showcase pack — sets
+    this to `True` to skip the guard.
+    """
     directory, manifest = _starter_pack_dir(pack_id)
     suggested = manifest.get("subject_id_suggestion") or pack_id
 
     if target_subject_id:
-        target_subject_id = _validate_subject_id(target_subject_id, field="target_subject_id")
+        target_subject_id = _validate_subject_id(
+            target_subject_id,
+            field="target_subject_id",
+            allow_reserved=allow_reserved_target,
+        )
 
     final_subject_id = await _resolve_target_subject(
         explicit=target_subject_id,
@@ -448,27 +464,191 @@ async def _resolve_target_subject(
 # ─── Public: support reseed (vendor-neutral) ────────────────────────────────
 
 
-async def reseed_support_subject(*, reason: str | None = None) -> dict[str, Any]:
+async def get_support_subject_state() -> dict[str, Any]:
+    """Snapshot the support subject's reseed metadata for the admin drawer.
+
+    Returns the bundled manifest version and what the live subject reports
+    about its last reseed (version, timestamp, reason, episode + memory
+    counts). Distinguishes pack-owned rows from operator-added rows so the
+    UI can warn before any destructive action.
+
+    Owned-row detection: rows carry `metadata_.starter_pack_id == pack_id`
+    when imported via this code path. Older bootstrap_docs_pack runs (pre-
+    versioning) wrote `metadata.pack == "statewave-support-docs"` instead;
+    we recognise both so a long-lived deployment doesn't think its own
+    docs pack is operator data.
+    """
+    from sqlalchemy import func, or_, select
+
+    target = settings.support_subject_id
+    pack_id = settings.support_starter_pack_id
+
+    _, manifest = _starter_pack_dir(pack_id)
+    bundled_version = manifest.get("version")
+
+    owned_predicate_ep = or_(
+        EpisodeRow.metadata_["starter_pack_id"].astext == pack_id,
+        EpisodeRow.metadata_["pack"].astext == "statewave-support-docs",
+    )
+    owned_predicate_mem = or_(
+        MemoryRow.metadata_["starter_pack_id"].astext == pack_id,
+        MemoryRow.metadata_["pack"].astext == "statewave-support-docs",
+    )
+
+    async with engine_module.get_session_factory()() as session:
+        # Total rows on the subject (includes operator-added).
+        total_eps = await session.scalar(
+            select(func.count(EpisodeRow.id)).where(EpisodeRow.subject_id == target)
+        )
+        total_mems = await session.scalar(
+            select(func.count(MemoryRow.id)).where(MemoryRow.subject_id == target)
+        )
+        # Rows the auto-update path is allowed to touch.
+        owned_eps = await session.scalar(
+            select(func.count(EpisodeRow.id)).where(
+                EpisodeRow.subject_id == target, owned_predicate_ep
+            )
+        )
+        owned_mems = await session.scalar(
+            select(func.count(MemoryRow.id)).where(
+                MemoryRow.subject_id == target, owned_predicate_mem
+            )
+        )
+        # Most recent reseed identity. Memories tend to outnumber episodes,
+        # but they all carry the same metadata — query whichever has rows.
+        last_row = await session.execute(
+            select(
+                EpisodeRow.metadata_["starter_pack_version"].astext,
+                EpisodeRow.metadata_["imported_at"].astext,
+                EpisodeRow.metadata_["reseed_reason"].astext,
+            )
+            .where(EpisodeRow.subject_id == target, owned_predicate_ep)
+            .order_by(EpisodeRow.created_at.desc())
+            .limit(1)
+        )
+        last = last_row.first()
+
+    installed_version = last[0] if last else None
+    last_imported_at = last[1] if last else None
+    last_reseed_reason = last[2] if last else None
+
+    return {
+        "subject_id": target,
+        "pack_id": pack_id,
+        "bundled_version": bundled_version,
+        "installed_version": installed_version,
+        "is_up_to_date": (
+            installed_version is not None and installed_version == bundled_version
+        ),
+        "total_episode_count": total_eps or 0,
+        "total_memory_count": total_mems or 0,
+        "owned_episode_count": owned_eps or 0,
+        "owned_memory_count": owned_mems or 0,
+        "operator_episode_count": (total_eps or 0) - (owned_eps or 0),
+        "operator_memory_count": (total_mems or 0) - (owned_mems or 0),
+        "last_reseed": {
+            "imported_at": last_imported_at,
+            "reason": last_reseed_reason,
+            "version": installed_version,
+        },
+    }
+
+
+async def reseed_support_subject(
+    *,
+    reason: str | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
     """Rebuild the shared `statewave-support-docs` subject from the bundled pack.
 
-    Idempotent: every call deletes existing episodes/memories on the target
-    subject before re-importing. Per-visitor `demo_web_*__statewave-support`
-    subjects are not touched — this targets the configured shared subject id
-    (`settings.support_subject_id`) only.
+    Version-aware: skips when the live subject is already on the bundled
+    pack's version (no-op fast path for container-restart auto-update).
+    Pass `force=True` to reseed regardless of the version check — that's
+    what the drawer's "Restore" button does when an operator wants to
+    reset to the bundled state.
+
+    Selective purge: only rows whose metadata identifies them as belonging
+    to this pack are deleted before reimport. Rows added by an operator
+    alongside ours (no `starter_pack_id` metadata) survive untouched. Any
+    legacy rows from older `bootstrap_docs_pack` runs that wrote
+    `metadata.pack == "statewave-support-docs"` are also recognised as
+    owned, so a long-lived deployment can upgrade without losing its docs
+    pack to the operator-data exclusion.
+
+    Per-visitor `demo_web_*__statewave-support` subjects are never
+    touched — the strict subject-id match scopes everything to the
+    configured shared subject (`settings.support_subject_id`).
+
+    Always logs the structured outcome including the reason, so an
+    operator searching support-side telemetry can find why a particular
+    reseed happened.
     """
+    from sqlalchemy import or_
+
     target = settings.support_subject_id
     pack_id = settings.support_starter_pack_id
 
     directory, manifest = _starter_pack_dir(pack_id)
+    bundled_version = manifest.get("version")
+
+    state = await get_support_subject_state()
+    installed_version = state["installed_version"]
+
+    # Version-aware short-circuit: identical version + no force → no-op.
+    # We still write a log line so operator-triggered no-ops are visible
+    # in support telemetry.
+    if not force and state["is_up_to_date"]:
+        logger.info(
+            "support_reseed_skipped",
+            target_subject_id=target,
+            pack_id=pack_id,
+            installed_version=installed_version,
+            bundled_version=bundled_version,
+            reason=reason,
+            outcome="already_current",
+        )
+        return {
+            "subject_id": target,
+            "pack_id": pack_id,
+            "pack_version": bundled_version,
+            "installed_version": installed_version,
+            "imported_episodes": 0,
+            "imported_memories": 0,
+            "reseeded_at": None,
+            "reason": reason,
+            "updated": False,
+            "outcome": "already_current",
+        }
+
     episodes_data = _load_jsonl(directory / "episodes.jsonl")
     memories_data = _load_jsonl(directory / "memories.jsonl")
 
-    # Idempotent reseed: wipe the shared subject's existing rows. The strict
-    # subject-id match means per-visitor `demo_web_<uuid>__statewave-support`
-    # rows are not affected.
+    # Selective purge: only delete rows our pack owns. Operator-added
+    # episodes and memories on the same subject (rare but possible — e.g.
+    # an internal note appended for the support team) are preserved. The
+    # owned predicate matches both the modern `starter_pack_id` provenance
+    # and the legacy `pack="statewave-support-docs"` metadata so an upgrade
+    # from a pre-versioning install doesn't strand its own docs pack.
+    owned_predicate_ep = or_(
+        EpisodeRow.metadata_["starter_pack_id"].astext == pack_id,
+        EpisodeRow.metadata_["pack"].astext == "statewave-support-docs",
+    )
+    owned_predicate_mem = or_(
+        MemoryRow.metadata_["starter_pack_id"].astext == pack_id,
+        MemoryRow.metadata_["pack"].astext == "statewave-support-docs",
+    )
+
     async with engine_module.get_session_factory()() as session:
-        await session.execute(delete(EpisodeRow).where(EpisodeRow.subject_id == target))
-        await session.execute(delete(MemoryRow).where(MemoryRow.subject_id == target))
+        await session.execute(
+            delete(EpisodeRow).where(
+                EpisodeRow.subject_id == target, owned_predicate_ep
+            )
+        )
+        await session.execute(
+            delete(MemoryRow).where(
+                MemoryRow.subject_id == target, owned_predicate_mem
+            )
+        )
         await session.commit()
 
     counts = await _ingest_records_async(
@@ -479,28 +659,45 @@ async def reseed_support_subject(*, reason: str | None = None) -> dict[str, Any]
         extra_provenance={"starter_pack_id": pack_id, "support_reseed": True},
         extra_metadata={
             "starter_pack_id": pack_id,
-            "starter_pack_version": manifest.get("version"),
+            "starter_pack_version": bundled_version,
             "imported_at": _now_iso(),
             "reseed_reason": reason,
         },
     )
 
+    outcome = (
+        "force_reseeded"
+        if force
+        else ("seeded" if installed_version is None else "auto_updated")
+    )
     logger.info(
         "support_reseed_completed",
         target_subject_id=target,
         pack_id=pack_id,
+        installed_version_before=installed_version,
+        installed_version_after=bundled_version,
         episodes=counts["episodes"],
         memories=counts["memories"],
+        operator_episodes_preserved=state["operator_episode_count"],
+        operator_memories_preserved=state["operator_memory_count"],
+        reason=reason,
+        outcome=outcome,
     )
 
     return {
         "subject_id": target,
         "pack_id": pack_id,
-        "pack_version": manifest.get("version"),
+        "pack_version": bundled_version,
+        "installed_version": bundled_version,
+        "previous_version": installed_version,
         "imported_episodes": counts["episodes"],
         "imported_memories": counts["memories"],
+        "operator_episodes_preserved": state["operator_episode_count"],
+        "operator_memories_preserved": state["operator_memory_count"],
         "reseeded_at": _now_iso(),
         "reason": reason,
+        "updated": True,
+        "outcome": outcome,
     }
 
 

--- a/start.sh
+++ b/start.sh
@@ -86,10 +86,19 @@ alembic upgrade head
 # deploys (Fly) don't ship the corpus inside the image, so the path check
 # silently skips this. Operators who want to disable explicitly can set
 # STATEWAVE_BOOTSTRAP_DOCS_PACK=false.
+#
+# NOTE: This live-docs path is now superseded by the bundled-pack
+# auto-update below. We keep the live-docs path for dev environments
+# that mount `/docs` (so a docs change on the host is picked up without
+# a build_support_pack regen + image rebuild). When neither
+# STATEWAVE_BOOTSTRAP_DOCS_PACK is true nor `/docs` is mounted, the
+# bundled-pack auto-update covers production.
 DOCS_PATH="${STATEWAVE_DOCS_PATH:-/docs}"
 BOOTSTRAP="${STATEWAVE_BOOTSTRAP_DOCS_PACK:-true}"
+DOCS_MOUNTED=0
 if [ "$BOOTSTRAP" = "true" ] && [ -d "$DOCS_PATH" ]; then
-    echo "Auto-bootstrap: docs pack will seed after API is ready (DOCS_PATH=$DOCS_PATH)"
+    DOCS_MOUNTED=1
+    echo "Auto-bootstrap: docs pack will seed from /docs after API is ready (DOCS_PATH=$DOCS_PATH)"
     (
         # Disable errexit inside the subshell — the bootstrap script
         # exits 2 to signal "subject already populated", which is a
@@ -112,13 +121,70 @@ if [ "$BOOTSTRAP" = "true" ] && [ -d "$DOCS_PATH" ]; then
             python -m scripts.bootstrap_docs_pack
         rc=$?
         case "$rc" in
-            0) echo "Auto-bootstrap: Statewave Support docs pack seeded." ;;
+            0) echo "Auto-bootstrap: Statewave Support docs pack seeded from /docs." ;;
             2) echo "Auto-bootstrap: docs pack already populated — skipped." ;;
             *) echo "Auto-bootstrap: bootstrap exited with code $rc (server is still serving)." >&2 ;;
         esac
     ) &
-elif [ "$BOOTSTRAP" = "true" ]; then
-    echo "Auto-bootstrap: STATEWAVE_DOCS_PATH ($DOCS_PATH) not present in image — skipped. (Set STATEWAVE_BOOTSTRAP_DOCS_PACK=false to silence this notice.)"
+fi
+
+# ─── Auto-update: support pack from bundled JSONL ────────────────────────
+#
+# Reseeds `statewave-support-docs` from the bundled
+# `statewave-support-agent` starter pack baked into the image. The reseed
+# endpoint is version-aware: if the live subject already carries the
+# bundled pack's version it returns a no-op without touching any rows.
+# Calling on every container restart is therefore idempotent — fresh
+# installs get seeded, image upgrades pick up the new pack, no-op when
+# already current. Selective purge means operator-added rows survive.
+#
+# Skipped when the live-docs path above ran (operator opted into refreshing
+# from the mounted /docs directly) — that path produces equivalent rows so
+# running both back-to-back would be redundant.
+#
+# Operators who want to disable can set
+# STATEWAVE_AUTO_UPDATE_SUPPORT_PACK=false. The drawer's manual "Restore"
+# button still works either way (it sets force=true).
+AUTO_UPDATE="${STATEWAVE_AUTO_UPDATE_SUPPORT_PACK:-true}"
+if [ "$AUTO_UPDATE" = "true" ] && [ "$DOCS_MOUNTED" = "0" ]; then
+    echo "Auto-update: support pack will reseed (or no-op) after API is ready."
+    (
+        set +e
+        for i in $(seq 1 60); do
+            if curl -sS -m 2 -o /dev/null http://127.0.0.1:8100/healthz 2>/dev/null; then
+                break
+            fi
+            sleep 1
+        done
+        AUTH_HEADER=""
+        if [ -n "$STATEWAVE_API_KEY" ]; then
+            AUTH_HEADER="X-API-Key: $STATEWAVE_API_KEY"
+        fi
+        BODY='{"reason":"auto-update on container start"}'
+        RESP=$(curl -sS -m 900 -X POST \
+            -H "Content-Type: application/json" \
+            ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
+            -d "$BODY" \
+            http://127.0.0.1:8100/admin/memory/support/reseed 2>&1)
+        rc=$?
+        if [ "$rc" = "0" ]; then
+            outcome=$(echo "$RESP" | grep -oE '"outcome":"[a-z_]+"' | head -1 | cut -d'"' -f4)
+            ver=$(echo "$RESP" | grep -oE '"installed_version":"[^"]*"' | head -1 | cut -d'"' -f4)
+            case "$outcome" in
+                already_current) echo "Auto-update: support pack already at v$ver — no-op." ;;
+                seeded)          echo "Auto-update: support pack freshly seeded at v$ver." ;;
+                auto_updated)    echo "Auto-update: support pack upgraded to v$ver." ;;
+                "")              echo "Auto-update: reseed call returned (could not parse outcome): $RESP" >&2 ;;
+                *)               echo "Auto-update: support pack reseeded ($outcome) at v$ver." ;;
+            esac
+        else
+            echo "Auto-update: reseed call failed (curl rc=$rc). Server still serving." >&2
+        fi
+    ) &
+elif [ "$AUTO_UPDATE" = "true" ]; then
+    echo "Auto-update: skipped (live-docs bootstrap is handling this restart)."
+else
+    echo "Auto-update: STATEWAVE_AUTO_UPDATE_SUPPORT_PACK=false — support pack will not auto-reseed."
 fi
 
 echo "Starting Statewave server..."

--- a/tests/test_admin_memory.py
+++ b/tests/test_admin_memory.py
@@ -416,7 +416,7 @@ async def test_http_docs_pack_reseed_alias_delegates_to_support_reseed(
     """
     captured: dict[str, object] = {}
 
-    async def fake_reseed(*, reason=None):
+    async def fake_reseed(*, reason=None, force=False):
         captured["reason"] = reason
         return {
             "subject_id": settings.support_subject_id,
@@ -450,7 +450,7 @@ async def test_http_docs_pack_reseed_alias_delegates_to_support_reseed(
 @pytest.mark.asyncio
 async def test_http_docs_pack_reseed_alias_works_without_body(client, monkeypatch):
     """Old scripts sometimes POSTed with no body — must still 200."""
-    async def fake_reseed(*, reason=None):
+    async def fake_reseed(*, reason=None, force=False):
         return {
             "subject_id": settings.support_subject_id,
             "pack_id": settings.support_starter_pack_id,
@@ -491,7 +491,7 @@ async def test_http_docs_pack_reseed_alias_does_not_require_github_config(
 
     called = {"n": 0}
 
-    async def fake_reseed(*, reason=None):
+    async def fake_reseed(*, reason=None, force=False):
         called["n"] += 1
         return {
             "subject_id": settings.support_subject_id,
@@ -540,7 +540,7 @@ async def test_http_docs_pack_reseed_alias_targets_only_shared_subject(
     """The alias targets `support_subject_id` only — never a visitor subject."""
     seen: dict[str, str] = {}
 
-    async def fake_reseed(*, reason=None):
+    async def fake_reseed(*, reason=None, force=False):
         # Pin: the service does not accept a target arg from the request,
         # so the alias cannot be pointed at a per-visitor subject by a
         # client. Returning the configured shared id is the only path.


### PR DESCRIPTION
## Summary
- **Version-aware reseed**: the support reseed endpoint compares bundled vs installed manifest versions and short-circuits to a no-op when they match. \`force=true\` overrides (used by the admin drawer's Restore button).
- **Selective purge**: only rows whose metadata identifies them as belonging to this pack are deleted before reimport. Operator-added rows on the same subject (rare but supported — internal runbooks, customer-specific FAQs) survive every auto-update.
- **New \`GET /admin/memory/support/state\` endpoint** returning bundled vs installed versions, owned vs operator row counts, and last-reseed metadata. Surfaces the previously dead \`reseed_reason\` field.
- **\`start.sh\` rework**: container-restart auto-update is now the default. STATEWAVE_AUTO_UPDATE_SUPPORT_PACK=false to disable. Legacy \`/docs\` live-mount bootstrap path preserved for dev.
- Folds in the \`allow_reserved_target\` flag on \`import_starter_pack\` (same files, related concern: lets the marketing widget's fast-seed flow legitimately write into the reserved \`demo_web_*\` namespace).

## Why
Operators running their own Statewave have no realistic update path today: pulling a new image with a newer bundled pack does nothing because the auto-bootstrap silently skips when the subject is non-empty. Manual \"Restore\" via the admin drawer wipes the live 200+ episodes back to whatever the on-disk pack contained — destructive when the live content was richer.

This PR closes that gap:
1. Pull a new image → container restart → version mismatch detected → selective purge of pack-owned rows + reimport at new version → operator additions survive.
2. Already current → no-op.
3. Manual restore via the drawer (force=true) still works for explicit re-installs.

## Behavior matrix

| State | force | Outcome |
|---|---|---|
| Subject empty | any | \`seeded\` — full bundled pack imported |
| Same version, no force | false | \`already_current\` — no rows touched |
| Different version, no force | false | \`auto_updated\` — selective purge + reimport |
| Same/diff version, force | true | \`force_reseeded\` — selective purge + reimport |

## Test plan
- [x] \`pytest tests/test_admin_memory.py\` — 42/42 pass (mock signatures updated for \`force\` kwarg)
- [x] Smoke test on local container:
  - Empty subject → \`seeded\` outcome
  - Second call → \`already_current\` no-op
  - Force=true → \`force_reseeded\` reimport
  - Operator note added → state endpoint reports \`operator_episode_count: 1\`
  - Force reseed → operator note survives (verified via direct DB count)
- [x] After deploy: container restart logs show \`Auto-update: support pack already at v… — no-op.\`

## Depends on
- [smaramwbc/statewave#20](https://github.com/smaramwbc/statewave/pull/20) — the bundled pack content (this PR's auto-update path imports from those JSONL files)

## Follows-up
- [smaramwbc/statewave-admin] — admin drawer rewrite that consumes \`GET /admin/memory/support/state\`
- [smaramwbc/statewave-web] — marketing widget fast-seed flow that consumes \`allow_reserved_target\`