### PR TITLE
fix(health): preserve non-ASCII tokens in keyword overlap detection

### DIFF
--- a/server/services/health.py
+++ b/server/services/health.py
@@ -352,8 +352,20 @@ def _has_keyword_overlap(text_a: str, text_b: str) -> bool:
         "that",
         "with",
     }
-    words_a = {w for w in re.findall(r"[a-z]+", text_a.lower()) if len(w) > 2 and w not in stopwords}
-    words_b = {w for w in re.findall(r"[a-z]+", text_b.lower()) if len(w) > 2 and w not in stopwords}
+    # `[^\W\d_]+` is the stdlib `re` idiom for "letters from any script,
+    # no digits or underscores" — equivalent to `\p{L}+` in the third-party
+    # `regex` package without the extra dep. Replaces a prior `[a-z]+`
+    # that silently dropped or truncated non-ASCII words (`café` → `caf`,
+    # `naïve` → `na`, `ve`), which made overlap detection undercount
+    # recurring issues in multilingual support traffic.
+    words_a = {
+        w for w in re.findall(r"[^\W\d_]+", text_a.lower())
+        if len(w) > 2 and w not in stopwords
+    }
+    words_b = {
+        w for w in re.findall(r"[^\W\d_]+", text_b.lower())
+        if len(w) > 2 and w not in stopwords
+    }
     if not words_a or not words_b:
         return False
     smaller = min(len(words_a), len(words_b))

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from server.services.health import compute_health
+from server.services.health import _has_keyword_overlap, compute_health
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +192,107 @@ async def test_repeated_issues_detected_through_punctuation():
     assert "repeated_issues" in signals
     assert result.state in ("watch", "at_risk")
     assert result.score < 70
+
+
+# ---------------------------------------------------------------------------
+# Unicode-aware keyword tokenization (issue #38)
+# ---------------------------------------------------------------------------
+#
+# The prior `[a-z]+` regex silently dropped or truncated non-ASCII
+# words: `café` → `caf`, `naïve` → `na` + `ve`, `straße` → `stra` + `e`.
+# Overlap detection therefore undercounted recurring issues for any
+# multilingual support traffic. These tests pin the contract that
+# accented Latin text and other Unicode-letter scripts survive
+# tokenization while the existing punctuation-handling fix from #35
+# is preserved.
+
+
+def test_keyword_overlap_preserves_accented_latin_words():
+    text = "Notre passerelle de paiement échoue à nouveau pour les clients européens"
+    # Same content phrased as a recurrence of the same issue
+    other = "La passerelle de paiement échoue encore pour les clients européens"
+    assert _has_keyword_overlap(text, other)
+
+
+def test_keyword_overlap_preserves_german_eszett_and_umlaut():
+    """`straße`, `prüfen`, `größer` etc. must survive intact."""
+    text_a = "Die Zahlungsstraße schlägt für größere Beträge fehl"
+    text_b = "Bitte Zahlungsstraße prüfen — größere Transaktionen schlagen fehl"
+    assert _has_keyword_overlap(text_a, text_b)
+
+
+def test_keyword_overlap_works_for_non_latin_scripts():
+    """Cyrillic / Greek / CJK letters all match `[^\\W\\d_]+` under the
+    Unicode default in Python 3's re module."""
+    text_a = "Платёжный шлюз снова не работает для европейских клиентов"
+    text_b = "Платёжный шлюз опять падает у европейских клиентов"
+    assert _has_keyword_overlap(text_a, text_b)
+
+
+def test_keyword_overlap_still_handles_attached_punctuation():
+    """Regression guard for the original #35 fix — the Unicode change
+    must not regress the punctuation-stripping behavior."""
+    text_a = "Our billing gateway is timing out when processing payments."
+    text_b = "The billing gateway is timing out AGAIN — payments are failing."
+    assert _has_keyword_overlap(text_a, text_b)
+
+
+def test_keyword_overlap_is_false_for_unrelated_text():
+    """Sanity check: unrelated text in either ASCII or Unicode should
+    NOT register as overlapping."""
+    assert not _has_keyword_overlap(
+        "Need to reset my admin password",
+        "Quiero cambiar el color de mi avatar",
+    )
+
+
+@pytest.mark.asyncio
+async def test_recurring_issue_detected_in_french_support_text():
+    """End-to-end: the recurring-issue signal fires for non-English
+    support text describing the same problem twice."""
+    resolutions = [
+        _make_resolution("sess-A", "resolved", resolved_at=_NOW - timedelta(days=2)),
+        _make_resolution("sess-B", "resolved", resolved_at=_NOW - timedelta(days=1)),
+        _make_resolution("sess-C", "open"),
+    ]
+    episodes = [
+        _make_episode(
+            "sess-A",
+            "La passerelle de paiement expire au moment du règlement. "
+            "Pouvez-vous redémarrer le service de paiement ?",
+            days_ago=2,
+        ),
+        _make_episode(
+            "sess-B",
+            "Besoin de réinitialiser mon mot de passe administrateur.",
+            days_ago=1,
+        ),
+        _make_episode(
+            "sess-C",
+            "La passerelle de paiement expire de nouveau — c'est urgent, "
+            "les factures doivent être réglées aujourd'hui.",
+            days_ago=0,
+        ),
+    ]
+
+    with (
+        patch(
+            "server.services.health.repo.list_resolutions",
+            new_callable=AsyncMock,
+            return_value=resolutions,
+        ),
+        patch(
+            "server.services.health.repo.list_episodes_by_subject",
+            new_callable=AsyncMock,
+            return_value=episodes,
+        ),
+    ):
+        result = await compute_health(AsyncMock(), "user-1")
+
+    signals = [f.signal for f in result.factors]
+    assert "repeated_issues" in signals, (
+        f"recurring-issue signal must fire on multilingual text; got {signals}"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #38. Swaps the tokenizer in [`_has_keyword_overlap`](server/services/health.py) from `[a-z]+` to `[^\W\d_]+` so accented Latin and non-Latin-script support text no longer silently undercounts overlap.

## The bug

```python
re.findall(r"[a-z]+", "café résumé naïve straße")
# → ['caf', 'r', 'sum', 'na', 've', 'stra', 'e']  ← truncated / split
```

For multilingual support traffic, the recurring-issue health signal therefore fired less often than warranted, biasing `watch` / `at_risk` reports toward English-only accounts.

## Fix

`[^\W\d_]+` is the stdlib `re` idiom for *"letters from any script, no digits or underscores"* — equivalent to `\p{L}+` in the third-party `regex` package without an added dependency. In Python 3, str patterns are Unicode-aware by default, so this matches accented Latin, Cyrillic, Greek, CJK, etc. as full words.

```python
re.findall(r"[^\W\d_]+", "café résumé naïve straße")
# → ['café', 'résumé', 'naïve', 'straße']  ← preserved
```

The existing English-text behavior is unchanged — punctuation still stripped, digits still excluded.

## Test plan

- [x] Existing punctuation regression test from #35 still passes (`test_repeated_issues_detected_through_punctuation`)
- [x] New unit tests in `_has_keyword_overlap` cover French, German (ß, ü), Russian Cyrillic, and an unrelated-text sanity check
- [x] New end-to-end test verifies the `repeated_issues` signal fires on a French support conversation
- [x] Full unit suite — 480 passed (6 new), 1 unrelated infra flake