### PR TITLE
refactor(server): drop silent fallbacks in compile + embedding paths

### DIFF
--- a/server/core/config.py
+++ b/server/core/config.py
@@ -29,7 +29,14 @@ class Settings(BaseSettings):
     # Compiler
     compiler_type: str = "heuristic"
 
-    # Embeddings
+    # Embeddings.
+    #
+    # The default `stub` produces deterministic hash vectors so a fresh
+    # boot works without LLM credentials, BUT stub vectors are not
+    # semantic — semantic search will not work usefully under the stub.
+    # Set STATEWAVE_EMBEDDING_PROVIDER=litellm + STATEWAVE_LITELLM_API_KEY +
+    # STATEWAVE_LITELLM_EMBEDDING_MODEL for real semantic similarity.
+    # `none` disables embeddings entirely (no vector column writes).
     embedding_provider: str = "stub"  # "stub" | "litellm" | "none"
     embedding_dimensions: int = 1536
 

--- a/server/services/compile_jobs.py
+++ b/server/services/compile_jobs.py
@@ -1,13 +1,23 @@
 """Background compilation job manager.
 
-Provides async compilation with job tracking:
-- submit_job(): start compilation in background, return job_id
-- get_job(): check job status and results
-- cleanup_old_jobs(): prune stale entries
+Two layers, one source of truth:
 
-v0.5: Durable mode (Postgres-backed) via compile_jobs_durable.
-Falls back to in-memory when DB is not available.
-Jobs survive restarts in durable mode.
+  * `compile_jobs_durable` is the source of truth — every job is a row
+    in Postgres, and DB errors propagate. Jobs survive process restarts
+    and are visible to other replicas.
+  * The `_jobs` dict in this module is a process-local cache so that a
+    `get_job_durable(id)` from the same process that submitted the job
+    skips the DB round-trip. It is NOT a fallback for a missing or
+    unhealthy database — if Postgres is down the operator sees a 5xx,
+    not a "submitted" job that no other process can see.
+
+Public API used by the app: `submit_job_durable`, `get_job_durable`,
+`mark_running_durable`, `mark_completed_durable`, `mark_failed_durable`.
+
+The sync, in-memory primitives at the bottom of this file (`submit_job`,
+`get_job`, `mark_running`, `mark_completed`, `mark_failed`) are kept
+only because unit tests use them to drive the `_jobs` cache without
+mocking SQLAlchemy. They are NOT used anywhere on the request path.
 """
 
 from __future__ import annotations
@@ -42,7 +52,10 @@ class CompileJob:
     completed_at: float | None = None
 
 
-# In-memory fallback store
+# Process-local cache of jobs submitted from this process — speeds up
+# `get_job_durable` polling without a DB round-trip per call. NOT a
+# fallback store: a missing entry here is just a cache miss, never a
+# substitute for the durable row.
 _jobs: dict[str, CompileJob] = {}
 _JOB_TTL_SECONDS = 300
 
@@ -50,73 +63,77 @@ _JOB_TTL_SECONDS = 300
 # ---------------------------------------------------------------------------
 # Durable (Postgres-backed) interface — async
 # These are the primary interface used by the async compile path.
+# A DB failure raises; the caller (memories.py) renders the error to
+# the client instead of returning a job that nothing else will ever see.
 # ---------------------------------------------------------------------------
 
 
 async def submit_job_durable(subject_id: str, tenant_id: str | None = None) -> CompileJob:
-    """Submit job with Postgres durability."""
-    try:
-        from server.services.compile_jobs_durable import submit_job as _durable_submit
+    """Submit a Postgres-durable compile job.
 
-        job = await _durable_submit(subject_id, tenant_id)
-        # Also track in memory for fast access during this process lifetime
-        _jobs[job.id] = job
-        return job
-    except Exception:
-        logger.warning("durable_submit_fallback_to_memory", exc_info=True)
-        return submit_job(subject_id)
+    Persists the row first; only seeds the process-local cache after the
+    DB write succeeds, so a half-submitted job never appears as "found"
+    to a follow-up `get_job_durable` in the same process.
+    """
+    from server.services.compile_jobs_durable import submit_job as _durable_submit
+
+    job = await _durable_submit(subject_id, tenant_id)
+    _jobs[job.id] = job
+    _cleanup_old_jobs()
+    return job
 
 
 async def get_job_durable(job_id: str) -> CompileJob | None:
