### PR TITLE
fix(health): detect recurring issues against per-resolved-session text

### DIFF
--- a/server/services/health.py
+++ b/server/services/health.py
@@ -13,6 +13,7 @@ Design principles:
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -136,24 +137,26 @@ async def compute_health(
         )
 
     # --- Signal 2: Repeated issue patterns ---
-    # Detect if multiple sessions exist with same issue keywords
+    # Detect if any open session resembles a *specific* prior resolved session.
+    # We compare each (open, resolved) pair individually rather than blob-vs-blob,
+    # so unrelated resolved sessions can't dilute the overlap.
     resolved_sessions = [r for r in resolutions if r.status == "resolved"]
     open_session_ids = {r.session_id for r in open_sessions}
 
-    # Check if any open session shares keywords with a prior resolved session
-    # (indicates a recurring problem)
     if open_sessions and resolved_sessions:
         open_texts = _collect_session_texts(episodes, open_session_ids)
-        resolved_texts = _collect_session_texts(episodes, {r.session_id for r in resolved_sessions})
-        if open_texts and resolved_texts and _has_keyword_overlap(open_texts, resolved_texts):
-            score -= _REPEATED_ISSUE_PENALTY
-            factors.append(
-                HealthFactor(
-                    signal="repeated_issues",
-                    impact=-_REPEATED_ISSUE_PENALTY,
-                    detail="Open issues resemble previously resolved ones",
+        for r in resolved_sessions:
+            resolved_text = _collect_session_texts(episodes, {r.session_id})
+            if open_texts and resolved_text and _has_keyword_overlap(open_texts, resolved_text):
+                score -= _REPEATED_ISSUE_PENALTY
+                factors.append(
+                    HealthFactor(
+                        signal="repeated_issues",
+                        impact=-_REPEATED_ISSUE_PENALTY,
+                        detail=f"Open issue resembles previously resolved session {r.session_id}",
+                    )
                 )
-            )
+                break  # Only penalize once
 
     # --- Signal 3: Escalation / urgency markers ---
     escalation_count = sum(1 for ep in episodes if _ep_has_urgency(ep))
@@ -349,8 +352,8 @@ def _has_keyword_overlap(text_a: str, text_b: str) -> bool:
         "that",
         "with",
     }
-    words_a = {w for w in text_a.lower().split() if len(w) > 2 and w not in stopwords}
-    words_b = {w for w in text_b.lower().split() if len(w) > 2 and w not in stopwords}
+    words_a = {w for w in re.findall(r"[a-z]+", text_a.lower()) if len(w) > 2 and w not in stopwords}
+    words_b = {w for w in re.findall(r"[a-z]+", text_b.lower()) if len(w) > 2 and w not in stopwords}
     if not words_a or not words_b:
         return False
     smaller = min(len(words_a), len(words_b))

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -146,6 +146,55 @@ async def test_repeated_issues_worsen_health():
 
 
 @pytest.mark.asyncio
+async def test_repeated_issues_detected_through_punctuation():
+    """Punctuation attached to words should not break overlap detection.
+
+    Regression: prior tokenizer used .split() which treated 'payments' and
+    'payments.' as different tokens. Realistic conversation text always has
+    attached punctuation, so the signal silently failed to fire on real data.
+    """
+    resolutions = [
+        _make_resolution("sess-A", "resolved", resolved_at=_NOW - timedelta(days=2)),
+        _make_resolution("sess-B", "resolved", resolved_at=_NOW - timedelta(days=1)),
+        _make_resolution("sess-C", "open"),
+    ]
+    episodes = [
+        _make_episode(
+            "sess-A",
+            "Our billing gateway is timing out when processing payments. "
+            "Let me restart the payment processing service.",
+            days_ago=2,
+        ),
+        _make_episode("sess-B", "Need to reset my admin password.", days_ago=1),
+        _make_episode(
+            "sess-C",
+            "The billing gateway is timing out AGAIN. This is urgent — "
+            "invoices due today and payments are failing.",
+            days_ago=0,
+        ),
+    ]
+
+    with (
+        patch(
+            "server.services.health.repo.list_resolutions",
+            new_callable=AsyncMock,
+            return_value=resolutions,
+        ),
+        patch(
+            "server.services.health.repo.list_episodes_by_subject",
+            new_callable=AsyncMock,
+            return_value=episodes,
+        ),
+    ):
+        result = await compute_health(AsyncMock(), "user-1")
+
+    signals = [f.signal for f in result.factors]
+    assert "repeated_issues" in signals
+    assert result.state in ("watch", "at_risk")
+    assert result.score < 70
+
+
+@pytest.mark.asyncio
 async def test_recently_resolved_accounts_score_better():
     """Account with recent resolution should score better than one with unresolved recurring issues."""
     # Good account: all resolved recently


