### PR TITLE
fix: single-source the project version + bump-version script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -90,7 +90,7 @@ body:
         - OS: [e.g., macOS 14.0, Ubuntu 22.04]
         - Python version: [e.g., 3.11.4]
         - Node.js version: [if applicable]
-        - Statewave version: [e.g., 0.5.0]
+        - Statewave version: [e.g., 0.7.1]
         - SDK version: [if using SDK]
         - Deployment: [local, Docker, Fly.io, etc.]
     validations:

--- a/.github/ISSUE_TEMPLATE/operator_issue.yml
+++ b/.github/ISSUE_TEMPLATE/operator_issue.yml
@@ -86,7 +86,7 @@ body:
       label: Environment
       description: Provide your environment details
       placeholder: |
-        - Statewave version: [e.g., 0.5.0]
+        - Statewave version: [e.g., 0.7.1]
         - Docker version: [if applicable]
         - Database: [PostgreSQL version]
         - Cloud region: [if applicable]

--- a/.github/ISSUE_TEMPLATE/sdk_issue.yml
+++ b/.github/ISSUE_TEMPLATE/sdk_issue.yml
@@ -87,7 +87,7 @@ body:
       label: Environment
       description: Provide your environment details
       placeholder: |
-        - SDK version: [e.g., 0.5.0]
+        - SDK version: [e.g., 0.7.1]
         - Python/Node.js version:
         - OS:
     validations:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Everything is organised around **subjects** — a user, account, agent, repo, or
 
 Statewave is **not** a chatbot framework, a vector database, a RAG pipeline, or a hosted service. It is infrastructure you run alongside your application.
 
