### PR TITLE
fix: backfill embeddings for imported memories

### DIFF
--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -17,6 +17,7 @@ from server.schemas.requests import CompileMemoriesRequest
 from server.schemas.responses import CompileMemoriesResponse, MemoryResponse, SearchMemoriesResponse
 from server.services.compilers import get_compiler
 from server.services.embeddings import get_provider as get_embedding_provider
+from server.services.embeddings.backfill import schedule_embedding_backfill
 from server.services.conflicts import resolve_conflicts
 from server.services import webhooks
 from server.services import compile_jobs
@@ -154,10 +155,13 @@ async def compile_memories(
         for row in new_rows:
             await session.refresh(row)
 
-        # Generate embeddings in background (don't block response)
-        memory_ids = [row.id for row in new_rows]
-        memory_texts = [row.content for row in new_rows]
-        asyncio.create_task(_generate_embeddings_background(memory_ids, memory_texts))
+        # Generate embeddings in background (don't block response). The
+        # shared scheduler also serves the starter-pack import path so
+        # both write paths populate embeddings consistently.
+        schedule_embedding_backfill(
+            [row.id for row in new_rows],
+            [row.content for row in new_rows],
+        )
 
         await webhooks.fire(
             "memories.compiled",
@@ -193,38 +197,6 @@ async def get_compile_status(job_id: str):
         response["error"] = job.error
 
     return JSONResponse(content=response)
-
-
-async def _generate_embeddings_background(memory_ids: list, texts: list[str]) -> None:
-    """Generate embeddings for memories in the background (non-blocking).
-
-    Writes go through the ORM so the pgvector SQLAlchemy adapter handles
-    list[float] → vector(1536) serialization. Previously this used raw SQL
-    with str(emb), which worked because pgvector parses JSON-array TEXT —
-    but the ORM path is type-safe and survives future column-type changes.
-    """
-    from sqlalchemy import update
-
-    from server.db.engine import get_session_factory
-    from server.db.tables import MemoryRow
-
-    provider = get_embedding_provider()
-    if not provider or not texts:
-        return
-
-    try:
-        embeddings = await provider.embed_texts(texts)
-        async with get_session_factory()() as session:
-            for mid, emb in zip(memory_ids, embeddings):
-                await session.execute(
-                    update(MemoryRow)
-                    .where(MemoryRow.id == mid)
-                    .values(embedding=emb)
-                )
-            await session.commit()
-        logger.info("embeddings_generated_background", count=len(embeddings))
-    except Exception:
-        logger.warning("background_embedding_failed", exc_info=True)
 
 
 @router.get("/search", response_model=SearchMemoriesResponse, summary="Search memories")

--- a/server/services/embeddings/backfill.py
+++ b/server/services/embeddings/backfill.py
@@ -1,0 +1,104 @@
+"""Background embedding generation for newly-inserted memories.
+
+Two write paths in Statewave create memories:
+  * `POST /v1/memories/compile` — LLM/heuristic extraction from episodes.
+  * `_ingest_records_async` (memory_packs) — bulk import of bundled or
+    operator-supplied starter packs / .swmem archives.
+
+Both paths used to embed inconsistently — the compile path scheduled a
+fire-and-forget embedding task, the import path silently wrote
+`embedding=NULL` for every row (the bundled JSONL ships without
+embeddings, and there was no post-insert embed step). That asymmetry
+broke vector retrieval on every clean import. This module is the shared
+implementation both paths now use, so the rule is uniform: every memory
+written by the server gets an embedding scheduled, and any row that
+arrived with one already pre-computed is left alone.
+
+Design:
+  * Fire-and-forget via `asyncio.create_task` — embedding latency must
+    never be in the user's request path. Failures are logged at WARNING,
+    not propagated; a missing embedding degrades retrieval but does not
+    break the request.
+  * Row-level granularity — pass only memories that need embedding.
+    Callers filter `embedding is None` themselves, so this function
+    doesn't have to round-trip the DB to discover which rows are stale.
+  * Provider-aware no-op — when the configured provider is `none`, this
+    function returns immediately without touching the DB.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Sequence
+from uuid import UUID
+
+import structlog
+from sqlalchemy import update
+
+from server.db.engine import get_session_factory
+from server.db.tables import MemoryRow
+from server.services.embeddings import get_provider
+
+logger = structlog.stdlib.get_logger()
+
+
+async def generate_embeddings_background(
+    memory_ids: Sequence[UUID | str],
+    texts: Sequence[str],
+) -> None:
+    """Compute embeddings for the given memories and persist them.
+
+    Designed to be scheduled with `asyncio.create_task(...)` from a
+    request handler — never `await`ed in the request path. Both inputs
+    must be the same length and ordered consistently.
+
+    No-op when:
+      * `memory_ids` / `texts` is empty,
+      * the embedding provider is disabled (`STATEWAVE_EMBEDDING_PROVIDER=none`),
+      * the provider call fails — failure is logged and swallowed; the
+        memories stay with `embedding IS NULL` and retrieval falls back
+        to its non-vector path. Re-running compile or a future write
+        will retry.
+    """
+    if not memory_ids or not texts:
+        return
+    if len(memory_ids) != len(texts):
+        logger.warning(
+            "background_embedding_mismatched_inputs",
+            ids=len(memory_ids),
+            texts=len(texts),
+        )
+        return
+
+    provider = get_provider()
+    if provider is None:
+        return
+
+    try:
+        embeddings = await provider.embed_texts(list(texts))
+        async with get_session_factory()() as session:
+            for mid, emb in zip(memory_ids, embeddings):
+                await session.execute(
+                    update(MemoryRow).where(MemoryRow.id == mid).values(embedding=emb)
+                )
+            await session.commit()
+        logger.info("embeddings_generated_background", count=len(embeddings))
+    except Exception:
+        logger.warning("background_embedding_failed", exc_info=True)
+
+
+def schedule_embedding_backfill(
+    memory_ids: Sequence[UUID | str],
+    texts: Sequence[str],
+) -> asyncio.Task | None:
+    """Convenience: schedule `generate_embeddings_background` on the
+    running event loop and return the task handle (or None when there's
+    nothing to do).
+
+    Callers in request handlers should use this rather than importing
+    `asyncio.create_task` themselves — keeps the fire-and-forget pattern
+    in one place and makes it greppable.
+    """
+    if not memory_ids or not texts:
+        return None
+    return asyncio.create_task(generate_embeddings_background(memory_ids, texts))

--- a/server/services/memory_packs.py
+++ b/server/services/memory_packs.py
@@ -284,6 +284,14 @@ async def _ingest_records_async(
             )
             session.add(row)
 
+        # Track memories that arrived without an embedding so we can
+        # schedule background embedding generation after the commit.
+        # Bundled starter packs and most operator-supplied .swmem archives
+        # ship without embeddings; without this step the import path
+        # would silently leave every imported memory with `embedding IS
+        # NULL`, breaking vector retrieval until a manual backfill.
+        memories_needing_embedding: list[tuple[uuid.UUID, str]] = []
+
         for mem in mems:
             new_id = uuid.uuid4()
             source_eps: list[uuid.UUID] = []
@@ -296,26 +304,42 @@ async def _ingest_records_async(
                     continue
             metadata = dict(mem.get("metadata") or {})
             metadata.update(extra_metadata)
+            content = mem.get("content") or ""
+            embedding = mem.get("embedding")
             row = MemoryRow(
                 id=new_id,
                 subject_id=target_subject_id,
                 tenant_id=target_tenant_id,
                 kind=mem.get("kind") or "fact",
-                content=mem.get("content") or "",
-                summary=mem.get("summary") or mem.get("content") or "",
+                content=content,
+                summary=mem.get("summary") or content,
                 confidence=float(mem.get("confidence", 0.9)),
                 valid_from=_parse_iso_or_now(mem.get("valid_from")),
                 valid_to=_parse_iso_or_none(mem.get("valid_to")),
                 source_episode_ids=source_eps,
                 metadata_=dict(metadata),
                 status=mem.get("status") or "active",
-                embedding=mem.get("embedding"),
+                embedding=embedding,
                 created_at=_parse_iso_or_now(mem.get("created_at")),
                 updated_at=_parse_iso_or_now(mem.get("updated_at")),
             )
             session.add(row)
+            if embedding is None and content:
+                memories_needing_embedding.append((new_id, content))
 
         await session.commit()
+
+    if memories_needing_embedding:
+        # Fire-and-forget: must not block the import response. The shared
+        # scheduler is the same one the compile path uses, so both write
+        # paths produce embedded memories with the same guarantees.
+        from server.services.embeddings.backfill import (
+            schedule_embedding_backfill,
+        )
+
+        ids = [m[0] for m in memories_needing_embedding]
+        texts = [m[1] for m in memories_needing_embedding]
+        schedule_embedding_backfill(ids, texts)
 
     return {"episodes": len(eps), "memories": len(mems)}
 

--- a/tests/test_admin_memory.py
+++ b/tests/test_admin_memory.py
@@ -21,6 +21,7 @@ factory; these unit tests focus on the validation/dispatch contract.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -580,3 +581,136 @@ def test_payload_format_constants_pinned():
     assert mp.PAYLOAD_FORMAT == "statewave-memory-payload"
     assert mp.PAYLOAD_FORMAT_VERSION == 1
     assert mp.STARTER_PACK_FORMAT == "statewave-starter-pack"
+
+
+# ─── Embedding scheduler in _ingest_records_async ─────────────────────────
+#
+# Regression guards for the import path's embedding behaviour. Before the
+# patch that added a post-commit `schedule_embedding_backfill` call, a
+# fresh starter-pack import or operator `.swmem` import would land all
+# memories with `embedding=NULL` (the bundled JSONL ships without
+# embeddings) and silently break vector retrieval. These tests pin the
+# fix without needing a real Postgres — the DB session is fully mocked.
+
+
+def _make_fake_session_factory():
+    """Build a session_factory() callable that hands out an awaitable-async-ctx
+    session whose .add / .execute / .commit are no-ops. The mock is shaped to
+    satisfy `async with engine_module.get_session_factory()() as session:`.
+    """
+    fake_session = AsyncMock()
+    fake_session.add = MagicMock()
+    fake_session.execute = AsyncMock()
+    fake_session.commit = AsyncMock()
+    fake_session_ctx = MagicMock()
+    fake_session_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session_ctx.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=fake_session_ctx)
+
+
+@pytest.mark.asyncio
+async def test_ingest_schedules_embedding_for_memories_without_embeddings(monkeypatch):
+    """Bundled starter packs ship without embeddings — they must be
+    auto-scheduled for embedding generation after insert. This is the
+    behaviour that was missing before the core patch and that broke
+    vector retrieval on every clean reseed."""
+    monkeypatch.setattr(
+        "server.db.engine.get_session_factory", _make_fake_session_factory
+    )
+    captured: list[tuple[list, list]] = []
+
+    def fake_scheduler(ids, texts):
+        captured.append((list(ids), list(texts)))
+        return None
+
+    monkeypatch.setattr(
+        "server.services.embeddings.backfill.schedule_embedding_backfill",
+        fake_scheduler,
+    )
+
+    await mp._ingest_records_async(
+        target_subject_id="test-subject",
+        target_tenant_id=None,
+        episodes_data=[],
+        memories_data=[
+            {"kind": "fact", "content": "Statewave uses PostgreSQL with pgvector."},
+            {"kind": "procedure", "content": "Run docker compose up -d to start."},
+        ],
+        extra_provenance={},
+        extra_metadata={},
+    )
+
+    assert len(captured) == 1, "scheduler should fire exactly once after commit"
+    ids, texts = captured[0]
+    assert len(ids) == 2
+    assert sorted(texts) == [
+        "Run docker compose up -d to start.",
+        "Statewave uses PostgreSQL with pgvector.",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ingest_skips_scheduling_when_embedding_already_present(monkeypatch):
+    """`.swmem` archives can carry pre-computed embeddings — re-embedding
+    them would burn provider tokens for no benefit. Only memories
+    arriving with `embedding=None` should be scheduled."""
+    monkeypatch.setattr(
+        "server.db.engine.get_session_factory", _make_fake_session_factory
+    )
+    captured_texts: list[str] = []
+
+    def fake_scheduler(ids, texts):
+        captured_texts.extend(texts)
+        return None
+
+    monkeypatch.setattr(
+        "server.services.embeddings.backfill.schedule_embedding_backfill",
+        fake_scheduler,
+    )
+
+    pre_embedded = [0.1] * 4  # length doesn't matter for this test
+    await mp._ingest_records_async(
+        target_subject_id="test-subject",
+        target_tenant_id=None,
+        episodes_data=[],
+        memories_data=[
+            {"kind": "fact", "content": "Already embedded.", "embedding": pre_embedded},
+            {"kind": "fact", "content": "Needs an embedding."},
+        ],
+        extra_provenance={},
+        extra_metadata={},
+    )
+
+    assert captured_texts == ["Needs an embedding."]
+
+
+@pytest.mark.asyncio
+async def test_ingest_does_not_schedule_when_no_memories(monkeypatch):
+    """Episode-only imports must not schedule embedding work."""
+    monkeypatch.setattr(
+        "server.db.engine.get_session_factory", _make_fake_session_factory
+    )
+    called = False
+
+    def fake_scheduler(ids, texts):
+        nonlocal called
+        called = True
+        return None
+
+    monkeypatch.setattr(
+        "server.services.embeddings.backfill.schedule_embedding_backfill",
+        fake_scheduler,
+    )
+
+    await mp._ingest_records_async(
+        target_subject_id="test-subject",
+        target_tenant_id=None,
+        episodes_data=[
+            {"id": "00000000-0000-4000-8000-000000000001", "source": "test", "type": "imported", "payload": {"text": "x"}}
+        ],
+        memories_data=[],
+        extra_provenance={},
+        extra_metadata={},
+    )
+
+    assert called is False

--- a/tests/test_embeddings_backfill.py
+++ b/tests/test_embeddings_backfill.py
@@ -1,0 +1,139 @@
+"""Tests for `server.services.embeddings.backfill`.
+
+The helper is shared by two write paths: the LLM compile endpoint
+(`POST /v1/memories/compile`) and the bulk-import path
+(`_ingest_records_async`). Both must produce embedded memories with the
+same guarantees, so the contract here is:
+
+  * empty inputs → no-op (no provider call, no DB session)
+  * mismatched id/text lengths → logged + no-op (defensive)
+  * provider returns None (`STATEWAVE_EMBEDDING_PROVIDER=none`) → no-op
+  * provider raises → swallow + log warning, never propagate
+  * happy path → one provider call, one UPDATE per memory
+
+These tests stub the provider + DB session factory so they run without
+Postgres. The integration test that exercises the real ingest path
+through `_ingest_records_async` lives separately.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from server.services.embeddings import backfill as backfill_mod
+
+
+@pytest.mark.anyio
+async def test_empty_inputs_are_a_noop():
+    """No provider call when there's nothing to embed."""
+    with patch.object(backfill_mod, "get_provider") as gp:
+        await backfill_mod.generate_embeddings_background([], [])
+        gp.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_mismatched_input_lengths_short_circuits():
+    """Defensive guard: callers that pass mismatched ids/texts get a
+    no-op + warning rather than a partial UPDATE that would silently
+    desync the DB."""
+    with patch.object(backfill_mod, "get_provider") as gp:
+        await backfill_mod.generate_embeddings_background(
+            [uuid4(), uuid4()], ["only one text"]
+        )
+        gp.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_disabled_provider_short_circuits():
+    """When `STATEWAVE_EMBEDDING_PROVIDER=none`, `get_provider()` returns
+    None and we must not touch the DB."""
+    with (
+        patch.object(backfill_mod, "get_provider", return_value=None),
+        patch.object(backfill_mod, "get_session_factory") as sf,
+    ):
+        await backfill_mod.generate_embeddings_background(
+            [uuid4()], ["something"]
+        )
+        sf.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_happy_path_writes_one_embedding_per_memory():
+    """Single provider call, one UPDATE per memory, one commit."""
+    ids = [uuid4(), uuid4(), uuid4()]
+    texts = ["a", "b", "c"]
+    fake_vectors = [[0.1] * 4, [0.2] * 4, [0.3] * 4]
+
+    fake_provider = MagicMock()
+    fake_provider.embed_texts = AsyncMock(return_value=fake_vectors)
+
+    fake_session = AsyncMock()
+    fake_session.execute = AsyncMock()
+    fake_session.commit = AsyncMock()
+
+    fake_session_ctx = MagicMock()
+    fake_session_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session_ctx.__aexit__ = AsyncMock(return_value=None)
+    fake_factory = MagicMock(return_value=fake_session_ctx)
+
+    with (
+        patch.object(backfill_mod, "get_provider", return_value=fake_provider),
+        patch.object(backfill_mod, "get_session_factory", return_value=fake_factory),
+    ):
+        await backfill_mod.generate_embeddings_background(ids, texts)
+
+    fake_provider.embed_texts.assert_awaited_once_with(texts)
+    assert fake_session.execute.await_count == len(ids)
+    fake_session.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_provider_failure_is_swallowed():
+    """A flaky provider must NOT propagate — embeddings are an
+    optimisation, retrieval falls back to non-vector ranking when
+    they're missing. The exception is logged and the request that
+    spawned this background task is unaffected."""
+    fake_provider = MagicMock()
+    fake_provider.embed_texts = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch.object(backfill_mod, "get_provider", return_value=fake_provider):
+        # Must not raise.
+        await backfill_mod.generate_embeddings_background(
+            [uuid4()], ["something"]
+        )
+
+
+@pytest.mark.anyio
+async def test_schedule_returns_none_when_nothing_to_do():
+    """The convenience scheduler skips `asyncio.create_task` entirely on
+    empty inputs — keeps the no-op path zero-cost."""
+    task = backfill_mod.schedule_embedding_backfill([], [])
+    assert task is None
+
+
+@pytest.mark.anyio
+async def test_schedule_returns_running_task():
+    """Happy path: returns the scheduled task so callers can await it
+    in tests (production callers fire-and-forget)."""
+    fake_provider = MagicMock()
+    fake_provider.embed_texts = AsyncMock(return_value=[[0.0] * 4])
+
+    fake_session = AsyncMock()
+    fake_session.execute = AsyncMock()
+    fake_session.commit = AsyncMock()
+    fake_session_ctx = MagicMock()
+    fake_session_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session_ctx.__aexit__ = AsyncMock(return_value=None)
+    fake_factory = MagicMock(return_value=fake_session_ctx)
+
+    with (
+        patch.object(backfill_mod, "get_provider", return_value=fake_provider),
+        patch.object(backfill_mod, "get_session_factory", return_value=fake_factory),
+    ):
+        task = backfill_mod.schedule_embedding_backfill([uuid4()], ["x"])
+        assert task is not None
+        await task
+        fake_provider.embed_texts.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes imported/starter-pack memories being written without embeddings.

Imported JSONL memories don't ship with embeddings. Previously `_ingest_records_async` inserted those memories with `embedding=NULL`, which broke vector retrieval for every clean reseed and every operator `.swmem` import until a manual backfill ran. The compile path was unaffected because it already scheduled a fire-and-forget embedding task; the import path silently skipped that step.

This PR adds a shared `schedule_embedding_backfill` helper and calls it from both write paths so the import path embeds memories the same way the compile path already does — fire-and-forget, provider-aware, swallow + log on failure.

## Changes

- New shared helper: `server/services/embeddings/backfill.py` — `generate_embeddings_background` + `schedule_embedding_backfill` convenience wrapper.
- `_ingest_records_async` now tracks rows arriving with `embedding=None` and schedules them for embedding after commit. Memories that arrive with pre-computed embeddings (operator `.swmem` archives that ship with vectors) are left untouched — no token waste, no double-embed.
- `POST /v1/memories/compile` uses the shared scheduler instead of its private `_generate_embeddings_background`. The old private function is removed.

## Tests

- New: 7 unit tests on the helper covering empty inputs, mismatched lengths, disabled provider, happy path, provider failure swallowed, scheduler returns task handle, scheduler skips empty.
- New: 3 admin-memory tests pinning the import path's scheduling behaviour (schedules for memories without embeddings, skips when embeddings present, no-op for episode-only imports).
- ruff clean.
- Local unit suite: 357 passed, 6 skipped.

## Test plan

- [ ] CI runs ruff + unit + integration test suites green
- [ ] Verify on a fresh DB: `POST /admin/memory/support/reseed force=true` → memories arrive with `embedding=NULL` → within ~5s all rows have embeddings populated automatically
- [ ] Verify `.swmem` archives carrying pre-computed embeddings are not re-embedded

## Deployment order

This is the foundation for the retrieval improvements in [statewave-web#TBD](https://github.com/smaramwbc/statewave-web/pulls). Ship this first.