-    """Get job from Postgres (falls back to in-memory)."""
-    # Check in-memory first (fast path for same-process)
+    """Get a job by id. Process-local cache first, then Postgres.
+
+    Cache hits skip the DB round-trip; cache misses fall through to
+    Postgres. DB errors propagate so a transient outage isn't reported
+    as "job not found".
+    """
     if job_id in _jobs:
         return _jobs[job_id]
-    try:
-        from server.services.compile_jobs_durable import get_job as _durable_get
+    from server.services.compile_jobs_durable import get_job as _durable_get
 
-        return await _durable_get(job_id)
-    except Exception:
-        return None
+    return await _durable_get(job_id)
 
 
 async def mark_running_durable(job_id: str) -> None:
-    """Mark running in both stores."""
-    mark_running(job_id)
-    try:
-        from server.services.compile_jobs_durable import mark_running as _durable_mark
+    """Mark the job running in Postgres + the process-local cache.
 
-        await _durable_mark(job_id)
-    except Exception:
-        pass
+    The DB write happens first: if it fails, we don't quietly mark the
+    cache as running while the persisted row stays pending. Subsequent
+    cache mutation only happens on a successful commit.
+    """
+    from server.services.compile_jobs_durable import mark_running as _durable_mark
+
+    await _durable_mark(job_id)
+    mark_running(job_id)
 
 
 async def mark_completed_durable(
     job_id: str, memories_created: int, memories: list[dict[str, Any]]
 ) -> None:
-    """Mark completed in both stores."""
-    mark_completed(job_id, memories_created, memories)
-    try:
-        from server.services.compile_jobs_durable import mark_completed as _durable_mark
+    """Mark the job completed in Postgres + the process-local cache."""
+    from server.services.compile_jobs_durable import mark_completed as _durable_mark
 
-        await _durable_mark(job_id, memories_created, memories)
-    except Exception:
-        pass
+    await _durable_mark(job_id, memories_created, memories)
+    mark_completed(job_id, memories_created, memories)
 
 
 async def mark_failed_durable(job_id: str, error: str) -> None:
-    """Mark failed in both stores."""
-    mark_failed(job_id, error)
-    try:
-        from server.services.compile_jobs_durable import mark_failed as _durable_mark
+    """Mark the job failed in Postgres + the process-local cache."""
+    from server.services.compile_jobs_durable import mark_failed as _durable_mark
 
-        await _durable_mark(job_id, error)
-    except Exception:
-        pass
+    await _durable_mark(job_id, error)
+    mark_failed(job_id, error)
 
 
 # ---------------------------------------------------------------------------
-# In-memory interface (legacy, still used as fast cache)
+# In-memory primitives
+#
+# Drive the `_jobs` cache directly. Used by tests to construct fixtures
+# without mocking SQLAlchemy, and by the durable wrappers above to keep
+# the cache in sync after a successful DB write. Not on any request path.
 # ---------------------------------------------------------------------------
 
 

