### PR TITLE
fix(security): sanitize starter-pack manifest errors before returning to API caller

### DIFF
--- a/server/services/memory_packs.py
+++ b/server/services/memory_packs.py
@@ -203,14 +203,37 @@ def list_starter_packs() -> list[dict[str, Any]]:
     the admin UI can render selectable cards. Manifest read errors on a
     single pack become a `__error` field on that entry rather than failing
     the whole list, so a corrupt pack can't break the picker.
+
+    The `__error` field carries a stable, sanitized error code rather than
+    the raw exception message. The full exception detail is logged
+    server-side via `logger.warning(..., exc_info=True)` so operators still
+    get the diagnostic info, but the API response can't accidentally leak
+    filesystem paths, JSON parser positions, or future error-message text
+    that may grow more sensitive over time (CodeQL py/stack-trace-exposure,
+    GH alert #1). The widened `except Exception` also catches
+    `json.JSONDecodeError` and `OSError` from the manifest read — both of
+    which previously bubbled past the narrower `except StarterPackError`
+    and broke the per-pack soft-fail contract this function promises.
     """
     out: list[dict[str, Any]] = []
     for entry in _read_index():
         directory = _PACKS_ROOT / entry["directory"]
         try:
             manifest = _read_starter_pack_manifest(directory)
-        except StarterPackError as e:
-            out.append({"pack_id": entry["pack_id"], "kind": entry.get("kind"), "__error": str(e)})
+        except Exception:
+            logger.warning(
+                "starter_pack_manifest_unreadable",
+                pack_id=entry.get("pack_id"),
+                directory=entry.get("directory"),
+                exc_info=True,
+            )
+            out.append(
+                {
+                    "pack_id": entry["pack_id"],
+                    "kind": entry.get("kind"),
+                    "__error": "manifest_unreadable",
+                }
+            )
             continue
         out.append(
             {

--- a/tests/test_admin_memory.py
+++ b/tests/test_admin_memory.py
@@ -131,6 +131,110 @@ def test_starter_pack_directory_layout_on_disk():
         assert (d / "memories.jsonl").exists(), f"missing memories.jsonl for {pack['pack_id']}"
 
 
+# ─── __error sanitization (CodeQL alert #1, py/stack-trace-exposure) ────────
+#
+# `list_starter_packs` returns `__error: <code>` for packs whose manifest
+# can't be read. The pre-fix code did `__error: str(exc)`, leaking
+# whatever the exception message contained (filesystem paths, JSON parser
+# positions, future error-message text). These tests pin the contract
+# that the exposed value is a stable, sanitized code regardless of which
+# exception path fired.
+
+
+def _stub_index_with_one_pack(monkeypatch, tmp_path):
+    """Replace _read_index() and _PACKS_ROOT so a synthetic pack dir
+    drives list_starter_packs without touching the bundled corpus."""
+    monkeypatch.setattr(mp, "_PACKS_ROOT", tmp_path)
+    monkeypatch.setattr(
+        mp,
+        "_read_index",
+        lambda: [{"pack_id": "synthetic-pack", "kind": "demo_agent", "directory": "synthetic-pack"}],
+    )
+    pack_dir = tmp_path / "synthetic-pack"
+    pack_dir.mkdir()
+    return pack_dir
+
+
+def test_list_starter_packs_returns_sanitized_code_when_manifest_missing(
+    monkeypatch, tmp_path
+):
+    """Missing manifest → `__error: 'manifest_unreadable'`, no path leak."""
+    _stub_index_with_one_pack(monkeypatch, tmp_path)
+    # No manifest.json written — _read_starter_pack_manifest raises
+    # StarterPackError with the directory name in the message.
+
+    packs = mp.list_starter_packs()
+    assert len(packs) == 1
+    p = packs[0]
+    assert p["__error"] == "manifest_unreadable", (
+        f"expected sanitized code, got {p['__error']!r} — likely leaking exception message"
+    )
+    # Belt-and-suspenders: the directory name (which the StarterPackError
+    # message DID contain) must not appear anywhere in the payload.
+    assert "synthetic-pack" not in p["__error"]
+
+
+def test_list_starter_packs_handles_corrupt_json_without_leaking(
+    monkeypatch, tmp_path
+):
+    """Pre-fix bug: json.JSONDecodeError bubbled past the narrow
+    `except StarterPackError` and broke the soft-fail contract; if it
+    HAD been caught, the message would have included the parser line/
+    column. Now: caught by the widened handler AND sanitized."""
+    pack_dir = _stub_index_with_one_pack(monkeypatch, tmp_path)
+    (pack_dir / "manifest.json").write_text("{ this is not valid json", encoding="utf-8")
+
+    packs = mp.list_starter_packs()
+    assert len(packs) == 1
+    p = packs[0]
+    assert p["__error"] == "manifest_unreadable"
+    assert p["pack_id"] == "synthetic-pack"
+
+
+def test_list_starter_packs_handles_oserror_without_leaking(
+    monkeypatch, tmp_path
+):
+    """Pre-fix bug: an unreadable manifest (e.g. permissions denied)
+    raised OSError, which slipped past the narrow except clause.
+    Now caught and sanitized."""
+    pack_dir = _stub_index_with_one_pack(monkeypatch, tmp_path)
+    # Create manifest.json as a directory so .read_text() raises
+    # IsADirectoryError (an OSError subclass) — portable across OS,
+    # avoids relying on chmod which behaves differently when running
+    # as root in a container.
+    (pack_dir / "manifest.json").mkdir()
+
+    packs = mp.list_starter_packs()
+    assert len(packs) == 1
+    p = packs[0]
+    assert p["__error"] == "manifest_unreadable"
+
+
+def test_list_starter_packs_logs_full_detail_server_side(
+    monkeypatch, tmp_path, caplog
+):
+    """Operator-facing diagnostic info must still be available — just
+    via the server log, not the API response."""
+    pack_dir = _stub_index_with_one_pack(monkeypatch, tmp_path)
+    (pack_dir / "manifest.json").write_text("{ broken", encoding="utf-8")
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        mp.list_starter_packs()
+
+    # Note: structlog routes through stdlib logging; caplog captures the
+    # event name. The full exception chain is attached via exc_info.
+    assert any(
+        "starter_pack_manifest_unreadable" in record.getMessage()
+        or "starter_pack_manifest_unreadable" in str(record.__dict__)
+        for record in caplog.records
+    ), (
+        f"expected 'starter_pack_manifest_unreadable' log event; "
+        f"saw: {[r.getMessage() for r in caplog.records]}"
+    )
+
+
 # ─── Subject-id validation ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes [CodeQL alert #1](https://github.com/smaramwbc/statewave/security/code-scanning/1) — \`py/stack-trace-exposure\` (CWE-209/497, medium severity).

[\`list_starter_packs\`](server/services/memory_packs.py#L199) previously did \`__error: str(exc)\` for packs whose manifest couldn't be read, exposing the exception message to the API caller. The \`__error\` value now carries a stable sanitized code (\`\"manifest_unreadable\"\`) and the full exception detail is logged server-side via structlog where operators expect it.

## Two issues fixed in one change

**1. Security (the CodeQL alert)** — \`__error: str(exc)\` exposed:
- the on-disk pack directory name (today)
- whatever future maintainers add to a \`StarterPackError(...)\` message tomorrow (filesystem paths, parser positions, etc.)

\`__error\` is now a stable code regardless of which exception fired. Diagnostic detail still reaches operators via \`logger.warning(\"starter_pack_manifest_unreadable\", ..., exc_info=True)\`.

**2. Robustness (drive-by)** — the narrow \`except StarterPackError\` was missing:
- \`json.JSONDecodeError\` from \`json.loads(manifest.read_text())\` on a corrupt file
- \`OSError\` from permission errors / unreadable inodes

Both silently bubbled past the handler and broke the per-pack soft-fail contract the docstring promises. Widened to \`except Exception\` so a single broken pack genuinely can't take down the whole picker, as advertised.

## Auth posture (for context)

The \`/admin/memory/starter-packs\` endpoint sits behind \`APIKeyMiddleware\` when \`STATEWAVE_API_KEY\` is configured. Today's exposed strings (project-relative paths) are not high-risk. The fix is principle-of-least-information for the API surface — and prevents future \`StarterPackError\` messages from accidentally leaking through this same channel.

## Test plan

- [x] 4 new tests in [tests/test_admin_memory.py](tests/test_admin_memory.py):
  - \`__error\` is the sanitized code (no leak) when manifest is missing
  - \`json.JSONDecodeError\` now caught + sanitized (was bubbling pre-fix)
  - \`OSError\` caught + sanitized (uses portable \`IsADirectoryError\` synthesis)
  - Full exception detail still reaches the server log via the \`starter_pack_manifest_unreadable\` structlog event
- [x] Full unit suite — 484 passed (4 new), 1 unrelated infra flake
- [x] Post-merge: confirm CodeQL alert #1 transitions to \`fixed\` on the next analysis run