### PR TITLE
ci(docker): auto-sync DOCKER.md to Docker Hub repo description

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -101,3 +101,16 @@ jobs:
           subject-name: ghcr.io/smaramwbc/statewave
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      # Sync DOCKER.md to the Docker Hub repo description on every default-branch
+      # build. Idempotent — re-running with unchanged content is a no-op. Only
+      # runs on push events so workflow_dispatch / tag builds don't churn it.
+      - name: Update Docker Hub description
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: statewavedev/statewave
+          short-description: "Memory + intelligence stack for AI agents"
+          readme-filepath: ./DOCKER.md

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,77 @@
+# Statewave server
+
+Memory + intelligence stack for AI agents — episodes in, distilled memories out.
+
+[![Image](https://img.shields.io/docker/image-size/statewavedev/statewave/latest?label=image)](https://hub.docker.com/r/statewavedev/statewave)
+[![Pulls](https://img.shields.io/docker/pulls/statewavedev/statewave)](https://hub.docker.com/r/statewavedev/statewave)
+[![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](https://github.com/smaramwbc/statewave/blob/main/LICENSE)
+
+Multi-arch (`linux/amd64`, `linux/arm64`), built with provenance + SBOM and signed via Sigstore.
+
+## Quickstart with Docker Compose
+
+```yaml
+services:
+  db:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: statewave
+      POSTGRES_PASSWORD: statewave
+      POSTGRES_DB: statewave
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U statewave"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  api:
+    image: statewavedev/statewave:latest
+    ports: ["8100:8100"]
+    environment:
+      STATEWAVE_DATABASE_URL: postgresql+asyncpg://statewave:statewave@db:5432/statewave
+      # LLM provider — pick one and set the matching key.
+      STATEWAVE_LITELLM_API_KEY: sk-...
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  pgdata:
+```
+
+```sh
+docker compose up -d
+curl http://localhost:8100/healthz
+```
+
+## Pin a version
+
+```sh
+STATEWAVE_VERSION=0.7.0 docker compose up -d
+```
+
+## Tags
+
+| Tag | Meaning |
+|---|---|
+| `latest` | Tip of `main` |
+| `X.Y.Z` | Semver release |
+| `X.Y` | Latest in the minor line |
+| `X` | Latest in the major line |
+| `sha-<7>` | Specific commit |
+
+## Verify the build attestation
+
+```sh
+gh attestation verify \
+  oci://docker.io/statewavedev/statewave:latest \
+  --owner smaramwbc
+```
+
+## Source & docs
+
+- Repository: <https://github.com/smaramwbc/statewave>
+- Documentation: <https://statewave.ai>
+- License: AGPL-3.0


### PR DESCRIPTION
## Summary

- New `DOCKER.md` in repo root — Docker-Hub-focused quickstart (compose snippet, env vars, tag table, attestation verify command).
- `docker-publish.yml` gains a `peter-evans/dockerhub-description@v4` step that runs after the image push and syncs `DOCKER.md` to the page at <https://hub.docker.com/r/statewavedev/statewave>.

Idempotent: runs only on push events to `main`, no-ops when content hasn't changed.

## Test plan

- [ ] After merge, Docker Hub repo page shows the rendered DOCKER.md content
- [ ] Short description on the listing page reads "Memory + intelligence stack for AI agents"
- [ ] Subsequent edits to DOCKER.md propagate on the next push to main

Refs: #40