### PR TITLE
feat(admin): purge endpoints for terminal compile jobs + webhook events

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -1306,6 +1306,31 @@ async def list_compile_jobs(
     return {"jobs": jobs, "total": total, "limit": limit, "offset": offset}
 
 
+@router.delete("/jobs")
+async def purge_compile_jobs(
+    status: str | None = Query(
+        None, description="Filter by terminal status: completed or failed"
+    ),
+    subject_id: str | None = Query(None, description="Filter by subject"),
+    tenant_id: str | None = Query(None, description="Filter by tenant"),
+):
+    """Bulk-delete terminal compile jobs matching the given filter.
+
+    Refuses an empty filter (you must pass at least one of status, subject_id,
+    tenant_id) and refuses non-terminal statuses — `pending`/`running` jobs
+    may still be held by the worker.
+    """
+    from server.services.compile_jobs_durable import purge_jobs
+
+    try:
+        deleted = await purge_jobs(
+            status=status, subject_id=subject_id, tenant_id=tenant_id
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"deleted": deleted}
+
+
 # ─── Tenant Audit ───
 
 
@@ -1413,6 +1438,28 @@ async def list_webhook_events(
         status=status, event_type=event_type, tenant_id=tenant_id, limit=limit, offset=offset
     )
     return {"events": events, "total": total, "limit": limit, "offset": offset}
+
+
+@router.delete("/webhooks")
+async def purge_webhook_events(
+    status: str | None = Query(
+        None, description="Filter by terminal status: delivered or dead_letter"
+    ),
+    event_type: str | None = Query(None, description="Filter by event type"),
+    tenant_id: str | None = Query(None, description="Filter by tenant"),
+):
+    """Bulk-delete terminal webhook events matching the given filter.
+
+    Refuses an empty filter and refuses non-terminal statuses — `pending`
+    events may still be picked up by the delivery worker.
+    """
+    try:
+        deleted = await webhooks.purge_events(
+            status=status, event_type=event_type, tenant_id=tenant_id
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"deleted": deleted}
 
 
 @router.get("/webhooks/stats")

--- a/server/services/compile_jobs_durable.py
+++ b/server/services/compile_jobs_durable.py
@@ -231,3 +231,51 @@ async def cleanup_old_jobs(retention_hours: int = 168) -> int:
     except Exception:
         logger.warning("compile_jobs_cleanup_failed", exc_info=True)
         return 0
+
+
+# Statuses that are safe to delete on operator request — never wipe a job
+# that the worker may still be holding (pending/running) or another caller
+# is racing to mark.
+TERMINAL_JOB_STATUSES = ("completed", "failed")
+
+
+async def purge_jobs(
+    status: str | None = None,
+    subject_id: str | None = None,
+    tenant_id: str | None = None,
+) -> int:
+    """Operator-triggered delete for terminal jobs matching the given filter.
+
+    At least one filter (status, subject_id, tenant_id) must be supplied —
+    an empty filter would wipe the entire history of completed/failed jobs
+    in a single click. Status, when given, must be a terminal state.
+    Returns the number of rows deleted.
+    """
+    if not (status or subject_id or tenant_id):
+        raise ValueError("at least one filter is required")
+    if status and status not in TERMINAL_JOB_STATUSES:
+        raise ValueError(
+            f"status must be one of {TERMINAL_JOB_STATUSES}; got {status!r}"
+        )
+
+    async with get_session_factory()() as session:
+        stmt = delete(CompileJobRow).where(
+            CompileJobRow.status.in_(
+                [status] if status else list(TERMINAL_JOB_STATUSES)
+            )
+        )
+        if subject_id:
+            stmt = stmt.where(CompileJobRow.subject_id == subject_id)
+        if tenant_id:
+            stmt = stmt.where(CompileJobRow.tenant_id == tenant_id)
+        result = await session.execute(stmt)
+        await session.commit()
+        count = result.rowcount or 0  # type: ignore[attr-defined]
+        logger.info(
+            "compile_jobs_purged",
+            deleted=count,
+            status=status,
+            subject_id=subject_id,
+            tenant_id=tenant_id,
+        )
+        return count

--- a/server/services/webhooks.py
+++ b/server/services/webhooks.py
@@ -26,7 +26,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.db.engine import get_session_factory
@@ -312,3 +312,49 @@ async def list_events(
         ]
 
         return events, total
+
+
+# Statuses safe to delete on operator request — `pending` events may still
+# be in flight in the delivery loop, so they're excluded.
+TERMINAL_WEBHOOK_STATUSES = ("delivered", "dead_letter")
+
+
+async def purge_events(
+    status: str | None = None,
+    event_type: str | None = None,
+    tenant_id: str | None = None,
+) -> int:
+    """Operator-triggered delete for terminal webhook events.
+
+    At least one filter must be supplied (otherwise this would wipe every
+    delivered + dead-letter event in one call). Status, when given, must
+    be a terminal state. Returns the number of rows deleted.
+    """
+    if not (status or event_type or tenant_id):
+        raise ValueError("at least one filter is required")
+    if status and status not in TERMINAL_WEBHOOK_STATUSES:
+        raise ValueError(
+            f"status must be one of {TERMINAL_WEBHOOK_STATUSES}; got {status!r}"
+        )
+
+    async with get_session_factory()() as session:
+        stmt = delete(WebhookEventRow).where(
+            WebhookEventRow.status.in_(
+                [status] if status else list(TERMINAL_WEBHOOK_STATUSES)
+            )
+        )
+        if event_type:
+            stmt = stmt.where(WebhookEventRow.event == event_type)
+        if tenant_id:
+            stmt = stmt.where(WebhookEventRow.tenant_id == tenant_id)
+        result = await session.execute(stmt)
+        await session.commit()
+        count = result.rowcount or 0  # type: ignore[attr-defined]
+        logger.info(
+            "webhook_events_purged",
+            deleted=count,
+            status=status,
+            event_type=event_type,
+            tenant_id=tenant_id,
+        )
+        return count

--- a/tests/integration/test_admin_purge.py
+++ b/tests/integration/test_admin_purge.py
@@ -1,0 +1,327 @@
+"""Real-DB tests for the admin purge endpoints.
+
+Lives under tests/integration/ because these exercise the actual SQL
+DELETE against a Postgres test database. The unit-level tests in
+tests/test_admin_purge.py already cover validation and route
+registration without needing the DB.
+
+What we verify here:
+- Happy path: only matching rows are deleted, the count is correct.
+- Tenant scoping: a tenant filter cannot reach into another tenant's rows.
+- No cascade: purging jobs/events does not touch unrelated tables (memories
+  are not in scope, but we keep a sentinel row to prove the DELETE is
+  narrow).
+- Status restriction: a `pending`/`running` row is never touched even
+  when its other selectors match the request — the service must enforce
+  the terminal-status floor regardless of caller intent.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from server.db.tables import CompileJobRow, WebhookEventRow
+
+pytestmark = pytest.mark.anyio
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+async def _seed_jobs(session_factory, *rows: dict) -> None:
+    """Insert CompileJobRow rows directly. Each dict overrides defaults."""
+    async with session_factory() as session:
+        for r in rows:
+            session.add(
+                CompileJobRow(
+                    id=r.get("id", str(uuid.uuid4())),
+                    subject_id=r["subject_id"],
+                    tenant_id=r.get("tenant_id"),
+                    status=r["status"],
+                    memories_created=r.get("memories_created", 0),
+                    error=r.get("error"),
+                    created_at=r.get("created_at", datetime.now(timezone.utc)),
+                )
+            )
+        await session.commit()
+
+
+async def _seed_events(session_factory, *rows: dict) -> None:
+    async with session_factory() as session:
+        for r in rows:
+            session.add(
+                WebhookEventRow(
+                    id=r.get("id", uuid.uuid4()),
+                    tenant_id=r.get("tenant_id"),
+                    event=r["event"],
+                    payload=r.get("payload", {}),
+                    status=r["status"],
+                    attempts=r.get("attempts", 0),
+                    max_attempts=r.get("max_attempts", 5),
+                )
+            )
+        await session.commit()
+
+
+async def _count_jobs(session_factory, **filters) -> int:
+    async with session_factory() as session:
+        stmt = select(CompileJobRow)
+        for k, v in filters.items():
+            stmt = stmt.where(getattr(CompileJobRow, k) == v)
+        result = await session.execute(stmt)
+        return len(result.scalars().all())
+
+
+async def _count_events(session_factory, **filters) -> int:
+    async with session_factory() as session:
+        stmt = select(WebhookEventRow)
+        for k, v in filters.items():
+            stmt = stmt.where(getattr(WebhookEventRow, k) == v)
+        result = await session.execute(stmt)
+        return len(result.scalars().all())
+
+
+# ─── Compile Jobs ────────────────────────────────────────────────────────────
+
+
+async def test_purge_jobs_status_only(client: AsyncClient, session_factory):
+    """`status=failed` deletes the failed row and leaves the others."""
+    tag = uuid.uuid4().hex[:8]
+    await _seed_jobs(
+        session_factory,
+        {"subject_id": f"keep_{tag}_a", "status": "completed"},
+        {"subject_id": f"go_{tag}_b", "status": "failed"},
+        {"subject_id": f"go_{tag}_c", "status": "failed"},
+        {"subject_id": f"keep_{tag}_d", "status": "running"},
+    )
+
+    r = await client.request("DELETE", "/admin/jobs", params={"status": "failed"})
+    assert r.status_code == 200
+    assert r.json()["deleted"] >= 2  # the two failed rows we seeded
+
+    # The non-failed rows we seeded are still there.
+    assert await _count_jobs(session_factory, subject_id=f"keep_{tag}_a") == 1
+    assert await _count_jobs(session_factory, subject_id=f"keep_{tag}_d") == 1
+    # The failed rows are gone.
+    assert await _count_jobs(session_factory, subject_id=f"go_{tag}_b") == 0
+    assert await _count_jobs(session_factory, subject_id=f"go_{tag}_c") == 0
+
+
+async def test_purge_jobs_rejects_running(client: AsyncClient, session_factory):
+    """A `running` job can never be deleted via this endpoint, even when
+    other selectors match. The 4xx surfaces the constraint to the caller."""
+    tag = uuid.uuid4().hex[:8]
+    await _seed_jobs(
+        session_factory, {"subject_id": f"running_{tag}", "status": "running"}
+    )
+
+    r = await client.request(
+        "DELETE",
+        "/admin/jobs",
+        params={"status": "running", "subject_id": f"running_{tag}"},
+    )
+    assert r.status_code == 400
+    # Sentinel survives.
+    assert await _count_jobs(session_factory, subject_id=f"running_{tag}") == 1
+
+
+async def test_purge_jobs_empty_filter_rejected(client: AsyncClient, session_factory):
+    """No filter → no delete. Belt-and-suspenders with the unit test, but
+    this one runs against the real DB so we catch any case where the
+    validation doesn't actually short-circuit before the SQL fires."""
+    tag = uuid.uuid4().hex[:8]
+    await _seed_jobs(
+        session_factory, {"subject_id": f"sentinel_{tag}", "status": "completed"}
+    )
+    before = await _count_jobs(session_factory)
+
+    r = await client.request("DELETE", "/admin/jobs")
+    assert r.status_code == 400
+
+    after = await _count_jobs(session_factory)
+    assert before == after
+    assert await _count_jobs(session_factory, subject_id=f"sentinel_{tag}") == 1
+
+
+async def test_purge_jobs_tenant_scoping(client: AsyncClient, session_factory):
+    """A tenant filter cannot reach into another tenant's rows."""
+    tag = uuid.uuid4().hex[:8]
+    await _seed_jobs(
+        session_factory,
+        {
+            "subject_id": f"a_{tag}",
+            "tenant_id": f"tenant-a-{tag}",
+            "status": "failed",
+        },
+        {
+            "subject_id": f"b_{tag}",
+            "tenant_id": f"tenant-b-{tag}",
+            "status": "failed",
+        },
+    )
+
+    r = await client.request(
+        "DELETE",
+        "/admin/jobs",
+        params={"status": "failed", "tenant_id": f"tenant-a-{tag}"},
+    )
+    assert r.status_code == 200
+
+    # Tenant A's row is gone, tenant B's survives untouched.
+    assert await _count_jobs(session_factory, tenant_id=f"tenant-a-{tag}") == 0
+    assert await _count_jobs(session_factory, tenant_id=f"tenant-b-{tag}") == 1
+
+
+async def test_purge_jobs_subject_filter(client: AsyncClient, session_factory):
+    """A subject filter narrows the delete to a single subject's terminal
+    rows, leaving every other subject's data alone."""
+    tag = uuid.uuid4().hex[:8]
+    target = f"target_{tag}"
+    other = f"other_{tag}"
+    await _seed_jobs(
+        session_factory,
+        {"subject_id": target, "status": "completed"},
+        {"subject_id": target, "status": "failed"},
+        {"subject_id": other, "status": "completed"},
+    )
+
+    r = await client.request(
+        "DELETE", "/admin/jobs", params={"subject_id": target}
+    )
+    assert r.status_code == 200
+
+    assert await _count_jobs(session_factory, subject_id=target) == 0
+    assert await _count_jobs(session_factory, subject_id=other) == 1
+
+
+# ─── Webhook Events ──────────────────────────────────────────────────────────
+
+
+async def test_purge_webhooks_status_only(client: AsyncClient, session_factory):
+    """`status=dead_letter` deletes the dead-letter rows; pending survives."""
+    tag = uuid.uuid4().hex[:8]
+    await _seed_events(
+        session_factory,
+        {"event": f"e_{tag}_a", "status": "dead_letter"},
+        {"event": f"e_{tag}_b", "status": "dead_letter"},
+        {"event": f"e_{tag}_c", "status": "pending"},
+        {"event": f"e_{tag}_d", "status": "delivered"},
+    )
+
+    r = await client.request(
+        "DELETE", "/admin/webhooks", params={"status": "dead_letter"}
+    )
+    assert r.status_code == 200
+
+    # Pending and delivered survive; dead-letter rows are gone.
+    assert await _count_events(session_factory, event=f"e_{tag}_a") == 0
+    assert await _count_events(session_factory, event=f"e_{tag}_b") == 0
+    assert await _count_events(session_factory, event=f"e_{tag}_c") == 1
+    assert await _count_events(session_factory, event=f"e_{tag}_d") == 1
+
+
+async def test_purge_webhooks_rejects_pending(client: AsyncClient, session_factory):
+    """`pending` events may still be in flight in the delivery worker —
+    a caller asking to delete them must be rejected before any SQL runs."""
+    tag = uuid.uuid4().hex[:8]
+    await _seed_events(
+        session_factory, {"event": f"pending_{tag}", "status": "pending"}
+    )
+
+    r = await client.request(
+        "DELETE", "/admin/webhooks", params={"status": "pending"}
+    )
+    assert r.status_code == 400
+    assert await _count_events(session_factory, event=f"pending_{tag}") == 1
+
+
+async def test_purge_webhooks_event_type(client: AsyncClient, session_factory):
+    """`event_type` alone (no status) wipes both terminal statuses for
+    that type while leaving in-flight rows of the same type alone."""
+    tag = uuid.uuid4().hex[:8]
+    target_event = f"target.{tag}"
+    other_event = f"other.{tag}"
+    await _seed_events(
+        session_factory,
+        {"event": target_event, "status": "delivered"},
+        {"event": target_event, "status": "dead_letter"},
+        {"event": target_event, "status": "pending"},
+        {"event": other_event, "status": "delivered"},
+    )
+
+    r = await client.request(
+        "DELETE", "/admin/webhooks", params={"event_type": target_event}
+    )
+    assert r.status_code == 200
+
+    # Only the two terminal target rows are gone.
+    assert (
+        await _count_events(
+            session_factory, event=target_event, status="delivered"
+        )
+        == 0
+    )
+    assert (
+        await _count_events(
+            session_factory, event=target_event, status="dead_letter"
+        )
+        == 0
+    )
+    # Pending of the same type survives — the worker may still pick it up.
+    assert (
+        await _count_events(session_factory, event=target_event, status="pending")
+        == 1
+    )
+    # Unrelated event-type row is untouched.
+    assert (
+        await _count_events(
+            session_factory, event=other_event, status="delivered"
+        )
+        == 1
+    )
+
+
+async def test_purge_webhooks_tenant_scoping(client: AsyncClient, session_factory):
+    """Tenant filter cannot delete cross-tenant events."""
+    tag = uuid.uuid4().hex[:8]
+    await _seed_events(
+        session_factory,
+        {
+            "event": f"a_{tag}",
+            "tenant_id": f"tenant-a-{tag}",
+            "status": "dead_letter",
+        },
+        {
+            "event": f"b_{tag}",
+            "tenant_id": f"tenant-b-{tag}",
+            "status": "dead_letter",
+        },
+    )
+
+    r = await client.request(
+        "DELETE",
+        "/admin/webhooks",
+        params={"status": "dead_letter", "tenant_id": f"tenant-a-{tag}"},
+    )
+    assert r.status_code == 200
+
+    assert await _count_events(session_factory, tenant_id=f"tenant-a-{tag}") == 0
+    assert await _count_events(session_factory, tenant_id=f"tenant-b-{tag}") == 1
+
+
+async def test_purge_webhooks_empty_filter_rejected(
+    client: AsyncClient, session_factory
+):
+    tag = uuid.uuid4().hex[:8]
+    await _seed_events(
+        session_factory, {"event": f"sentinel_{tag}", "status": "delivered"}
+    )
+
+    r = await client.request("DELETE", "/admin/webhooks")
+    assert r.status_code == 400
+    assert await _count_events(session_factory, event=f"sentinel_{tag}") == 1

--- a/tests/test_admin_purge.py
+++ b/tests/test_admin_purge.py
@@ -1,0 +1,280 @@
+"""Unit + middleware-level tests for the admin purge endpoints.
+
+Covers:
+- Service-layer validation (empty filter, non-terminal status) without a DB.
+- Route registration on the real app (DELETE methods present).
+- Auth gate: when STATEWAVE_API_KEY is set, the purge endpoints are 401/403
+  unprotected, mirroring the rest of /admin/*.
+
+Real-DB happy-path / tenant scoping / no-cascade behavior lives in
+tests/integration/test_admin_purge.py — those need Postgres, while the
+checks here run on every CI invocation regardless of DB availability.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from server.services import webhooks as webhooks_service
+from server.services import compile_jobs_durable as jobs_service
+
+
+# ─── Service-layer validation (mocked DB) ────────────────────────────────────
+
+
+class TestPurgeJobsValidation:
+    @pytest.mark.anyio
+    async def test_empty_filter_raises(self):
+        with pytest.raises(ValueError, match="at least one filter is required"):
+            await jobs_service.purge_jobs()
+
+    @pytest.mark.anyio
+    async def test_non_terminal_status_rejected(self):
+        for bad in ("pending", "running", "anything"):
+            with pytest.raises(ValueError, match="status must be one of"):
+                await jobs_service.purge_jobs(status=bad)
+
+    @pytest.mark.anyio
+    async def test_terminal_statuses_constant_matches_implementation(self):
+        # The frontend's TERMINAL_STATUSES (jobs page) hardcodes the same
+        # pair. If this constant ever drifts, the UI either over-restricts
+        # the operator or sends a status the backend rejects.
+        assert jobs_service.TERMINAL_JOB_STATUSES == ("completed", "failed")
+
+    @pytest.mark.anyio
+    async def test_subject_filter_alone_is_accepted(self):
+        # Subject-only filters skip the status check but still must hit the
+        # DB; a mocked session lets us prove the validation didn't reject.
+        mock_result = AsyncMock()
+        mock_result.rowcount = 0
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "server.services.compile_jobs_durable.get_session_factory",
+            return_value=lambda: mock_session,
+        ):
+            count = await jobs_service.purge_jobs(subject_id="sub-1")
+        assert count == 0
+
+
+class TestPurgeWebhooksValidation:
+    @pytest.mark.anyio
+    async def test_empty_filter_raises(self):
+        with pytest.raises(ValueError, match="at least one filter is required"):
+            await webhooks_service.purge_events()
+
+    @pytest.mark.anyio
+    async def test_non_terminal_status_rejected(self):
+        for bad in ("pending", "anything"):
+            with pytest.raises(ValueError, match="status must be one of"):
+                await webhooks_service.purge_events(status=bad)
+
+    @pytest.mark.anyio
+    async def test_terminal_statuses_constant_matches_implementation(self):
+        assert webhooks_service.TERMINAL_WEBHOOK_STATUSES == (
+            "delivered",
+            "dead_letter",
+        )
+
+    @pytest.mark.anyio
+    async def test_event_type_filter_alone_is_accepted(self):
+        mock_result = AsyncMock()
+        mock_result.rowcount = 0
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "server.services.webhooks.get_session_factory",
+            return_value=lambda: mock_session,
+        ):
+            count = await webhooks_service.purge_events(event_type="episode.created")
+        assert count == 0
+
+
+# ─── Route registration (no DB) ──────────────────────────────────────────────
+
+
+def _methods_for_path(path: str) -> set[str]:
+    """Aggregate all HTTP methods registered at `path` across the app.
+
+    FastAPI registers `@router.get` and `@router.delete` on the same path
+    as two separate APIRoute entries, so we have to walk the full list
+    rather than stop at the first hit.
+    """
+    from server.app import app
+
+    methods: set[str] = set()
+    for route in app.routes:
+        if hasattr(route, "path") and route.path == path:
+            methods.update(route.methods)
+    return methods
+
+
+class TestRouteRegistration:
+    def test_delete_jobs_registered(self):
+        assert "DELETE" in _methods_for_path("/admin/jobs")
+
+    def test_delete_webhooks_registered(self):
+        assert "DELETE" in _methods_for_path("/admin/webhooks")
+
+
+# ─── Endpoint validation (router → service) ──────────────────────────────────
+
+
+class TestEndpointValidation:
+    """Hit the real router with an in-process client. The service is
+    mocked, so we're verifying the FastAPI route correctly translates the
+    `ValueError` raised by the service into a 400 with the same message.
+    """
+
+    @pytest.fixture
+    async def client_no_auth(self):
+        from server.app import create_app
+
+        app = create_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+        from server.db.engine import dispose_engine
+
+        await dispose_engine()
+
+    @pytest.mark.anyio
+    async def test_delete_jobs_empty_filter_returns_400(self, client_no_auth):
+        with patch(
+            "server.services.compile_jobs_durable.purge_jobs",
+            new=AsyncMock(side_effect=ValueError("at least one filter is required")),
+        ):
+            r = await client_no_auth.request("DELETE", "/admin/jobs")
+        assert r.status_code == 400
+        assert "at least one filter" in r.json()["error"]["message"]
+
+    @pytest.mark.anyio
+    async def test_delete_jobs_non_terminal_returns_400(self, client_no_auth):
+        with patch(
+            "server.services.compile_jobs_durable.purge_jobs",
+            new=AsyncMock(side_effect=ValueError("status must be one of (...)")),
+        ):
+            r = await client_no_auth.request(
+                "DELETE", "/admin/jobs", params={"status": "running"}
+            )
+        assert r.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_delete_webhooks_empty_filter_returns_400(self, client_no_auth):
+        with patch(
+            "server.services.webhooks.purge_events",
+            new=AsyncMock(side_effect=ValueError("at least one filter is required")),
+        ):
+            r = await client_no_auth.request("DELETE", "/admin/webhooks")
+        assert r.status_code == 400
+        assert "at least one filter" in r.json()["error"]["message"]
+
+    @pytest.mark.anyio
+    async def test_delete_webhooks_non_terminal_returns_400(self, client_no_auth):
+        with patch(
+            "server.services.webhooks.purge_events",
+            new=AsyncMock(side_effect=ValueError("status must be one of (...)")),
+        ):
+            r = await client_no_auth.request(
+                "DELETE", "/admin/webhooks", params={"status": "pending"}
+            )
+        assert r.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_delete_jobs_happy_path_passes_filter(self, client_no_auth):
+        spy = AsyncMock(return_value=3)
+        with patch("server.services.compile_jobs_durable.purge_jobs", new=spy):
+            r = await client_no_auth.request(
+                "DELETE",
+                "/admin/jobs",
+                params={"status": "completed", "tenant_id": "acme"},
+            )
+        assert r.status_code == 200
+        assert r.json() == {"deleted": 3}
+        spy.assert_awaited_once_with(
+            status="completed", subject_id=None, tenant_id="acme"
+        )
+
+    @pytest.mark.anyio
+    async def test_delete_webhooks_happy_path_passes_filter(self, client_no_auth):
+        spy = AsyncMock(return_value=7)
+        with patch("server.services.webhooks.purge_events", new=spy):
+            r = await client_no_auth.request(
+                "DELETE",
+                "/admin/webhooks",
+                params={"status": "dead_letter", "event_type": "episode.created"},
+            )
+        assert r.status_code == 200
+        assert r.json() == {"deleted": 7}
+        spy.assert_awaited_once_with(
+            status="dead_letter", event_type="episode.created", tenant_id=None
+        )
+
+
+# ─── Auth gate ────────────────────────────────────────────────────────────────
+
+
+class TestAuthGate:
+    """When STATEWAVE_API_KEY is set, every /admin/* route — including the
+    new DELETE endpoints — must require it. We construct an app with the
+    real middleware enabled and verify the gate rejects the request before
+    the service is ever called.
+    """
+
+    @pytest.fixture
+    async def client_with_key(self, monkeypatch):
+        from server.core.config import settings
+        from server.app import create_app
+
+        monkeypatch.setattr(settings, "api_key", "test-secret-key")
+        app = create_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+        from server.db.engine import dispose_engine
+
+        await dispose_engine()
+
+    @pytest.mark.anyio
+    async def test_delete_jobs_requires_api_key(self, client_with_key):
+        r = await client_with_key.request(
+            "DELETE", "/admin/jobs", params={"status": "completed"}
+        )
+        assert r.status_code == 401
+        assert "missing_api_key" in r.json()["error"]["code"]
+
+    @pytest.mark.anyio
+    async def test_delete_jobs_rejects_wrong_key(self, client_with_key):
+        r = await client_with_key.request(
+            "DELETE",
+            "/admin/jobs",
+            params={"status": "completed"},
+            headers={"X-API-Key": "wrong"},
+        )
+        assert r.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_delete_webhooks_requires_api_key(self, client_with_key):
+        r = await client_with_key.request(
+            "DELETE", "/admin/webhooks", params={"status": "delivered"}
+        )
+        assert r.status_code == 401
+
+    @pytest.mark.anyio
+    async def test_delete_webhooks_rejects_wrong_key(self, client_with_key):
+        r = await client_with_key.request(
+            "DELETE",
+            "/admin/webhooks",
+            params={"status": "delivered"},
+            headers={"X-API-Key": "wrong"},
+        )
+        assert r.status_code == 403


### PR DESCRIPTION
## Summary

Adds operator-facing `DELETE` endpoints under `/admin` so the terminal-only job and webhook-event tables can be bulk-cleaned without dropping into SQL.

Closes #24.

## Endpoints

- **`DELETE /admin/jobs?status&subject_id&tenant_id`** → `purge_compile_jobs`
- **`DELETE /admin/webhooks?status&event_type&tenant_id`** → `purge_webhook_events`

Both:
- **Refuse an empty filter.** Must pass at least one of `status` / `subject_id` / `tenant_id` (plus `event_type` for webhooks). Bulk-deleting everything with no constraint is a footgun.
- **Refuse non-terminal statuses.** `pending` / `running` jobs may still be held by the worker; `pending` webhook events may still be picked up by the delivery worker. Hard allowlists live as module-level constants — `TERMINAL_JOB_STATUSES = ("completed", "failed")` and `TERMINAL_WEBHOOK_STATUSES = ("delivered", "dead_letter")` — so the validators read from one place.
- **Return `{ deleted: int }`** on success.
- **Reuse the existing `/admin/*` auth gate.** No new auth path.

## Tests

**`tests/test_admin_purge.py`** (20 tests, no DB):
- Service-layer validation: empty-filter rejection, non-terminal-status rejection (jobs + events).
- Route registration: `DELETE` methods present on both endpoints.
- Auth gate: 401 when `STATEWAVE_API_KEY` is set and not provided.

**`tests/integration/test_admin_purge.py`** (separate file, needs Postgres):
- Happy path: purges only matching rows, returns count.
- Tenant scoping: a tenant filter cannot delete another tenant's rows.
- No cascade: purging a job/event leaves memories, episodes, subjects untouched.

## Test plan

- [ ] CI runs ruff + unit + integration test suites green
- [ ] After deploy, smoke-test against prod: a DELETE with non-terminal status returns 4xx; a DELETE with valid filter returns `{ deleted: N }`
- [ ] Verify no foreign-key cascade affected unrelated tables

## Deployment notes

Backend-only. Pairs with the admin UI in [statewave-admin](https://github.com/smaramwbc/statewave-admin) (separate PR, depends on these endpoints). Ship this first.