### PR TITLE
chore: update postgres eval README link

### DIFF
--- a/infra/postgres-pgvector/README.md
+++ b/infra/postgres-pgvector/README.md
@@ -103,8 +103,7 @@ curl -sf -X POST -H \"X-API-Key: \$STATEWAVE_API_KEY\" \\
   https://statewave-api.fly.dev/v1/context | jq .token_estimate
 
 # 3. Run the docs eval — doc_match_rate should hold or improve
-cd statewave-examples/eval-docs-support
-STATEWAVE_URL=https://statewave-api.fly.dev STATEWAVE_API_KEY=... python eval_docs_support.py
+STATEWAVE_URL=https://statewave-api.fly.dev STATEWAVE_API_KEY=... python scripts/eval/eval_docs_support.py
 ```
 
 ## Rollback


### PR DESCRIPTION
## Why

\`scripts/eval/eval_docs_support.py\` lives in this repo since #34 (merged b7b09ef). The infra/postgres-pgvector README's post-migration verification step still pointed at the old \`statewave-examples/eval-docs-support/\` path — that directory is being deleted by smaramwbc/statewave-examples#4, so the README would break the moment that lands.

## What changed

\`infra/postgres-pgvector/README.md\` step 3 — replaced the \`cd\` + relative invocation with a direct invocation against the new in-repo path:

\`\`\`diff
 # 3. Run the docs eval — doc_match_rate should hold or improve
-cd statewave-examples/eval-docs-support
-STATEWAVE_URL=https://statewave-api.fly.dev STATEWAVE_API_KEY=... python eval_docs_support.py
+STATEWAVE_URL=https://statewave-api.fly.dev STATEWAVE_API_KEY=... python scripts/eval/eval_docs_support.py
\`\`\`

## Verification

\`grep -rn eval-docs-support . --include="*.md"\` returns no remaining references in this repo's markdown.