--- a/server/services/compile_jobs_durable.py
+++ b/server/services/compile_jobs_durable.py
@@ -1,9 +1,15 @@
 """Durable compile job manager — Postgres-backed.
 
-Jobs survive server restarts. Replaces the in-memory store from v0.4.
-Falls back gracefully: if DB write fails, job still runs (just untracked).
+Jobs survive server restarts. The store is the source of truth for job
+status; callers that need a same-process fast path use the wrapper in
+`compile_jobs.py` (`get_job_durable` consults a small process-local
+cache before this module).
 
-Public API unchanged:
+Database errors propagate. If Postgres is unhealthy a compile request
+returns 5xx — not "submitted but invisible to the next process". The
+operator sees the failure and fixes the deploy instead of running blind.
+
+Public API:
 - submit_job(subject_id) → CompileJob
 - get_job(job_id) → CompileJob | None
 - mark_running(job_id)
@@ -61,92 +67,83 @@ def _row_to_job(row: CompileJobRow) -> CompileJob:
 
 
 async def submit_job(subject_id: str, tenant_id: str | None = None) -> CompileJob:
-    """Create a durable compile job and persist to Postgres."""
+    """Create a durable compile job and persist to Postgres.
+
+    Raises whatever SQLAlchemy raises on DB failure — we no longer
+    return a "submitted" job that was never persisted. Callers must
+    surface DB outages to the operator.
+    """
     job_id = str(uuid.uuid4())[:8]
     now = datetime.now(timezone.utc)
-
-    try:
-        async with get_session_factory()() as session:
-            row = CompileJobRow(
-                id=job_id,
-                subject_id=subject_id,
-                tenant_id=tenant_id,
-                status="pending",
-                memories_created=0,
-                created_at=now,
-            )
-            session.add(row)
-            await session.commit()
-    except Exception:
-        logger.warning("compile_job_persist_failed", job_id=job_id, exc_info=True)
-
+    async with get_session_factory()() as session:
+        row = CompileJobRow(
+            id=job_id,
+            subject_id=subject_id,
+            tenant_id=tenant_id,
+            status="pending",
+            memories_created=0,
+            created_at=now,
+        )
+        session.add(row)
+        await session.commit()
     return CompileJob(id=job_id, subject_id=subject_id, created_at=now.timestamp())
 
 
 async def get_job(job_id: str) -> CompileJob | None:
-    """Retrieve a job by ID from Postgres."""
-    try:
-        async with get_session_factory()() as session:
-            result = await session.execute(select(CompileJobRow).where(CompileJobRow.id == job_id))
-            row = result.scalar_one_or_none()
-            if row is None:
-                return None
-            return _row_to_job(row)
-    except Exception:
-        logger.warning("compile_job_get_failed", job_id=job_id, exc_info=True)
-        return None
+    """Retrieve a job by ID from Postgres.
+
+    Returns None only when the job genuinely does not exist. DB errors
+    propagate so a transient outage doesn't masquerade as "not found".
+    """
+    async with get_session_factory()() as session:
+        result = await session.execute(select(CompileJobRow).where(CompileJobRow.id == job_id))
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return _row_to_job(row)
 
 
 async def mark_running(job_id: str) -> None:
-    """Mark job as running."""
-    try:
-        async with get_session_factory()() as session:
-            await session.execute(
-                update(CompileJobRow)
-                .where(CompileJobRow.id == job_id)
-                .values(status="running", started_at=datetime.now(timezone.utc))
-            )
-            await session.commit()
-    except Exception:
-        logger.warning("compile_job_mark_running_failed", job_id=job_id, exc_info=True)
+    """Mark job as running. Raises on DB failure."""
+    async with get_session_factory()() as session:
+        await session.execute(
+            update(CompileJobRow)
+            .where(CompileJobRow.id == job_id)
+            .values(status="running", started_at=datetime.now(timezone.utc))
+        )
+        await session.commit()
 
 
 async def mark_completed(
     job_id: str, memories_created: int, memories: list[dict[str, Any]]
 ) -> None:
-    """Mark job as completed with result count."""
-    try:
-        async with get_session_factory()() as session:
-            await session.execute(
-                update(CompileJobRow)
-                .where(CompileJobRow.id == job_id)
-                .values(
-                    status="completed",
-                    memories_created=memories_created,
-                    completed_at=datetime.now(timezone.utc),
-                )
+    """Mark job as completed with result count. Raises on DB failure."""
+    async with get_session_factory()() as session:
+        await session.execute(
+            update(CompileJobRow)
+            .where(CompileJobRow.id == job_id)
+            .values(
+                status="completed",
+                memories_created=memories_created,
+                completed_at=datetime.now(timezone.utc),
             )
-            await session.commit()
-    except Exception:
-        logger.warning("compile_job_mark_completed_failed", job_id=job_id, exc_info=True)
+        )
+        await session.commit()
 
 
 async def mark_failed(job_id: str, error: str) -> None:
-    """Mark job as failed with error message."""
-    try:
-        async with get_session_factory()() as session:
-            await session.execute(
-                update(CompileJobRow)
-                .where(CompileJobRow.id == job_id)
-                .values(
-                    status="failed",
-                    error=error,
-                    completed_at=datetime.now(timezone.utc),
-                )
+    """Mark job as failed with error message. Raises on DB failure."""
+    async with get_session_factory()() as session:
+        await session.execute(
+            update(CompileJobRow)
+            .where(CompileJobRow.id == job_id)
+            .values(
+                status="failed",
+                error=error,
+                completed_at=datetime.now(timezone.utc),
             )
-            await session.commit()
-    except Exception:
-        logger.warning("compile_job_mark_failed_failed", job_id=job_id, exc_info=True)
+        )
+        await session.commit()
 
 
 async def list_jobs(
@@ -160,58 +157,58 @@ async def list_jobs(
 
     Returns (jobs_list, total_count) tuple.
     """
