### PR TITLE
fix(compose): ship ADMIN_AUTH_DISABLED=true as a dev default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,21 @@ services:
       # accepts any X-API-Key value. Replace with a real key in production.
       STATEWAVE_API_KEY: dev-local-placeholder
       NODE_ENV: production
+      # Operator-console auth. The admin requires either a configured password
+      # OR an explicit auth-disabled flag. We default to disabled here for the
+      # same reason the api defaults to STATEWAVE_DEBUG=true: a fresh
+      # `docker compose up -d` should work without you having to invent a
+      # password first.
+      #
+      # Production: override by setting ADMIN_AUTH_DISABLED= (empty) AND
+      # supplying ADMIN_PASSWORD + ADMIN_SESSION_SECRET via your env or .env
+      # file. The two operator-console-side variables flow through unchanged
+      # — there is no fallback if both are absent and ADMIN_AUTH_DISABLED is
+      # also empty, which is what surfaces the "Admin is not configured"
+      # screen.
+      ADMIN_AUTH_DISABLED: ${ADMIN_AUTH_DISABLED:-true}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
+      ADMIN_SESSION_SECRET: ${ADMIN_SESSION_SECRET:-}
     depends_on:
       api:
         condition: service_started


### PR DESCRIPTION
## Summary

PR #45 added the admin service to the compose stack but didn't pass `ADMIN_PASSWORD` / `ADMIN_SESSION_SECRET`, so the operator console rendered:

> Admin is not configured. Set ADMIN_PASSWORD and ADMIN_SESSION_SECRET.

…and refused to sign in.

This PR mirrors the existing `STATEWAVE_DEBUG=true` default by shipping `ADMIN_AUTH_DISABLED=true` as the compose default. A fresh `docker compose up -d` works end-to-end without you having to invent a password first.

## Production override

Set `ADMIN_AUTH_DISABLED=` (empty) **and** supply both `ADMIN_PASSWORD` + `ADMIN_SESSION_SECRET` in your `.env` or shell env. The compose uses `${VAR:-}` substitution so they flow from the host environment unchanged.

## Verified locally

- `docker compose up -d --force-recreate admin` — clean start
- `curl http://localhost:8080` → HTTP 200, title `Statewave Admin`, no "Admin is not configured" string in the response
- Admin UI loads without the auth blocker

Refs: smaramwbc/statewave#40