### PR TITLE
fix(context): lexical-overlap bonus so semantic+keyword matches clear kind/recency floor

### DIFF
--- a/server/services/context.py
+++ b/server/services/context.py
@@ -56,6 +56,16 @@ _RESOLVED_SESSION_PENALTY = -5.0  # Penalty for episodes in already-resolved ses
 _BREADCRUMB_MAX = 3.0  # Bonus for memories whose source-doc heading/breadcrumb
 # matches the query (docs-grounded subjects only — see _breadcrumb_overlap_bonus).
 # Capped well below KIND_PRIORITY (5–10) and SEMANTIC_MAX (8) so it nudges, not dominates.
+_LEXICAL_BONUS_MAX = 4.0  # Additive bonus when query terms appear verbatim in
+# memory content, applied on top of the semantic score. Without this, a narrow
+# factual query like "how do I install with npm" can match the right procedure
+# at semantic rank 1 yet sit at /v1/context rank ~127 because cosine spread for
+# the candidate pool is ~3 points while KIND_PRIORITY (procedure 8 vs
+# profile_fact 10) plus full recency (5) easily exceeds that spread. The
+# lexical bonus contributes the missing tiebreaker: when both semantic AND
+# literal keyword evidence agree, the memory clears the kind/recency noise
+# floor. Capped at 4.0 so it can't override a clearly dominant kind signal —
+# only break ties between similarly-ranked candidates.
 
 # Support-agent-specific scoring signals
 _OPEN_ISSUE_BOOST = 4.0  # Bonus for episodes in sessions with open/unresolved issues