-    try:
-        async with get_session_factory()() as session:
-            from sqlalchemy import func
+    async with get_session_factory()() as session:
+        from sqlalchemy import func
 
-            # Build base filter conditions
-            conditions = []
-            if status:
-                conditions.append(CompileJobRow.status == status)
-            if subject_id:
-                conditions.append(CompileJobRow.subject_id == subject_id)
-            if tenant_id is not None:
-                conditions.append(CompileJobRow.tenant_id == tenant_id)
+        # Build base filter conditions
+        conditions = []
+        if status:
+            conditions.append(CompileJobRow.status == status)
+        if subject_id:
+            conditions.append(CompileJobRow.subject_id == subject_id)
+        if tenant_id is not None:
+            conditions.append(CompileJobRow.tenant_id == tenant_id)
 
-            # Get total count
-            count_stmt = select(func.count()).select_from(CompileJobRow)
-            for cond in conditions:
-                count_stmt = count_stmt.where(cond)
-            total = await session.scalar(count_stmt) or 0
+        # Get total count
+        count_stmt = select(func.count()).select_from(CompileJobRow)
+        for cond in conditions:
+            count_stmt = count_stmt.where(cond)
+        total = await session.scalar(count_stmt) or 0
 
-            # Get paginated results
-            stmt = select(CompileJobRow).order_by(CompileJobRow.created_at.desc())
-            for cond in conditions:
-                stmt = stmt.where(cond)
-            stmt = stmt.offset(offset).limit(limit)
+        # Get paginated results
+        stmt = select(CompileJobRow).order_by(CompileJobRow.created_at.desc())
+        for cond in conditions:
+            stmt = stmt.where(cond)
+        stmt = stmt.offset(offset).limit(limit)
 
-            result = await session.execute(stmt)
-            rows = result.scalars().all()
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
 
-            jobs = [
-                {
-                    "job_id": row.id,
-                    "subject_id": row.subject_id,
-                    "tenant_id": row.tenant_id,
-                    "status": row.status,
-                    "memories_created": row.memories_created,
-                    "error": row.error,
-                    "created_at": row.created_at.isoformat() if row.created_at else None,
-                    "started_at": row.started_at.isoformat() if row.started_at else None,
-                    "completed_at": row.completed_at.isoformat() if row.completed_at else None,
-                }
-                for row in rows
-            ]
-            return jobs, total
-    except Exception:
-        logger.warning("compile_jobs_list_failed", exc_info=True)
-        return [], 0
+        jobs = [
+            {
+                "job_id": row.id,
+                "subject_id": row.subject_id,
+                "tenant_id": row.tenant_id,
+                "status": row.status,
+                "memories_created": row.memories_created,
+                "error": row.error,
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+                "started_at": row.started_at.isoformat() if row.started_at else None,
+                "completed_at": row.completed_at.isoformat() if row.completed_at else None,
+            }
+            for row in rows
+        ]
+        return jobs, total
 
 
 async def cleanup_old_jobs(retention_hours: int = 168) -> int:
     """Delete completed/failed jobs older than retention window.
 
     Default: 7 days (168 hours). Returns count of deleted rows.
+
+    Runs from a long-lived background loop on app startup; we swallow +
+    log here because a transient DB blip should not crash the lifespan
+    task. Errors surface as ERROR-level logs that the operator can find.
     """
     from datetime import timedelta
 