-> **Status:** v0.6.1 — actively developed. Full support-agent intelligence stack: session-aware context, resolution tracking, handoff packs, health scoring, SLA tracking, proactive alerts. See [current limitations](#current-limitations) below.
+> **Status:** v0.7.1 — actively developed. Full support-agent intelligence stack: session-aware context, resolution tracking, handoff packs, health scoring, SLA tracking, proactive alerts. See [current limitations](#current-limitations) below.
 
 ## 🎯 Try it
 
@@ -182,7 +182,7 @@ pytest tests/ -v
 
 ## Current limitations
 
-Statewave is in active development (v0.6.1). Honest status:
+Statewave is in active development (v0.7.1). Honest status:
 
 - **Rate limiting is per-IP** — distributed (Postgres-backed), but keyed by IP only, not per-tenant or per-API-key yet
 - **Multi-tenant is app-layer** — real query-scoped isolation (v0.5), no Postgres RLS yet

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+"""Bump or verify the project version across all user-facing surfaces.
+
+`pyproject.toml` is the source of truth. The server reads its version
+dynamically via `importlib.metadata`, so it never needs editing. Markdown
+and YAML cannot read package metadata at render time, so this script keeps
+the README status lines and issue-template examples in lockstep.
+
+Usage:
+    python scripts/bump_version.py 0.8.0     # rewrite pyproject + docs
+    python scripts/bump_version.py --check   # exit 1 if anything drifted
+
+Exit codes:
+    0 — bumped successfully, or all targets already match pyproject
+    1 — drift detected (--check) or invalid arguments
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+PYPROJECT_VERSION_RE = re.compile(r'^version = "(?P<version>[^"]+)"', re.MULTILINE)
+
+
+@dataclass
+class Target:
+    """A single anchored substitution in a tracked file."""
+
+    path: Path
+    # Format strings substituted with `version=...`. The literal `{version}`
+    # placeholder is the only field interpolated; everything else is matched
+    # verbatim, so historical refs like `(v0.5)` and demo content are safe.
+    pattern: str
+    template: str
+
+    def expected(self, version: str) -> str:
+        return self.template.format(version=version)
+
+    def stale(self, version: str) -> bool:
+        return self.expected(version) not in self.path.read_text(encoding="utf-8")
+
+
+def _readme_targets() -> list[Target]:
+    return [
+        Target(
+            path=ROOT / "README.md",
+            pattern=r"> \*\*Status:\*\* v(?P<version>\S+) — actively developed\.",
+            template="> **Status:** v{version} — actively developed.",
+        ),
+        Target(
+            path=ROOT / "README.md",
+            pattern=r"Statewave is in active development \(v(?P<version>[^)]+)\)\. Honest status:",
+            template="Statewave is in active development (v{version}). Honest status:",
+        ),
+    ]
+
+
+def _issue_template_targets() -> list[Target]:
+    templates = ROOT / ".github" / "ISSUE_TEMPLATE"
+    return [
+        Target(
+            path=templates / "operator_issue.yml",
+            pattern=r"Statewave version: \[e\.g\., (?P<version>[^\]]+)\]",
+            template="Statewave version: [e.g., {version}]",
+        ),
+        Target(
+            path=templates / "sdk_issue.yml",
+            pattern=r"SDK version: \[e\.g\., (?P<version>[^\]]+)\]",
+            template="SDK version: [e.g., {version}]",
+        ),
+        Target(
+            path=templates / "bug_report.yml",
+            pattern=r"Statewave version: \[e\.g\., (?P<version>[^\]]+)\]",
+            template="Statewave version: [e.g., {version}]",
+        ),
+    ]
+
+
+def all_targets() -> list[Target]:
+    return _readme_targets() + _issue_template_targets()
+
+
+def read_pyproject_version() -> str:
+    match = PYPROJECT_VERSION_RE.search(PYPROJECT.read_text(encoding="utf-8"))
+    if not match:
+        raise RuntimeError('could not locate `version = "…"` in pyproject.toml')
+    return match["version"]
+
+
+def write_pyproject_version(new: str) -> None:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    updated, count = PYPROJECT_VERSION_RE.subn(f'version = "{new}"', text, count=1)
+    if count != 1:
+        raise RuntimeError('could not locate `version = "…"` in pyproject.toml')
+    PYPROJECT.write_text(updated, encoding="utf-8")
+
+
+def apply_target(target: Target, new: str) -> bool:
+    text = target.path.read_text(encoding="utf-8")
+    pattern = re.compile(target.pattern)
+    match = pattern.search(text)
+    if not match:
+        raise RuntimeError(
+            f"pattern not found in {target.path.relative_to(ROOT)}: {target.pattern!r}"
+        )
+    if match.group("version") == new:
+        return False
+    updated = pattern.sub(target.expected(new), text, count=1)
+    target.path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def cmd_bump(new: str) -> int:
+    if not SEMVER_RE.match(new):
+        print(f"error: {new!r} is not a valid version (expected X.Y.Z)", file=sys.stderr)
+        return 1
+
+    current = read_pyproject_version()
+    if current == new:
+        print(f"pyproject.toml already at {new}; checking docs are in sync…")
+    else:
+        write_pyproject_version(new)
+        print(f"pyproject.toml: {current} → {new}")
+
+    changed = 0
+    for target in all_targets():
+        if apply_target(target, new):
+            print(f"  updated {target.path.relative_to(ROOT)}")
+            changed += 1
+    if changed == 0:
+        print("  (docs already in sync)")
+    return 0
+
+
+def cmd_check() -> int:
+    version = read_pyproject_version()
+    drifted = [t for t in all_targets() if t.stale(version)]
+    if not drifted:
+        print(f"all version references match pyproject.toml ({version})")
+        return 0
+    print(f"version drift detected — pyproject.toml is {version}, but:", file=sys.stderr)
+    for t in drifted:
+        print(f"  - {t.path.relative_to(ROOT)} does not contain expected text", file=sys.stderr)
+    print(f"\nfix: python scripts/bump_version.py {version}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("version", nargs="?", help="new version, e.g. 0.8.0")
+    group.add_argument("--check", action="store_true", help="verify only, do not edit")
+    args = parser.parse_args()
+
+    if args.check:
+        return cmd_check()
+    return cmd_bump(args.version)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/app.py
+++ b/server/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError, version
 
 import structlog
 from fastapi import FastAPI
@@ -20,6 +21,14 @@ from server.core.tenant import TenantMiddleware
 from server.core.tracing import setup_tracing
 
 logger = structlog.stdlib.get_logger()
+
+
+def get_app_version() -> str:
+    """Return the installed package version, or a dev sentinel when not installed."""
+    try:
+        return version("statewave")
+    except PackageNotFoundError:
+        return "0.0.0-dev"
 
 
 async def _cleanup_loop():
@@ -91,7 +100,7 @@ async def lifespan(app: FastAPI):
     except Exception as exc:
         logger.warning("schema_check_skipped", reason=str(exc)[:200])
 
-    logger.info("app_startup", version="0.7.1", debug=settings.debug)
+    logger.info("app_startup", version=get_app_version(), debug=settings.debug)
     yield
     if cleanup_task:
         cleanup_task.cancel()
@@ -113,7 +122,7 @@ def create_app() -> FastAPI:
             "compile durable typed memories, retrieve ranked context within "
             "token budgets, and govern data by subject."
         ),
-        version="0.7.1",
+        version=get_app_version(),
         docs_url="/docs",
         redoc_url="/redoc",
         lifespan=lifespan,


### PR DESCRIPTION
## Summary

`server/app.py` hardcoded `"0.7.1"` while `pyproject.toml` was the nominal source of truth, so any future release would silently drift the API/OpenAPI version, the startup log line, and the README/issue-template examples.

- `server/app.py` reads the version at runtime via `importlib.metadata` (falls back to `"0.0.0-dev"` when running uninstalled — useful for tests)
- README status lines and issue-template version examples bumped to the current `0.7.1`
- `scripts/bump_version.py` rewrites `pyproject.toml` + the doc anchors in lockstep on each release; `--check` is suitable as a CI guard against future drift

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('server/app.py').read())"` — syntax OK
- [x] `python3 scripts/bump_version.py --check` — clean
- [x] `python3 scripts/bump_version.py 9.9.9` then back to `0.7.1` — round-trip clean
- [x] CI green on this PR (runs the existing pytest suite against pgvector Postgres)
- [x] After merge: `fly deploy` and confirm `GET /openapi.json` reports `info.version == "0.7.1"`