### PR TITLE
feat(compose): add admin service to default compose stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,5 +52,29 @@ services:
       db:
         condition: service_healthy
 
+  admin:
+    # Statewave admin console — operator UI for browsing subjects, episodes,
+    # memories, starter packs. `docker compose up -d` brings it up alongside
+    # the API; reach it at http://localhost:8080.
+    #
+    # Optional: a contributor who doesn't want the admin running locally can
+    # start just the core stack with `docker compose up -d api db`.
+    image: statewavedev/statewave-admin:${STATEWAVE_ADMIN_VERSION:-latest}
+    ports:
+      - "8080:8080"
+    environment:
+      # Talks to the api over the compose network — both containers see each
+      # other by service name. The browser hits the admin's own server, which
+      # proxies API calls server-side, so this URL never leaves the compose
+      # network.
+      STATEWAVE_API_URL: http://api:8100
+      # Local dev placeholder — the api runs in STATEWAVE_DEBUG=true and
+      # accepts any X-API-Key value. Replace with a real key in production.
+      STATEWAVE_API_KEY: dev-local-placeholder
+      NODE_ENV: production
+    depends_on:
+      api:
+        condition: service_started
+
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Adds `statewave-admin` as a third service in `docker-compose.yml`, pulled from Docker Hub:

| Service | Image | Port |
|---|---|---|
| `api` | `statewavedev/statewave:latest` | 8100 |
| `admin` | `statewavedev/statewave-admin:latest` (new) | 8080 |
| `db` | `pgvector/pgvector:pg16` | 5432 |

A fresh `docker compose up -d` brings up the full stack — server, admin operator console, and Postgres — with no extra steps. The admin proxies API calls server-side over the compose network (`STATEWAVE_API_URL=http://api:8100`), so the browser never has to reach `localhost:8100` directly.

`STATEWAVE_API_KEY` is set to a dev placeholder (`dev-local-placeholder`) because the api runs with `STATEWAVE_DEBUG=true` locally and accepts any X-API-Key value. Production deployments should override this.

## Opt-out

Contributors who don't want admin running locally can start just the core stack:

```sh
docker compose up -d api db
```

## Verified locally

- `docker compose up -d` brings all three services up cleanly
- `curl http://localhost:8080` → HTTP 200 (admin SPA)
- `curl http://localhost:8100/healthz` → `{"status":"ok"}`
- Admin UI loads in browser, can list subjects on the api

Refs: smaramwbc/statewave#40