@@ -229,7 +226,7 @@ async def cleanup_old_jobs(retention_hours: int = 168) -> int:
                 logger.info("compile_jobs_cleaned", deleted=count)
             return count
     except Exception:
-        logger.warning("compile_jobs_cleanup_failed", exc_info=True)
+        logger.error("compile_jobs_cleanup_failed", exc_info=True)
         return 0
 
 

--- a/server/services/compilers/heuristic.py
+++ b/server/services/compilers/heuristic.py
@@ -1,7 +1,10 @@
 """Heuristic memory compiler — regex/pattern-based extraction.
 
 Extracts profile facts and episode summaries from chat-like episode payloads.
-No external dependencies. Suitable for local dev and as the default fallback.
+No external dependencies. Used by the default deploy
+(STATEWAVE_COMPILER_TYPE=heuristic) and by tests that don't want to mock
+an LLM. For higher-quality memories on real workloads, set
+STATEWAVE_COMPILER_TYPE=llm with a configured LiteLLM model.
 """
 
 from __future__ import annotations

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -8,7 +8,10 @@ adapter owns provider selection, timeout, retries, and error mapping.
 Optimized for speed:
 - Batches small episodes into a single LLM call
 - Runs multiple batches in parallel with concurrency control
-- Falls back gracefully on parse errors or API failures
+- Per-batch errors are logged at WARNING and contribute zero memories
+  to the final result. (The previous "Falls back gracefully" wording
+  obscured this — partial failures still log loudly so they can be
+  investigated.)
 
 Requires:
 - STATEWAVE_COMPILER_TYPE=llm
@@ -77,11 +80,24 @@ class LLMCompiler:
         self._model = model
 
     def compile(self, episodes: Sequence[EpisodeRow]) -> list[MemoryRow]:
-        """Sync fallback — uses heuristic compiler."""
-        from server.services.compilers.heuristic import HeuristicCompiler
+        """Sync entry point — not supported for the LLM compiler.
 
-        logger.warning("llm_compiler_sync_fallback")
-        return HeuristicCompiler().compile(episodes)
+        LLM extraction is fundamentally async (network round-trips,
+        per-batch concurrency). The previous behaviour silently
+        delegated to the regex-based `HeuristicCompiler`, which produced
+        plausible-looking but lower-quality memories under
+        STATEWAVE_COMPILER_TYPE=llm — exactly the silent-fallback
+        pattern this module no longer carries.
+
+        Callers must use `compile_async`; the `/v1/memories/compile`
+        path already does (see server/api/memories.py: it calls
+        `compile_async` whenever the active compiler defines it).
+        """
+        raise NotImplementedError(
+            "LLMCompiler is async-only — use `compile_async`. The sync "
+            "`compile()` no longer silently delegates to the heuristic "
+            "compiler. See server/api/memories.py for the dispatch logic."
+        )
 
     async def compile_async(self, episodes: Sequence[EpisodeRow]) -> list[MemoryRow]:
         """Async compile — batches episodes and processes in parallel."""

--- a/server/services/embeddings/__init__.py
+++ b/server/services/embeddings/__init__.py
@@ -2,11 +2,21 @@
 
 All embedding providers implement the BaseEmbeddingProvider protocol.
 The get_provider() factory returns the active provider based on config.
