### PR TITLE
feat(docs-pack): include connectors/*.md in support-pack manifest

### DIFF
--- a/scripts/docs_loader.py
+++ b/scripts/docs_loader.py
@@ -43,6 +43,18 @@ MANIFEST: tuple[str, ...] = (
     "deployment/troubleshooting.md",
     "deployment/migrations.md",
     "dev/backup-restore.md",
+    # Connectors section — added 2026-05-08. The chat widget needs to be
+    # able to answer "what connectors are available" / "how do I sync
+    # Slack into Statewave" with first-party content, not LLM hallucination.
+    "connectors/index.md",
+    "connectors/quickstart.md",
+    "connectors/concepts.md",
+    "connectors/subject-strategy.md",
+    "connectors/privacy-redaction.md",
+    "connectors/mcp.md",
+    "connectors/github.md",
+    "connectors/markdown.md",
+    "connectors/roadmap.md",
 )
 
 SUBJECT_ID = "statewave-support-docs"


### PR DESCRIPTION
## Summary

Extends `scripts/docs_loader.py` MANIFEST with nine `connectors/*.md` files so the chat widget on www.statewave.ai can ground on first-party connector documentation instead of hallucinating package names or refusing with the GitHub-issues fallback.

## Why this matters

Before this PR, asking the live widget "what connectors does Statewave have?" returned things like:

> The documentation does not specify any available connectors for Statewave. For more detailed inquiries about specific connectors or integrations, please visit https://github.com/smaramwbc/statewave/issues.

After (verified on statewave-api.fly.dev with the extended manifest):

> Statewave offers a convenience meta-package called `@statewavedev/connectors`, which includes various connectors designed to feed real-world events into Statewave… `@statewavedev/connectors-n8n` handles workflow executions, failures, and errors via the n8n REST API…

## Pack size

| | Before | After |
|---|---|---|
| Episodes | 276 | 371 |
| Memories (LLM-compiled) | 439 | 529 |

Manageable bump; compile cost scales linearly.

## Files added to MANIFEST

```
connectors/index.md
connectors/quickstart.md
connectors/concepts.md
connectors/subject-strategy.md
connectors/privacy-redaction.md
connectors/mcp.md
connectors/github.md
connectors/markdown.md
connectors/roadmap.md
```

## Test plan

- [x] Local refresh against statewave-api.fly.dev — verified assembled_context contains Slack/n8n/Zapier
- [x] Prod widget probe — widget answers connector questions with first-party content
- [x] After merge + image republish: confirm a fresh `docker compose up` auto-bootstrap on a clean install lands the same 371 ep / 529 mem on the local DB

Refs: smaramwbc/statewave#40