### PR TITLE
ci(docker): tolerate Docker Hub description sync failure

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,10 +103,14 @@ jobs:
           push-to-registry: true
 
       # Sync DOCKER.md to the Docker Hub repo description on every default-branch
-      # build. Idempotent — re-running with unchanged content is a no-op. Only
-      # runs on push events so workflow_dispatch / tag builds don't churn it.
+      # build. Tolerates failure (continue-on-error) — newer-style Docker Hub
+      # PATs only authorize image push, not repo metadata writes, so this step
+      # 403s unless DOCKERHUB_TOKEN is replaced with an Organization Access
+      # Token with `Repo Admin` scope. The image publish above must not be
+      # gated on the description sync succeeding.
       - name: Update Docker Hub description
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary

The dockerhub-description step on the docker-publish workflow returns 403 Forbidden — `access denied: insufficient scope`. Newer Docker Hub PATs split image-push and repository-metadata writes into separate scopes, and our token only has the former. The image publish itself works.

`continue-on-error: true` on that step so a failed description sync no longer marks the whole run red. The next image push goes back to a clean ✓.

## How to actually populate Docker Hub descriptions

Three options, in order of stickiness:

1. **Generate a Docker Hub Organization Access Token** for `statewavedev` with `Repo Admin` scope, replace the `DOCKERHUB_TOKEN` secret in this repo, re-run the workflow. Auto-sync resumes for every push to the default branch.
2. **One-time local sync via account password** — a small curl script reads DOCKER.md and PATCHes Docker Hub. Password stays on the local machine.
3. **Paste DOCKER.md content into the Docker Hub web UI** for each repo. Static, manual updates from then on.

## Test plan

- [ ] After merge, the next push to default branch shows the image publish as ✓ even with the description-sync step failing.

Refs: smaramwbc/statewave#40