### PR TITLE
ci(docker): publish statewavedev/statewave to Docker Hub + GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,103 @@
+name: Docker publish
+
+# Builds the Statewave server image and pushes it to:
+#   - Docker Hub: statewavedev/statewave
+#   - GHCR:       ghcr.io/smaramwbc/statewave
+#
+# Multi-arch (linux/amd64, linux/arm64), with build provenance + SBOM, signed
+# via Sigstore through actions/attest-build-provenance.
+#
+# Triggers:
+#   - push to main           → :latest, :sha-<short>
+#   - push of v* tag         → :X.Y.Z, :X.Y, :X (semver)
+#   - workflow_dispatch      → manual rerun
+#
+# Required repo wiring (already configured at the repo level):
+#   - vars.DOCKERHUB_USERNAME = statewavedev
+#   - secrets.DOCKERHUB_TOKEN = a Docker Hub access token with R/W on the
+#     statewavedev namespace
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            statewavedev/statewave
+            ghcr.io/smaramwbc/statewave
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          labels: |
+            org.opencontainers.image.title=Statewave
+            org.opencontainers.image.description=Statewave server — memory + intelligence stack for AI agents
+            org.opencontainers.image.vendor=Statewave
+            org.opencontainers.image.licenses=AGPL-3.0
+            org.opencontainers.image.source=https://github.com/smaramwbc/statewave
+            org.opencontainers.image.documentation=https://statewave.ai
+
+      - id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Attest build provenance — Docker Hub
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: index.docker.io/statewavedev/statewave
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest build provenance — GHCR
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/smaramwbc/statewave
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       retries: 10
 
   api:
+    # Default to the published multi-arch image — `docker compose up -d` works
+    # without a local checkout. Pin a version with STATEWAVE_VERSION=0.7.0.
+    # Contributors who want to rebuild locally: `docker compose build api`
+    # rebuilds from the Dockerfile in this repo and tags the same name.
+    image: statewavedev/statewave:${STATEWAVE_VERSION:-latest}
     build: .
     ports:
       - "8100:8100"


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/docker-publish.yml` builds the server image and pushes to **Docker Hub** (`statewavedev/statewave`) and **GHCR** (`ghcr.io/smaramwbc/statewave`).
- Multi-arch: `linux/amd64` + `linux/arm64` via QEMU + buildx.
- Signed build provenance via `actions/attest-build-provenance@v2` pushed to both registries.
- `docker-compose.yml` flips `api.image` to `statewavedev/statewave:${STATEWAVE_VERSION:-latest}` so end users `docker compose up -d` without `git clone`. `build: .` stays as the contributor fallback.

## Triggers

| Trigger | Tags published |
|---|---|
| Push to `main` | `:latest`, `:sha-<short>` |
| Push of `v*` tag | `:X.Y.Z`, `:X.Y`, `:X`, `:sha-<short>` |
| `workflow_dispatch` | Whatever the ref resolves to |

## Required wiring

- `vars.DOCKERHUB_USERNAME` = `statewavedev` (already set)
- `secrets.DOCKERHUB_TOKEN` = Docker Hub access token (R/W on `statewavedev`) — **needs to be set** before the first run

## Test plan

- [ ] After merge, observe the Docker publish run on `main`. Expect `statewavedev/statewave:latest` + `:sha-<short>` to appear on Docker Hub and `ghcr.io/smaramwbc/statewave:latest` on GHCR.
- [ ] `docker pull statewavedev/statewave:latest` from a clean machine, `docker run -p 8100:8100 statewavedev/statewave` smoke-starts.
- [ ] `docker buildx imagetools inspect statewavedev/statewave:latest` shows both `linux/amd64` and `linux/arm64`.
- [ ] Provenance attestation visible at `https://hub.docker.com/r/statewavedev/statewave/tags`.
- [ ] Tag `v0.7.1` (next release) and verify semver tags publish.

Refs: #40