@@ -273,11 +283,19 @@ async def assemble_context(
     if all_memory_rows:
         ts_range = _timestamp_range([r.created_at for r in all_memory_rows])
         for row in all_memory_rows:
-            # Use semantic score when available, else word-overlap
+            # Use semantic score when available, else word-overlap. When
+            # semantic is in play, also add a lexical-overlap bonus so a
+            # memory that BOTH embeds close to the query AND literally
+            # contains the query keywords clears the kind/recency noise
+            # floor. The fallback word-overlap path already factors in
+            # literal matches, so the lexical bonus is only applied on
+            # top of the semantic path to avoid double-counting.
             if use_semantic and row.id in semantic_scores:
                 relevance = semantic_scores[row.id]
+                lexical_bonus = _lexical_overlap_bonus(row.content, task_tokens)
             else:
                 relevance = _relevance_score(row.content, task_tokens)
+                lexical_bonus = 0.0
 
             breadcrumb_bonus = _breadcrumb_overlap_bonus(
                 memory_breadcrumbs.get(row.id, []),
@@ -288,6 +306,7 @@ async def assemble_context(
                 _KIND_PRIORITY.get(row.kind, 1.0)
                 + _recency_score(row.created_at, ts_range)
                 + relevance
+                + lexical_bonus
                 + _temporal_score(row.valid_from, row.valid_to)
                 + breadcrumb_bonus
             )
@@ -560,9 +579,22 @@ def _session_keyword_overlap(current_keywords: set[str], prior_keywords: set[str
     return overlap / len(current_keywords)
 
 
+_RELEVANCE_PUNCT = "?.,:;()[]{}'\"!"
+
+
 def _tokenize_for_relevance(text: str) -> set[str]:
-    """Lowercase word tokens for relevance scoring."""
-    return set(text.lower().split())
+    """Lowercase word tokens for relevance scoring, with surrounding
+    punctuation stripped. Without stripping, content fragments like
+    `'npm install'` (literal quotes from a markdown code-snippet docs
+    pack) tokenize as `'npm` and won't intersect a query token of `npm`,
+    silently zeroing the lexical signal."""
+    if not text:
+        return set()
+    return {
+        stripped
+        for stripped in (t.strip(_RELEVANCE_PUNCT) for t in text.lower().split())
+        if stripped
+    }
 
 
 def _has_urgency(text: str) -> bool:
@@ -575,11 +607,35 @@ def _relevance_score(content: str, task_tokens: set[str]) -> float:
     """Word-overlap relevance: 0 to _RELEVANCE_MAX."""
     if not task_tokens or not content:
         return 0.0
-    content_tokens = set(content.lower().split())
+    content_tokens = _tokenize_for_relevance(content)
     overlap = len(task_tokens & content_tokens)
     # Normalize by task token count
     ratio = overlap / len(task_tokens)
     return min(ratio * _RELEVANCE_MAX, _RELEVANCE_MAX)
+
+
+def _lexical_overlap_bonus(content: str, task_tokens: set[str]) -> float:
+    """Additive bonus when query terms appear verbatim in memory content.
+
+    Applied on top of the semantic score. Stopwords ("how", "do", "the",
+    "with", ...) are excluded so trivial overlap on connectives can't
+    inflate the bonus — only meaningful keyword agreement counts.
+
+    Normalizes by the count of meaningful task tokens, so a 2/2 hit on a
+    short query like "install npm" scores the same as a 4/4 hit on a
+    longer one. Capped at _LEXICAL_BONUS_MAX.
+    """
+    if not task_tokens or not content:
+        return 0.0
+    meaningful = {t for t in task_tokens if t and t not in _STOPWORDS}
+    if not meaningful:
+        return 0.0
+    content_tokens = _tokenize_for_relevance(content)
+    overlap = len(meaningful & content_tokens)
+    if overlap == 0:
+        return 0.0
+    ratio = overlap / len(meaningful)
+    return min(ratio * _LEXICAL_BONUS_MAX, _LEXICAL_BONUS_MAX)
 
 
 # Generic words that drag breadcrumb overlap toward noise without informing

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,15 +1,25 @@
 """Tests for context assembly — ranking and token budget enforcement."""
 
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
 from server.services.context import (
     _BREADCRUMB_MAX,
+    _LEXICAL_BONUS_MAX,
     _breadcrumb_overlap_bonus,
+    _lexical_overlap_bonus,
     _relevance_score,
     _recency_score,
     _temporal_score,
     _tokenize_for_relevance,
     _timestamp_range,
+    assemble_context,
 )
-from datetime import datetime, timezone, timedelta
 
 
 # ---------------------------------------------------------------------------
@@ -199,3 +209,313 @@ def test_breadcrumb_bonus_skips_empty_breadcrumb_strings():
     # Empty / blank entries shouldn't crash or raise the score
     score = _breadcrumb_overlap_bonus(["", "Compiler Modes"], task_tokens)
     assert score > 0
+
+
+# ---------------------------------------------------------------------------
+# Tokenization punctuation handling
+# ---------------------------------------------------------------------------
+#
+# Pinned because the docs pack stores code snippets with surrounding quotes
+# (e.g. `'npm install statewave-ts'`). Without punctuation stripping, the
+# query token "npm" wouldn't match "'npm" and the lexical signal silently
+# zeroes — the original failure mode behind issue #27.
+
+
+def test_tokenize_strips_surrounding_quotes_and_punctuation():
+    tokens = _tokenize_for_relevance("Use 'npm install statewave-ts' for TypeScript.")
+    assert "npm" in tokens
+    assert "install" in tokens
+    assert "typescript" in tokens
+
+
+def test_tokenize_strips_question_marks():
+    tokens = _tokenize_for_relevance("Do I need a GPU?")
+    assert "gpu" in tokens
+
+
+def test_relevance_matches_quoted_keywords():
+    """`_relevance_score` should now match keywords that appear inside
+    quotes in the content (regression test for issue #27)."""
+    task_tokens = _tokenize_for_relevance("install with npm")
+    score = _relevance_score(
+        "To install Statewave, use 'npm install statewave-ts' for TypeScript.",
+        task_tokens,
+    )
+    assert score > 0
+
+
+# ---------------------------------------------------------------------------
+# Lexical-overlap bonus (additive on top of semantic)
+# ---------------------------------------------------------------------------
+
+
+def test_lexical_bonus_zero_for_no_content_or_no_tokens():
+    assert _lexical_overlap_bonus("", _tokenize_for_relevance("install npm")) == 0.0
+    assert _lexical_overlap_bonus("install npm", set()) == 0.0
+
+
+def test_lexical_bonus_zero_when_only_stopwords_overlap():
+    """Trivial overlap on connectives ('how', 'do', 'with') must not
+    inflate the bonus — only meaningful keyword agreement counts."""
+    task_tokens = _tokenize_for_relevance("how do I install with npm")
+    # Content shares only the stopwords ("how", "do", "i", "with"); the
+    # meaningful keywords ("install", "npm") are absent.
+    score = _lexical_overlap_bonus(
+        "how do I configure the rate limiter with custom buckets", task_tokens
+    )
+    assert score == 0.0
+
+
+def test_lexical_bonus_zero_when_query_is_only_stopwords():
+    """A query made entirely of stopwords yields no meaningful tokens, so
+    no content can score a lexical bonus — even one that 'matches'."""
+    task_tokens = _tokenize_for_relevance("how do I get help with this")
+    score = _lexical_overlap_bonus("how do I get help with this", task_tokens)
+    assert score == 0.0
+
+
+def test_lexical_bonus_rewards_full_keyword_match():
+    task_tokens = _tokenize_for_relevance("how do I install with npm")
+    score = _lexical_overlap_bonus(
+        "To install Statewave, use 'npm install statewave-ts' for TypeScript.",
+        task_tokens,
+    )
+    assert score > 0
+    assert score <= _LEXICAL_BONUS_MAX
+
+
+def test_lexical_bonus_capped_at_max():
+    task_tokens = _tokenize_for_relevance("install npm")
+    score = _lexical_overlap_bonus(
+        "install install install npm npm npm", task_tokens
+    )
+    assert score <= _LEXICAL_BONUS_MAX
+
+
+def test_lexical_bonus_partial_keyword_match():
+    """Half the meaningful keywords should yield ~half the bonus."""
+    task_tokens = _tokenize_for_relevance("install npm typescript python")
+    full_score = _lexical_overlap_bonus(
+        "install npm typescript python", task_tokens
+    )
+    partial_score = _lexical_overlap_bonus(
+        "install npm java rust", task_tokens
+    )
+    assert partial_score > 0
+    assert partial_score < full_score
+
+
+# ---------------------------------------------------------------------------
+# Issue #27 — semantic+lexical match must not be buried by kind/recency
+# ---------------------------------------------------------------------------
+
+
+def _make_memory_row(
+    *,
+    kind: str,
+    content: str,
+    minutes_ago: int = 0,
+):
+    base = datetime(2026, 5, 5, 12, 0, 0, tzinfo=timezone.utc)
+    when = base - timedelta(minutes=minutes_ago)
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        subject_id="statewave-support-docs",
+        tenant_id=None,
+        kind=kind,
+        content=content,
+        summary=content[:80],
+        confidence=1.0,
+        valid_from=when,
+        valid_to=None,
+        source_episode_ids=[],
+        metadata_={},
+        status="active",
+        created_at=when,
+        updated_at=when,
+    )
+
+
+@contextmanager
+def _mock_semantic_repos(
+    *, fact_rows, procedure_rows, summary_rows, semantic_results
+):
+    """Mock the repo layer so assemble_context can run with a realistic
+    semantic-provider candidate pool. `semantic_results` is a list of
+    (row, cosine_distance) tuples."""
+
+    async def _search_memories(_session, _subject_id, *, tenant_id=None, kind=None, limit=None):
+        if kind == "profile_fact":
+            return fact_rows
+        if kind == "procedure":
+            return procedure_rows
+        if kind == "episode_summary":
+            return summary_rows
+        return []
+
+    fake_provider = SimpleNamespace(provides_semantic_similarity=True)
+
+    async def _embed_query(_session_factory, _provider, _task):
+        return [0.0] * 16  # shape doesn't matter — we mock the search
+
+    with (
+        patch(
+            "server.services.context.repo.search_memories",
+            new=AsyncMock(side_effect=_search_memories),
+        ),
+        patch(
+            "server.services.context.repo.list_episodes_by_subject",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "server.services.context.repo.search_memories_by_embedding",
+            new_callable=AsyncMock,
+            return_value=semantic_results,
+        ),
+        patch(
+            "server.services.context.get_embedding_provider",
+            return_value=fake_provider,
+        ),
+        patch(
+            "server.services.context.cached_embed_query",
+            new=AsyncMock(side_effect=_embed_query),
+        ),
+        patch(
+            "server.db.engine.get_session_factory",
+            return_value=lambda: None,
+        ),
+        patch(
+            "server.services.context.repo.get_episodes_by_ids",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_strong_semantic_plus_lexical_match_outranks_kind_priority():
+    """Issue #27 — a procedure with strong semantic+lexical match for a
+    narrow factual query must not be buried behind profile_facts that
+    only weakly match the query.
+
+    Mirrors the production reproducer:
+      - 30 profile_facts with newer created_at and unrelated content
+        (semantic sim ~0.4–0.5, no keyword overlap)
+      - 1 procedure with older created_at containing 'npm install
+        statewave-ts' (semantic sim ~0.9, full keyword overlap)
+
+    Without the lexical-overlap bonus, the procedure's score
+    (KIND_PRIORITY 8 + low recency + decent semantic) loses to the
+    profile_facts' (KIND_PRIORITY 10 + high recency + mediocre semantic)
+    and lands deep in the result list. With the bonus it surfaces at
+    the top of the procedures section.
+    """
+    npm_proc = _make_memory_row(
+        kind="procedure",
+        content=(
+            "To install Statewave, use 'pip install statewave-py' for Python "
+            "or 'npm install statewave-ts' for TypeScript."
+        ),
+        minutes_ago=600,  # OLDEST → recency_score = 0 for the procedure pool
+    )
+
+    # Other procedures: newer (max recency), unrelated content (no keyword
+    # overlap with the npm query). Without the lexical bonus these
+    # outrank the npm procedure on recency alone, even though pure
+    # semantic ranks the npm procedure first.
+    other_procs = [
+        _make_memory_row(
+            kind="procedure",
+            content=f"Configure rate limiter bucket {i} for sustained throughput.",
+            minutes_ago=i,
+        )
+        for i in range(4)
+    ]
+
+    facts = [
+        _make_memory_row(
+            kind="profile_fact",
+            content=f"Statewave supports feature flag {i} for advanced configuration.",
+            minutes_ago=i,
+        )
+        for i in range(20)
+    ]
+
+    # Semantic spread mirrors a real query: npm procedure at distance 0.1
+    # (sim 0.9 → 7.2 points), other procedures and facts at distances
+    # 0.5–0.85 (sim 0.5–0.15 → 4.0–1.2 points). The cosine-only spread
+    # is ~3 points, narrower than KIND_PRIORITY+recency variability —
+    # which is exactly why the lexical tiebreaker is needed.
+    semantic_results = [(npm_proc, 0.1)]
+    for i, p in enumerate(other_procs):
+        semantic_results.append((p, 0.5 + (i * 0.05)))
+    for i, f in enumerate(facts):
+        semantic_results.append((f, 0.55 + (i * 0.01)))
+
+    with _mock_semantic_repos(
+        fact_rows=facts,
+        procedure_rows=[npm_proc] + other_procs,
+        summary_rows=[],
+        semantic_results=semantic_results,
+    ):
+        result = await assemble_context(
+            AsyncMock(),
+            "statewave-support-docs",
+            "how do I install with npm?",
+            max_tokens=4000,
+        )
+
+    # Both assertions are differential — they only pass with the lexical
+    # bonus in place. Without it, the npm procedure scores
+    # (kind 8 + recency 0 + semantic 7.2 + temporal 3) = 18.2, while
+    # the newest "other" procedure scores (kind 8 + recency 5 +
+    # semantic 4.0 + temporal 3) = 20.0 and ranks above it.
+    assert str(npm_proc.id) in result.provenance["procedure_ids"], (
+        "npm-install procedure was excluded from the context bundle entirely"
+    )
+    assert result.provenance["procedure_ids"][0] == str(npm_proc.id), (
+        f"expected npm procedure first; got order: {result.provenance['procedure_ids']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lexical_bonus_does_not_override_strong_kind_signal_alone():
+    """Sanity check: the lexical bonus is a tiebreaker, not a kind
+    override. A profile_fact with both strong semantic AND strong
+    lexical match should still outrank a procedure with the same.
+
+    Why: KIND_PRIORITY (10 vs 8) reflects a real preference — when both
+    signals agree the more profile-shaped fact should win. Lexical
+    bonus must be small enough not to flip that ordering by itself.
+    """
+    fact = _make_memory_row(
+        kind="profile_fact",
+        content="The user installs npm packages globally for CLI tools.",
+        minutes_ago=0,
+    )
+    proc = _make_memory_row(
+        kind="procedure",
+        content="To install npm packages globally, run 'npm install -g'.",
+        minutes_ago=0,
+    )
+
+    # Equal semantic strength
+    semantic_results = [(fact, 0.2), (proc, 0.2)]
+
+    with _mock_semantic_repos(
+        fact_rows=[fact],
+        procedure_rows=[proc],
+        summary_rows=[],
+        semantic_results=semantic_results,
+    ):
+        result = await assemble_context(
+            AsyncMock(),
+            "user-1",
+            "install npm globally",
+            max_tokens=4000,
+        )
+
+    assert str(fact.id) in result.provenance["fact_ids"]
+    assert str(proc.id) in result.provenance["procedure_ids"]


### PR DESCRIPTION
## Summary

Fixes #27 — narrow factual queries (e.g. "how do I install with npm") were ranking the right memory at position ~127 of 159 in `/v1/context` even though pure-semantic search ranked it #1.

Two compounding causes:

- **Tokenization didn't strip punctuation.** Docs-pack content like `'npm install statewave-ts'` (literal quotes from code snippets) tokenized as `'npm` and silently failed to match a query token of `npm`, zeroing the lexical signal.
- **Lexical signal was discarded when semantic was in play.** The cosine spread for the candidate pool (~3 points across `SEMANTIC_MAX=8`) is narrower than `KIND_PRIORITY` (procedure 8 vs profile_fact 10) plus recency (0..5), so a strong-semantic procedure could be buried behind freshly-created profile_facts that only weakly matched the query.

## Fix

- Strip surrounding punctuation in `_tokenize_for_relevance` (also benefits the existing word-overlap fallback path).
- Add `_lexical_overlap_bonus`, capped at `_LEXICAL_BONUS_MAX = 4.0`, stopword-filtered, applied additively on top of the semantic score.

When both signals agree, the memory clears the kind/recency floor. When only one agrees, the existing weights still arbitrate — kind priority is preserved as a tiebreaker.

## Verification

Synthetic reproducer mirroring the prod case (npm-install procedure vs 4 unrelated newer procedures + 20 unrelated facts):

- **Pre-fix:** npm procedure ranks **5 of 5** within procedures (kind 8 + recency 0 + semantic 7.2 + temporal 3 = 18.2; beaten by newer unrelated procedures at 20.0).
- **Post-fix:** npm procedure ranks **1 of 5** (22.2 with +4 lexical for the verbatim `install`+`npm` overlap).

## Test plan

- [x] `pytest tests/test_context.py` — 32 passed (10 new tests)
- [x] Full unit suite — 461 passed, 1 skipped, 1 unrelated infra flake on `test_admin_subjects::test_memory_related_basic` (real-Postgres + litellm event-loop issue, no `context.py` imports)
- [x] Reseed prod docs pack post-merge and re-verify the issue's reproducer query (`how do I install with npm` against `statewave-support-docs`) returns the npm procedure within top-3 of `.facts + .procedures`
- [x] Spot-check the widget on a few narrow factual queries to confirm no regression on existing behavior