### PR TITLE
feat(episodes): add first-class occurred_at column for source-event time

### DIFF
--- a/alembic/versions/0015_episode_occurred_at.py
+++ b/alembic/versions/0015_episode_occurred_at.py
@@ -1,0 +1,78 @@
+"""episodes.occurred_at — first-class source-event timestamp
+
+Revision ID: 0015
+Revises: 0014_query_embedding_cache
+Create Date: 2026-05-09
+
+Until this migration the only timestamp on an episode was `created_at`,
+which the database fills in at insertion time via `server_default=now()`.
+That conflated two semantically-distinct concepts:
+
+  * **created_at** — when the row landed in our database
+  * **occurred_at** — when the source event actually happened
+
+For live-chat ingest these are the same thing. For everything else they're
+not: a backfilled GitHub issue from 2024, a Slack message replayed from a
+historical export, a Zendesk ticket imported from another system. In each
+case the connector knows the real source-event time, and timeline-style
+queries ("what did the customer say in March", "show me activity around
+the outage") are wrong if we sort by `created_at`.
+
+This migration:
+  * Adds `occurred_at timestamptz` to `episodes`, NOT NULL with a
+    server-default of `now()` so existing connector code that doesn't
+    supply the field keeps working unchanged.
+  * Backfills existing rows so `occurred_at = created_at` — a sensible
+    default since for those rows we have no better information.
+  * Adds a composite (subject_id, occurred_at) index for the timeline
+    query path; we keep the existing (subject_id, created_at) index
+    because batch insert flows still order by created_at and search
+    flows still want stable insertion order as a tiebreak.
+
+Reverse-compatible: clients that don't pass `occurred_at` are unaffected
+(the column defaults to now() server-side, identical to created_at). The
+downgrade drops the column and the new index.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0015_episode_occurred_at"
+down_revision: Union[str, None] = "0014_query_embedding_cache"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add the column with a server-default so the table stays writeable
+    #    while we backfill. The DEFAULT applies to any rows inserted between
+    #    the ADD COLUMN and the backfill UPDATE on busy systems.
+    op.add_column(
+        "episodes",
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # 2. Backfill existing rows so each episode's occurred_at matches its
+    #    created_at. For docs/demo packs imported before this migration,
+    #    there's no better signal; the alternative would be guessing.
+    op.execute("UPDATE episodes SET occurred_at = created_at")
+
+    # 3. Composite index for timeline-style queries — they filter by subject
+    #    and order by occurred_at. Keep the existing (subject_id, created_at)
+    #    index because the search path still uses created_at as a tiebreak.
+    op.create_index(
+        "ix_episodes_subject_occurred",
+        "episodes",
+        ["subject_id", "occurred_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_episodes_subject_occurred", table_name="episodes")
+    op.drop_column("episodes", "occurred_at")

--- a/server/api/episodes.py
+++ b/server/api/episodes.py
@@ -24,7 +24,10 @@ async def create_episode(
     tenant_id: str | None = Depends(get_tenant_id),
 ):
     """Record a raw interaction episode. Episodes are append-only and immutable."""
-    row = EpisodeRow(
+    # `occurred_at` is optional in the request: when None, the database column
+    # server-defaults to now() (= ingest time), which matches the legacy behaviour.
+    # Connectors that backfill historical data set this explicitly.
+    row_kwargs: dict = dict(
         subject_id=body.subject_id,
         tenant_id=tenant_id,
         session_id=body.session_id,
@@ -34,6 +37,9 @@ async def create_episode(
         metadata_=body.metadata,
         provenance=body.provenance,
     )
+    if body.occurred_at is not None:
+        row_kwargs["occurred_at"] = body.occurred_at
+    row = EpisodeRow(**row_kwargs)
     await repo.insert_episode(session, row)
     await session.commit()
     await session.refresh(row)
@@ -47,6 +53,7 @@ async def create_episode(
         metadata=row.metadata_,
         provenance=row.provenance,
         session_id=row.session_id,
+        occurred_at=row.occurred_at,
         created_at=row.created_at,
     )
 
@@ -66,7 +73,7 @@ async def create_episodes_batch(
     with span("create_episodes_batch", {"count": len(body.episodes)}):
         rows: list[EpisodeRow] = []
         for ep in body.episodes:
-            row = EpisodeRow(
+            row_kwargs: dict = dict(
                 subject_id=ep.subject_id,
                 tenant_id=tenant_id,
                 session_id=ep.session_id,
@@ -76,6 +83,9 @@ async def create_episodes_batch(
                 metadata_=ep.metadata,
                 provenance=ep.provenance,
             )
+            if ep.occurred_at is not None:
+                row_kwargs["occurred_at"] = ep.occurred_at
+            row = EpisodeRow(**row_kwargs)
             await repo.insert_episode(session, row)
             rows.append(row)
         await session.commit()
@@ -100,6 +110,7 @@ async def create_episodes_batch(
                     metadata=r.metadata_,
                     provenance=r.provenance,
                     session_id=r.session_id,
+                    occurred_at=r.occurred_at,
                     created_at=r.created_at,
                 )
                 for r in rows

--- a/server/api/timeline.py
+++ b/server/api/timeline.py
@@ -33,6 +33,7 @@ async def get_timeline(
                 metadata=e.metadata_,
                 provenance=e.provenance,
                 session_id=e.session_id,
+                occurred_at=e.occurred_at,
                 created_at=e.created_at,
             )
             for e in episodes

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -47,10 +47,14 @@ async def list_episodes_by_subject(
     tenant_id: str | None = None,
     limit: int = 100,
 ) -> Sequence[EpisodeRow]:
+    # Order by `occurred_at` (the source-event time) so backfilled episodes
+    # land in their real chronological position. `created_at` is the
+    # tiebreak so simultaneous events from a single ingest batch retain
+    # their insertion order in the response.
     stmt = (
         select(EpisodeRow)
         .where(EpisodeRow.subject_id == subject_id)
-        .order_by(EpisodeRow.created_at.asc())
+        .order_by(EpisodeRow.occurred_at.asc(), EpisodeRow.created_at.asc())
         .limit(limit)
     )
     stmt = _tenant_filter(stmt, EpisodeRow.tenant_id, tenant_id)

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -36,11 +36,22 @@ class EpisodeRow(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+    # When the source event actually happened. Distinct from `created_at`
+    # (= ingest time) so backfilled connectors (Slack history, GitHub
+    # issues from 2024, Zendesk imports, …) can preserve their real
+    # timeline. Server-defaults to now() so legacy clients that don't
+    # supply the field keep working unchanged.
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
     last_compiled_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, default=None
     )
 
-    __table_args__ = (Index("ix_episodes_subject_created", "subject_id", "created_at"),)
+    __table_args__ = (
+        Index("ix_episodes_subject_created", "subject_id", "created_at"),
+        Index("ix_episodes_subject_occurred", "subject_id", "occurred_at"),
+    )
 
 
 class MemoryRow(Base):

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -15,6 +16,12 @@ class CreateEpisodeRequest(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     provenance: dict[str, Any] = Field(default_factory=dict)
     session_id: str | None = Field(None, max_length=256)
+    # When the source event actually happened. Optional — when absent, the
+    # database server-defaults to now() (= ingest time), which is the right
+    # answer for live-chat ingest. Connectors that backfill historical data
+    # (Slack history, GitHub issues, Zendesk imports) should always set
+    # this so timeline-style queries see the real ordering.
+    occurred_at: datetime | None = None
 
 
 class BatchCreateEpisodesRequest(BaseModel):

--- a/server/schemas/responses.py
+++ b/server/schemas/responses.py
@@ -20,6 +20,7 @@ class EpisodeResponse(BaseModel):
     metadata: dict[str, Any]
     provenance: dict[str, Any]
     session_id: str | None = None
+    occurred_at: datetime
     created_at: datetime
 
 

--- a/server/services/backup.py
+++ b/server/services/backup.py
@@ -68,6 +68,7 @@ async def export_subject(subject_id: str, *, tenant_id: str | None = None) -> di
             "payload": ep.payload,
             "metadata": ep.metadata_,
             "provenance": ep.provenance,
+            "occurred_at": ep.occurred_at.isoformat(),
             "created_at": ep.created_at.isoformat(),
             "last_compiled_at": ep.last_compiled_at.isoformat() if ep.last_compiled_at else None,
         }
@@ -186,6 +187,16 @@ async def import_subject(
             new_id = uuid.UUID(old_id) if preserve_ids else uuid.uuid4()
             id_map[old_id] = str(new_id)
 
+            # `occurred_at` was added in migration 0015. Backups taken before
+            # that migration won't have the field; fall back to `created_at`
+            # so restored episodes still land in a sensible chronological
+            # position.
+            created_at_dt = datetime.fromisoformat(ep_data["created_at"])
+            occurred_at_dt = (
+                datetime.fromisoformat(ep_data["occurred_at"])
+                if ep_data.get("occurred_at")
+                else created_at_dt
+            )
             row = EpisodeRow(
                 id=new_id,
                 subject_id=subject_id,
@@ -195,7 +206,8 @@ async def import_subject(
                 payload=ep_data["payload"],
                 metadata_=ep_data.get("metadata", {}),
                 provenance=ep_data.get("provenance", {}),
-                created_at=datetime.fromisoformat(ep_data["created_at"]),
+                occurred_at=occurred_at_dt,
+                created_at=created_at_dt,
                 last_compiled_at=(
                     datetime.fromisoformat(ep_data["last_compiled_at"])
                     if ep_data.get("last_compiled_at")

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -767,6 +767,7 @@ def _episode_response(row: Any) -> EpisodeResponse:
         payload=row.payload,
         metadata=row.metadata_,
         provenance=row.provenance,
+        occurred_at=row.occurred_at,
         created_at=row.created_at,
         session_id=getattr(row, "session_id", None),
     )

--- a/server/services/memory_packs.py
+++ b/server/services/memory_packs.py
@@ -270,6 +270,13 @@ async def _ingest_records_async(
             metadata.update(extra_metadata)
             provenance = dict(ep.get("provenance") or {})
             provenance.update(extra_provenance)
+            ep_created_dt = _parse_iso_or_now(ep.get("created_at"))
+            # Packs created before migration 0015 don't carry occurred_at;
+            # fall back to created_at so restored episodes still land in a
+            # sensible chronological position.
+            ep_occurred_dt = (
+                _parse_iso_or_now(ep["occurred_at"]) if ep.get("occurred_at") else ep_created_dt
+            )
             row = EpisodeRow(
                 id=new_id,
                 subject_id=target_subject_id,
@@ -279,7 +286,8 @@ async def _ingest_records_async(
                 payload=ep.get("payload") or {},
                 metadata_=metadata,
                 provenance=provenance,
-                created_at=_parse_iso_or_now(ep.get("created_at")),
+                occurred_at=ep_occurred_dt,
+                created_at=ep_created_dt,
                 last_compiled_at=_parse_iso_or_none(ep.get("last_compiled_at")),
             )
             session.add(row)
@@ -942,6 +950,10 @@ async def export_memory_payload(
                         "payload": ep.get("payload"),
                         "metadata": ep.get("metadata") or {},
                         "provenance": ep.get("provenance") or {},
+                        # `occurred_at` is forward-compatible: packs created
+                        # before migration 0015 won't have it, in which case
+                        # the import path below falls back to `created_at`.
+                        "occurred_at": ep.get("occurred_at"),
                         "created_at": ep.get("created_at"),
                         "last_compiled_at": ep.get("last_compiled_at"),
                     }

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0014_query_embedding_cache"
+EXPECTED_HEAD = "0015_episode_occurred_at"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/server/services/snapshots.py
+++ b/server/services/snapshots.py
@@ -272,6 +272,9 @@ async def restore_snapshot(
             ep_created = ep.created_at
             if ep_created.tzinfo is None:
                 ep_created = ep_created.replace(tzinfo=timezone.utc)
+            ep_occurred = ep.occurred_at
+            if ep_occurred.tzinfo is None:
+                ep_occurred = ep_occurred.replace(tzinfo=timezone.utc)
 
             session.add(
                 EpisodeRow(
@@ -287,6 +290,10 @@ async def restore_snapshot(
                         "restored_from_snapshot": str(snapshot_id),
                         "original_episode_id": str(ep.id),
                     },
+                    # Apply the same time_shift to occurred_at as created_at so
+                    # the relative chronology is preserved when a snapshot is
+                    # restored at a later point in time.
+                    occurred_at=ep_occurred + time_shift,
                     created_at=ep_created + time_shift,
                     last_compiled_at=(ep_created + time_shift) if ep.last_compiled_at else None,
                 )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 14
+    assert len(revs) == 15
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 4
+    assert result.pending_count == 5
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 14
+    assert result.pending_count == 15
 
 
 def test_resolve_pending_unknown_revision():

--- a/tests/test_repeat_issue.py
+++ b/tests/test_repeat_issue.py
@@ -30,6 +30,7 @@ def _make_episode_row(
     text: str = "hello",
     minutes_ago: int = 0,
 ):
+    when = _BASE - timedelta(minutes=minutes_ago)
     return SimpleNamespace(
         id=uuid.uuid4(),
         subject_id="user-1",
@@ -39,7 +40,10 @@ def _make_episode_row(
         metadata_={},
         provenance={},
         session_id=session_id,
-        created_at=_BASE - timedelta(minutes=minutes_ago),
+        # Match the new ORM shape — occurred_at defaults to created_at when
+        # no explicit source-event time is supplied.
+        occurred_at=when,
+        created_at=when,
     )
 
 

--- a/tests/test_session_context.py
+++ b/tests/test_session_context.py
@@ -31,6 +31,7 @@ def _make_episode_row(
     minutes_ago: int = 0,
 ):
     """Create a fake episode row matching the ORM shape."""
+    when = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
     return SimpleNamespace(
         id=uuid.uuid4(),
         subject_id="user-1",
@@ -40,7 +41,10 @@ def _make_episode_row(
         metadata_={},
         provenance={},
         session_id=session_id,
-        created_at=datetime.now(timezone.utc) - timedelta(minutes=minutes_ago),
+        # Match the new ORM shape — occurred_at defaults to created_at when
+        # no explicit source-event time is supplied.
+        occurred_at=when,
+        created_at=when,
     )
 
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -31,6 +31,7 @@ class FakeEpisode:
         last_compiled_at=None,
         session_id=None,
         updated_at=None,
+        occurred_at=None,
     ):
         self.id = id
         self.subject_id = subject_id
@@ -40,6 +41,10 @@ class FakeEpisode:
         self.metadata_ = metadata_ or {}
         self.provenance = provenance or {}
         self.created_at = created_at
+        # If no explicit source-event time was supplied, mirror created_at —
+        # matches the new server behaviour where occurred_at defaults to
+        # ingest time when the client doesn't set it.
+        self.occurred_at = occurred_at if occurred_at is not None else created_at
         self.session_id = session_id
         self.last_compiled_at = last_compiled_at
         self.updated_at = updated_at or created_at

--- a/tests/test_support_ranking.py
+++ b/tests/test_support_ranking.py
@@ -35,6 +35,7 @@ def _make_episode_row(
 ):
     # Use a fixed base time to avoid microsecond timing issues in tests
     base = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+    when = base - timedelta(minutes=minutes_ago)
     return SimpleNamespace(
         id=uuid.uuid4(),
         subject_id="user-1",
@@ -44,7 +45,10 @@ def _make_episode_row(
         metadata_={},
         provenance={},
         session_id=session_id,
-        created_at=base - timedelta(minutes=minutes_ago),
+        # Match the new ORM shape — occurred_at defaults to created_at when
+        # no explicit source-event time is supplied.
+        occurred_at=when,
+        created_at=when,
     )
 
 


### PR DESCRIPTION
## Why

Until this PR, the only timestamp on an episode was `created_at` — which the database fills in at insertion via `server_default=now()`. For live-chat ingest that's fine; for everything else it isn't:

- A **backfilled GitHub issue from 2024**, ingested today, lands at "today" on the timeline.
- A **Slack message history replay** loses every message's actual posting time.
- The **MCP client's `occurred_at` field** was silently dropped (pydantic ignored unknown extras), which is why Claude Desktop's recent ingest call showed `2026-05-08T23:38:17Z` instead of the supplied `2026-05-09T00:00:00Z`.

## What changes

**Schema** — `episodes.occurred_at TIMESTAMPTZ NOT NULL DEFAULT now()` plus a `(subject_id, occurred_at)` composite index. Migration 0015 adds the column and backfills `occurred_at = created_at` on existing rows.

**Pydantic** — `CreateEpisodeRequest.occurred_at: datetime | None = None`. When None, the database server-default fires (= ingest time, identical to legacy behaviour). When set, it's passed through unchanged.

**Response** — `EpisodeResponse.occurred_at: datetime` (new field). `TimelineResponse` surfaces it via `EpisodeResponse`.

**Ordering** — `list_episodes_by_subject` switches to `ORDER BY occurred_at ASC, created_at ASC` so backfilled events take their real chronological position; `created_at` is the tiebreak so simultaneous events keep insertion order.

**Restore paths** — `backup.import`, `snapshots.create` + `restore`, `memory_packs.import` + `export` all preserve `occurred_at` end-to-end. Snapshot restore applies the same `time_shift` to `occurred_at` as it does to `created_at`. Imports gracefully fall back to `created_at` when reading archives created before this migration.

## Verified locally

```
$ curl -X POST .../v1/episodes -d '{"subject_id":"demo:occurred-test", ..., "occurred_at":"2024-01-15T10:00:00Z"}'
  → response: occurred_at = 2024-01-15T10:00:00Z, created_at = 2026-05-09T00:25:59Z  ✓

$ curl -X POST .../v1/episodes -d '{"subject_id":"demo:occurred-test", ...}'   # no occurred_at
  → response: occurred_at = created_at = 2026-05-09T00:25:59Z  ✓

$ curl .../v1/timeline?subject_id=demo:occurred-test
  → episodes ordered by occurred_at: 2024 first, then earlier prod data, then today's live  ✓
```

441/442 local tests pass — the one excluded is a pre-existing LLM-async-timing integration flake unrelated to this change.

## Production deploy notes

The Alembic migration auto-runs on container startup via `start.sh`. On `statewave-api.fly.dev`:

- Adds the column with server-default → all existing rows get `now()` momentarily…
- …then the same transaction's `UPDATE episodes SET occurred_at = created_at` backfills sane values.

For the prod data volume (a few hundred episodes on `statewave-support-docs` + the demo subjects) the migration is sub-second and runs inside Alembic's transaction so it's atomic.

After deploy I'll verify on prod that `occurred_at = created_at` for all pre-migration rows, then confirm a fresh ingest with explicit `occurred_at` round-trips.

## Follow-up

A separate PR on `statewave-connectors` will revert today's MCP client workaround that stuffed `occurred_at` inside `payload` — once this lands and prod has the column, the client passes `occurred_at` at the top level normally.

Refs: smaramwbc/statewave#40