### PR DESCRIPTION
Closes #33.

## Root cause

`repeated_issues` was firing in unit tests but silently failing on realistic data. Two compounding bugs:

1. **Tokenization**: `_has_keyword_overlap` used `text.lower().split()` (whitespace only), so attached punctuation killed matches — `"payments"` ≠ `"payments."`, `"timeout"` ≠ `"timeout."`. Any realistic conversation text loses several matches it should have.
2. **Blob-vs-blob comparison**: open-session text was compared against **all resolved sessions concatenated**. Unrelated resolved sessions (password reset) diluted the overlap with the actually-recurring session (gateway timeout) below the 30% threshold.

For the canonical 4-session benchmark scenario, hand-calculating with the tokenizer fix alone got overlap to 29.0% — still under threshold. Per-session comparison gives 37.5% against the matching session.

## Fix

```diff
- words_a = {w for w in text_a.lower().split() if ...}
+ words_a = {w for w in re.findall(r"[a-z]+", text_a.lower()) if ...}
```

```python
# Compare each (open, resolved) pair individually, not blob-vs-blob.
for r in resolved_sessions:
    resolved_text = _collect_session_texts(episodes, {r.session_id})
    if open_texts and resolved_text and _has_keyword_overlap(open_texts, resolved_text):
        score -= _REPEATED_ISSUE_PENALTY
        factors.append(HealthFactor(
            signal="repeated_issues",
            ...
            detail=f"Open issue resembles previously resolved session {r.session_id}",
        ))
        break
```

The detail now names the specific resolved session (e.g. `"Open issue resembles previously resolved session sess-A"`) instead of the generic `"Open issues resemble previously resolved ones"`.

## Push-back on the issue's other suggestions

The issue also suggested adding a `recurring_issue` signal and an `urgency_markers` signal. Both already exist (`repeated_issues`, `escalations`); `escalations` was already firing for this scenario. The fix is the smaller, surgical one. I'd also leave `recent_resolution` intact — it's a healthy customer-engagement signal and shouldn't be suppressed when other negatives are working correctly.

## Verified

Live workflow benchmark (`statewave-examples/benchmark-support-agent/benchmark_support_workflow.py`):

```
Criterion                               Statewave      Naive
------------------------------------------------------------
Active issue identified                         ✓          ✗
Recurring issue pattern detected                ✓          ✗
Customer health computed                        ✓          ✗   ← was ✗
Health state in handoff                         ✓          ✗   ← was ✗
Resolved issues deprioritized                   ✓          ✗
Compact output                                  ✓          ✓
Deterministic output                            ✓          ✓
Provenance tracing                              ✓          ✗

Score: Statewave 8/8 | Naive 2/8
```

Live `/v1/subjects/{id}/health` for the benchmark scenario:

```json
{
  "score": 55,
  "state": "watch",
  "factors": [
    {"signal": "unresolved_issues", "impact": -15, "detail": "1 open session(s)"},
    {"signal": "repeated_issues", "impact": -20, "detail": "Open issue resembles previously resolved session sess-A"},
    {"signal": "escalations", "impact": -20, "detail": "3 episode(s) with urgency markers"},
    {"signal": "recent_resolution", "impact": 10, "detail": "2 session(s) resolved in last 7 days"}
  ]
}
```

## Tests

- `tests/test_health.py` — all 12 unit tests pass, including a new `test_repeated_issues_detected_through_punctuation` regression that uses realistic punctuated conversation text and would have failed under the old tokenizer.
- Full statewave test suite: 469 passed (4 pre-existing integration failures unrelated to health — verified by stashing this change and re-running).

## Follow-up

Once this lands, the loosened pytest assertion in [statewave-examples PR #4](https://github.com/smaramwbc/statewave-examples/pull/4) (`test_health_endpoint_shape` → `test_health_scoring`) can be tightened back to assert `state in ("watch", "at_risk")` and `score < 70` for the recurring-issue scenario.