+
+The default provider is `stub` so a fresh `docker compose up` can boot
+without any LLM credentials, but stub vectors are deterministic hash
+output, NOT semantic. The factory logs a loud WARNING the first time
+the stub is selected so an operator can see at a glance that semantic
+search is degraded.
 """
 
 from __future__ import annotations
 
+import structlog
+
 from typing import Protocol
+
+logger = structlog.stdlib.get_logger()
 
 
 class BaseEmbeddingProvider(Protocol):
@@ -72,6 +82,21 @@ def get_provider() -> BaseEmbeddingProvider | None:
         from server.services.embeddings.stub import StubEmbeddingProvider
 
         _provider_instance = StubEmbeddingProvider(dimensions=settings.embedding_dimensions)
+        # One-shot loud warning per process. The stub produces
+        # deterministic but semantically meaningless vectors — semantic
+        # search ranks pseudo-randomly with the stub. Operators reading
+        # logs see this immediately instead of debugging "why is search
+        # ranking weird" against a hash function.
+        logger.warning(
+            "embedding_provider_stub_active",
+            advice=(
+                "Statewave is using the hash-based embedding stub. Vectors are "
+                "deterministic but NOT semantic — /v1/memories/search?semantic=true "
+                "and /v1/context relevance ranking will not work usefully. "
+                "Set STATEWAVE_EMBEDDING_PROVIDER=litellm and a "
+                "STATEWAVE_LITELLM_EMBEDDING_MODEL to enable real semantic search."
+            ),
+        )
     elif settings.embedding_provider == "litellm":
         from server.services.embeddings.litellm import LiteLLMEmbeddingProvider
 

--- a/tests/test_compile_jobs_durable.py
+++ b/tests/test_compile_jobs_durable.py
@@ -105,8 +105,16 @@ class TestDurableJobs:
         assert job.id in _jobs
 
     @pytest.mark.anyio
-    async def test_submit_job_durable_falls_back_on_db_error(self):
-        """If durable persist fails, falls back to in-memory only."""
+    async def test_submit_job_durable_propagates_db_error(self):
+        """A DB failure surfaces to the caller — no silent in-memory fallback.
+
+        The previous behaviour swallowed the exception and returned an
+        in-memory-only job. That made a Postgres outage look like a
+        successful submit while the row was never persisted; a
+        follow-up `get_job_durable` from any other process saw nothing.
+        Compile requests now return 5xx during a DB outage so the
+        operator sees + fixes the deploy.
+        """
         def mock_factory():
             raise RuntimeError("DB down")
 
@@ -114,11 +122,13 @@ class TestDurableJobs:
             "server.services.compile_jobs_durable.get_session_factory",
             return_value=mock_factory,
         ):
-            job = await submit_job_durable("test-subject")
+            with pytest.raises(RuntimeError, match="DB down"):
+                await submit_job_durable("test-subject")
 
-        # Should still work (in-memory fallback)
-        assert job.subject_id == "test-subject"
-        assert job.id in _jobs
+        # The cache must NOT be seeded by a failed submit — otherwise a
+        # follow-up get_job_durable in this same process would return a
+        # job that no other process can see.
+        assert _jobs == {}
 
     @pytest.mark.anyio
     async def test_get_job_durable_checks_memory_first(self):
@@ -242,6 +252,84 @@ class TestDurableJobs:
 
         assert job.status == JobStatus.failed
         assert job.error == "timeout"
+
+
+class TestDurableNoSilentFallback:
+    """Pin the no-silent-fallback contract for the durable wrappers.
+
+    A DB outage must surface as an exception to the caller — never a
+    success-shaped return — so a misconfigured deploy fails loudly
+    instead of running with a half-disabled job tracker.
+    """
+
+    @pytest.mark.anyio
+    async def test_get_job_durable_propagates_db_error(self):
+        """A DB outage during get must NOT look like 'job not found'."""
+        def mock_factory():
+            raise RuntimeError("DB down")
+
+        with patch(
+            "server.services.compile_jobs_durable.get_session_factory",
+            return_value=mock_factory,
+        ):
+            with pytest.raises(RuntimeError, match="DB down"):
+                # Use an id that isn't in the in-memory cache so we
+                # actually hit the DB layer.
+                await get_job_durable("not-in-cache")
+
+    @pytest.mark.anyio
+    async def test_mark_running_durable_propagates_db_error(self):
+        """A DB outage during mark_running must NOT silently flip the cache."""
+        job = submit_job("sub")
+        original_status = job.status
+
+        def mock_factory():
+            raise RuntimeError("DB down")
+
+        with patch(
+            "server.services.compile_jobs_durable.get_session_factory",
+            return_value=mock_factory,
+        ):
+            with pytest.raises(RuntimeError, match="DB down"):
+                await mark_running_durable(job.id)
+
+        # Cache stayed pristine — we don't want a job that looks
+        # 'running' in this process while the persisted row stays pending.
+        assert job.status == original_status
+
+    @pytest.mark.anyio
+    async def test_mark_completed_durable_propagates_db_error(self):
+        job = submit_job("sub")
+
+        def mock_factory():
+            raise RuntimeError("DB down")
+
+        with patch(
+            "server.services.compile_jobs_durable.get_session_factory",
+            return_value=mock_factory,
+        ):
+            with pytest.raises(RuntimeError, match="DB down"):
+                await mark_completed_durable(job.id, 5, [])
+
+        assert job.status == JobStatus.pending
+        assert job.memories_created == 0
+
+    @pytest.mark.anyio
+    async def test_mark_failed_durable_propagates_db_error(self):
+        job = submit_job("sub")
+
+        def mock_factory():
+            raise RuntimeError("DB down")
+
+        with patch(
+            "server.services.compile_jobs_durable.get_session_factory",
+            return_value=mock_factory,
+        ):
+            with pytest.raises(RuntimeError, match="DB down"):
+                await mark_failed_durable(job.id, "boom")
+
+        assert job.status == JobStatus.pending
+        assert job.error is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -121,6 +121,41 @@ def test_get_provider_returns_stub_by_default():
         reset_provider()
 
 
+def test_stub_provider_logs_loud_warning_at_first_use(caplog):
+    """Operators must SEE that semantic search is degraded under the stub.
+
+    Selecting the stub as the active provider emits a WARNING with
+    actionable advice (set STATEWAVE_EMBEDDING_PROVIDER=litellm). This
+    is the single moment where the cost of the convenient default is
+    surfaced — without it, an unconfigured deploy looks healthy until
+    someone notices semantic-search results are pseudo-random.
+    """
+    import logging
+    from server.services.embeddings import get_provider, reset_provider
+    import server.core.config
+
+    original_settings = server.core.config.settings
+    try:
+        from server.core.config import Settings
+        import os
+
+        os.environ.pop("STATEWAVE_EMBEDDING_PROVIDER", None)
+        reset_provider()
+        server.core.config.settings = Settings(_env_file=None, embedding_provider="stub")
+
+        with caplog.at_level(logging.WARNING):
+            provider = get_provider()
+
+        assert provider is not None
+        warning_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("embedding_provider_stub_active" in m for m in warning_messages), (
+            f"expected stub-active warning, got: {warning_messages}"
+        )
+    finally:
+        server.core.config.settings = original_settings
+        reset_provider()
+
+
 # ---------------------------------------------------------------------------
 # _TTLCache (used by LiteLLMEmbeddingProvider for query embedding cache)
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_compiler.py
+++ b/tests/test_llm_compiler.py
@@ -222,3 +222,19 @@ async def test_compile_coerces_list_summary_to_string():
         assert isinstance(memories[0].summary, str)
         assert "bullet 1" in memories[0].summary
         assert "bullet 2" in memories[0].summary
+
+
+def test_sync_compile_raises_instead_of_silent_heuristic_delegation():
+    """LLMCompiler.compile() must NOT silently delegate to HeuristicCompiler.
+
+    The previous behaviour returned heuristic-extracted memories under
+    STATEWAVE_COMPILER_TYPE=llm, which produced lower-quality results
+    that looked like LLM output. Operators couldn't tell from the
+    response shape that the LLM compiler had been bypassed. Now sync
+    callers see a `NotImplementedError` and a clear pointer to
+    `compile_async`.
+    """
+    compiler = _make_compiler()
+    ep = _make_episode(payload={"text": "anything"})
+    with pytest.raises(NotImplementedError, match="compile_async"):
+        compiler.compile([ep])


### PR DESCRIPTION
## Summary

Statewave isn't in production yet — the audit principle for this repo is **"required config must fail loudly, no backwards-compat shims"**. This PR closes four silent-degradation footguns the codebase was carrying.

### 1. Compile-job durability — propagate DB errors

`compile_jobs_durable` wrapped every Postgres call in `except Exception` and returned a success-shaped value:

- `submit_job` returned an **unpersisted** `CompileJob` on DB failure — caller saw "submitted", no row existed, no other process could see the job.
- `get_job` returned `None` on any DB error — a transient outage looked identical to "job not found".
- `mark_running` / `mark_completed` / `mark_failed` swallowed DB errors silently while the in-memory cache moved forward.

`compile_jobs` compounded it: `submit_job_durable` caught the durable failure and silently created an in-memory-only job; the `mark_X_durable` wrappers wrote the cache **first**, then swallowed any DB error.

**After:** the durable layer raises on DB failure. The wrappers update the DB first, then mirror to the process-local cache only on success. A follow-up `get_job_durable` from another process can't see a job that was never persisted; an outage surfaces as a 5xx the operator can act on.

`cleanup_old_jobs` keeps its `try/except` — it runs from a long-lived background loop where one transient blip should not crash the lifespan task — but logs at `ERROR` with a clearer name.

### 2. `LLMCompiler.compile()` — raise instead of silent heuristic delegation

`LLMCompiler.compile()` (sync) silently delegated to `HeuristicCompiler` with a single low-volume `logger.warning("llm_compiler_sync_fallback")`. Operators running `STATEWAVE_COMPILER_TYPE=llm` got heuristic-quality memories with the LLM-compiler signature in `metadata.compiler="llm"`. There was no way to tell from the response shape that the LLM path had been bypassed.

**After:** `compile()` raises `NotImplementedError` with an explicit pointer to `compile_async`. The `/v1/memories/compile` route already prefers `compile_async` whenever the active compiler defines it, so the dispatch path was never broken — only the silent quality regression for any caller taking the sync path.

### 3. Embedding stub — make the cost visible

Stub embeddings are deterministic hash output, **not** semantic. With the default `STATEWAVE_EMBEDDING_PROVIDER=stub` an unconfigured deploy boots happily and `?semantic=true` ranks pseudo-randomly. Operators had no way to discover this from logs.

**After:** a one-shot `WARNING` the first time the stub is selected, naming the limitation and the env vars needed for real semantic search. The default itself is unchanged — losing the zero-config dev story would be too disruptive — but the cost is now surfaced.

### 4. Wording cleanup

Renames \"fallback\"-flavoured phrasing where the code no longer falls back:

- `compile_jobs.py`: \"In-memory fallback store\" → \"process-local cache, NOT a fallback\"
- `compilers/heuristic.py`: \"default fallback\" → \"used by the default deploy\"
- `compilers/llm.py`: drops \"Falls back gracefully on parse errors\" claim

## Tests

- `tests/test_compile_jobs_durable.py`:
  - **replaces** `test_submit_job_durable_falls_back_on_db_error` with `test_submit_job_durable_propagates_db_error` (asserts the exception raises and the cache is NOT seeded by a failed submit)
  - **adds** 4 new tests pinning that `get_job_durable`, `mark_running_durable`, `mark_completed_durable`, `mark_failed_durable` all propagate the DB error and leave the cache pristine
- `tests/test_llm_compiler.py`: new `test_sync_compile_raises_instead_of_silent_heuristic_delegation`
- `tests/test_embeddings.py`: new `test_stub_provider_logs_loud_warning_at_first_use`

## What's NOT in this PR

- **`_process_batch` swallow** in `compilers/llm.py`: a per-batch LLM error still logs at `WARNING` and contributes zero memories to the final result. The audit specifically scoped only `compile()`; the per-batch swallow is a separate decision (rate-limit handling vs. fail-the-whole-job-on-one-blip) that warrants its own PR.
- **`embeddings/backfill.py` swallow**: fire-and-forget background task, by design — outside the audit scope.

## Test plan
- [x] `pytest -q --ignore=tests/integration` — 388 passed, 1 skipped (pre-existing)
- [x] CI green
- [x] Manual smoke: with Postgres running, `POST /v1/memories/compile` async mode persists a row visible to a second process
- [x] Manual smoke: with Postgres stopped, the same call returns 5xx instead of a job_id that can never be polled