### PR TITLE
feat(helm): add API-only Helm chart at helm/statewave (v0.7)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,3 +41,6 @@ node_modules
 *.db
 *.sqlite
 *.sqlite3
+
+# Helm chart — only needed for k8s deploys, not the API image
+helm

--- a/helm/statewave/.helmignore
+++ b/helm/statewave/.helmignore
@@ -1,0 +1,19 @@
+# Patterns to ignore when building Helm packages.
+# Mirrors the default helmignore template.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/statewave/Chart.yaml
+++ b/helm/statewave/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: statewave
+description: |
+  Statewave — memory infrastructure for AI agents.
+  Deploys the Statewave API (FastAPI + pgvector) on Kubernetes. Postgres
+  with the pgvector extension is a prerequisite and is NOT bundled by this
+  chart — point STATEWAVE_DATABASE_URL at a managed instance (Neon,
+  Supabase, RDS, Cloud SQL, …) or an in-cluster Postgres you operate.
+type: application
+
+# Chart version follows the chart's own lifecycle, not the API image's.
+# Bump this for any chart-template change.
+version: 0.1.0
+
+# appVersion tracks the Statewave API release this chart was validated
+# against. Operators can override the deployed image via image.tag.
+appVersion: "0.7.0"
+
+home: https://statewave.ai
+sources:
+  - https://github.com/smaramwbc/statewave
+icon: https://statewave.ai/favicon.svg
+
+keywords:
+  - ai
+  - memory
+  - llm
+  - agents
+  - rag
+  - pgvector
+  - fastapi
+
+maintainers:
+  - name: Statewave maintainers
+    url: https://github.com/smaramwbc/statewave

--- a/helm/statewave/README.md
+++ b/helm/statewave/README.md
@@ -1,0 +1,136 @@
+# Statewave Helm chart
+
+Deploys the Statewave API on Kubernetes.
+
+> **Scope:** API-only. This chart does **not** deploy Postgres, the Statewave admin console, or any LLM / embedding model server. Bring your own Postgres (with the pgvector extension) and point `database.url` at it.
+>
+> **Companion guide:** see [`deployment/kubernetes.md`](https://github.com/smaramwbc/statewave-docs/blob/main/deployment/kubernetes.md) in `statewave-docs` for the full deployment walkthrough, secret-management patterns, and troubleshooting.
+
+## Prerequisites
+
+- Kubernetes 1.24+
+- Helm 3.10+
+- A Postgres instance reachable from the cluster, with the `pgvector` extension installed. Managed options: Neon, Supabase, RDS, Cloud SQL. In-cluster option: any chart that uses the `pgvector/pgvector:pg16` image (or installs `CREATE EXTENSION vector` against a stock Postgres).
+
+## Quick start
+
+```bash
+helm install statewave \
+  oci://ghcr.io/smaramwbc/charts/statewave \
+  --version 0.1.0 \
+  --set database.url='postgresql+asyncpg://user:pass@db.example.com:5432/statewave' \
+  --set llm.apiKey='sk-…' \
+  --set auth.apiKey='replace-me'
+```
+
+> The chart is also available from this repo as a directory:
+> ```bash
+> helm install statewave ./helm/statewave \
+>   --set database.url='postgresql+asyncpg://…' \
+>   --set llm.apiKey='sk-…'
+> ```
+
+The first install runs a Helm pre-install Job (`alembic upgrade head`) before any API pod admits traffic. Upgrades repeat the migration as a pre-upgrade Job.
+
+## Configuration
+
+All values are documented inline in [`values.yaml`](values.yaml). Highlights:
+
+| Value | Default | Notes |
+|---|---|---|
+| `image.tag` | `""` (falls back to `Chart.AppVersion`) | Pin a digest in production. |
+| `replicaCount` | `1` | See connection-budget math in the [Horizontal Scaling Guide](https://github.com/smaramwbc/statewave-docs/blob/main/deployment/horizontal-scaling.md) before raising. |
+| `database.url` / `database.existingSecret` | — | One is **required**. |
+| `compiler.type` | `llm` | `heuristic` for demo / no-LLM mode. |
+| `embedding.provider` | `litellm` | `stub` for demo / no-embedding mode. |
+| `llm.apiKey` / `llm.existingSecret` | — | Required when `compiler.type=llm` or `embedding.provider=litellm`. |
+| `auth.apiKey` / `auth.existingSecret` | — | Strongly recommended in production. |
+| `rateLimit.rpm` | `0` (off) | Per-IP. Postgres-backed, correct across replicas. |
+| `cors.origins` | `["*"]` | Lock down for production. |
+| `service.type` | `ClusterIP` | Set to `LoadBalancer` only if you skip the Ingress. |
+| `ingress.enabled` | `false` | When enabled, **raise the proxy timeouts to ≥ 60s** — `/v1/context` cold-starts can take that long. |
+| `migrationJob.enabled` | `true` | Disable only if you run migrations out-of-band. |
+| `autoscaling.enabled` | `false` | HPA on CPU. Recompute the connection budget when raising `maxReplicas`. |
+| `supportPack.autoUpdate` | `false` | Off by default for self-hosted operators (the bundled docs pack is statewave.ai-specific content). |
+
+## Secret management
+
+Two patterns supported. Pick **one** per credential:
+
+### A. Inline (chart-managed Secret)
+
+For dev / single-environment installs:
+
+```bash
+helm install statewave ./helm/statewave \
+  --set database.url='postgresql+asyncpg://…' \
+  --set llm.apiKey='sk-…' \
+  --set auth.apiKey='…'
+```
+
+The chart creates a single `<release>-credentials` Secret holding all inline values.
+
+### B. External Secret reference (recommended)
+
+For production. Keep credentials in your Secret manager (Sealed Secrets, External Secrets Operator, SOPS, AWS/GCP Secrets Manager + CSI driver, …) and point the chart at the resulting Secret:
+
+```yaml
+database:
+  existingSecret: statewave-db
+  existingSecretKey: STATEWAVE_DATABASE_URL
+
+llm:
+  existingSecret: statewave-llm
+  existingSecretKey: STATEWAVE_LITELLM_API_KEY
+
+auth:
+  existingSecret: statewave-auth
+  existingSecretKey: STATEWAVE_API_KEY
+```
+
+When all three are externalised, no chart-managed Secret is created.
+
+## Multi-instance / horizontal scaling
+
+Statewave coordinates across replicas via Postgres (compile queue, webhook DLQ, rate limit, L2 query embedding cache). Sticky sessions are unnecessary and reduce L1 cache hit rates.
+
+Before raising `replicaCount` past 2–3, walk the connection-budget math:
+
+```
+required_db_connections = replicas × (pool_size + max_overflow) + headroom
+                        = replicas × 15 + ~15
+```
+
+At higher replica counts, put a transaction-mode PgBouncer in front of Postgres. Full guidance: [`deployment/horizontal-scaling.md`](https://github.com/smaramwbc/statewave-docs/blob/main/deployment/horizontal-scaling.md).
+
+## Probes
+
+- **Liveness** — `GET /healthz` (process up).
+- **Readiness** — `GET /readyz` (DB reachable, queue healthy, optional LLM check).
+
+`/readyz` may flap briefly during DB restarts; the chart's `failureThreshold: 6` keeps a single flap from cycling the pod.
+
+## Upgrades
+
+```bash
+helm upgrade statewave ./helm/statewave \
+  --reuse-values \
+  --set image.tag=0.7.1
+```
+
+The pre-upgrade Job runs `alembic upgrade head` before the rollout begins. Rolling upgrades require backwards-compatible schemas across one version (the project's standard policy) — see the [migration runbook](https://github.com/smaramwbc/statewave-docs/blob/main/deployment/migrations.md).
+
+## Uninstall
+
+```bash
+helm uninstall statewave
+```
+
+Helm removes everything the chart created. **Postgres data is not touched** — that's the operator's responsibility (the chart never owned it).
+
+## What this chart deliberately does not do
+
+- **No bundled Postgres.** Statewave needs a managed/operated DB lifecycle (backups, PITR, vacuum tuning) that does not belong inside a single application chart.
+- **No admin console.** The `statewave-admin` console is a separate deployable with its own auth surface; bundle it via a separate chart or overlay.
+- **No model server.** Self-hosted vLLM / Ollama / TEI deployments belong to their own chart with GPU scheduling and a separate runbook.
+- **No NetworkPolicy.** Cluster-wide policy is operator-defined; the chart would either be too permissive or too restrictive for any given environment.

--- a/helm/statewave/templates/NOTES.txt
+++ b/helm/statewave/templates/NOTES.txt
@@ -1,0 +1,71 @@
+Statewave API has been deployed.
+
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+Chart:      {{ .Chart.Name }}-{{ .Chart.Version }}
+App image:  {{ include "statewave.image" . }}
+
+──────────────────────────────────────────────────
+1. Check that the API is healthy:
+
+  kubectl --namespace {{ .Release.Namespace }} rollout status deployment/{{ include "statewave.fullname" . }}
+
+2. Get the in-cluster service URL:
+
+  http://{{ include "statewave.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+3. Port-forward for a one-off check from your laptop:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "statewave.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  curl -fsS http://127.0.0.1:{{ .Values.service.port }}/healthz
+  curl -fsS http://127.0.0.1:{{ .Values.service.port }}/readyz
+
+{{- if .Values.ingress.enabled }}
+
+4. Ingress is enabled at:
+  {{- range .Values.ingress.hosts }}
+    {{- $host := .host }}
+    {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ .path }}
+    {{- end }}
+  {{- end }}
+
+  Reminder: /v1/context can run 5–30s on cold-start (semantic search +
+  embedding RTT). Make sure your Ingress controller's read/send timeouts
+  are at least 60s. NGINX example:
+
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+{{- end }}
+
+──────────────────────────────────────────────────
+Database
+
+This chart does NOT deploy Postgres. Statewave needs a pgvector-capable
+Postgres reachable at the URL configured in
+{{- if .Values.database.existingSecret }}
+secret/{{ .Values.database.existingSecret }}.{{ .Values.database.existingSecretKey }}.
+{{- else }}
+secret/{{ include "statewave.inlineSecretName" . }}.STATEWAVE_DATABASE_URL.
+{{- end }}
+
+If /readyz returns 503 with a database error, the most common causes are:
+  - Wrong URL or credentials
+  - Postgres image without the pgvector extension installed
+  - Network policy blocking pod → Postgres traffic
+  - Postgres max_connections too low for `replicas × (pool_size + max_overflow)`
+
+──────────────────────────────────────────────────
+{{- if gt (int .Values.replicaCount) 1 }}
+
+Multi-instance deploy detected (replicas={{ .Values.replicaCount }}).
+
+Statewave coordinates correctly across replicas via Postgres (compile
+queue, webhook DLQ, rate limit, L2 query embedding cache). Mind the
+connection-budget math — see the Horizontal Scaling Guide:
+  https://github.com/smaramwbc/statewave-docs/blob/main/deployment/horizontal-scaling.md
+
+{{- end }}
+
+Docs:        https://github.com/smaramwbc/statewave-docs
+Issues:      https://github.com/smaramwbc/statewave/issues

--- a/helm/statewave/templates/_helpers.tpl
+++ b/helm/statewave/templates/_helpers.tpl
@@ -1,0 +1,205 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "statewave.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "statewave.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label.
+*/}}
+{{- define "statewave.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "statewave.labels" -}}
+helm.sh/chart: {{ include "statewave.chart" . }}
+{{ include "statewave.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: statewave
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "statewave.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "statewave.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "statewave.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "statewave.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image reference. Falls back to .Chart.AppVersion when image.tag is empty.
+*/}}
+{{- define "statewave.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+
+{{/*
+Name of the chart-managed Secret holding inline credentials. We only
+materialise this Secret when at least one inline credential value is
+non-empty, so operators using existingSecret references never see an
+empty secret in their cluster.
+*/}}
+{{- define "statewave.inlineSecretName" -}}
+{{- printf "%s-credentials" (include "statewave.fullname" .) }}
+{{- end }}
+
+{{/*
+Whether the chart should render an inline credentials Secret.
+True when any of database.url / llm.apiKey / auth.apiKey is supplied
+inline (non-empty) AND not delegated to an existingSecret.
+*/}}
+{{- define "statewave.shouldRenderInlineSecret" -}}
+{{- $needs := false -}}
+{{- if and .Values.database.url (not .Values.database.existingSecret) -}}{{- $needs = true -}}{{- end -}}
+{{- if and .Values.llm.apiKey (not .Values.llm.existingSecret) -}}{{- $needs = true -}}{{- end -}}
+{{- if and .Values.auth.apiKey (not .Values.auth.existingSecret) -}}{{- $needs = true -}}{{- end -}}
+{{- $needs -}}
+{{- end -}}
+
+{{/*
+Common environment block — emitted by both the Deployment and the
+migration Job so that DB credentials and provider config stay aligned.
+*/}}
+{{- define "statewave.commonEnv" -}}
+# Database
+- name: STATEWAVE_DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.database.existingSecret }}
+      name: {{ .Values.database.existingSecret }}
+      key: {{ .Values.database.existingSecretKey }}
+      {{- else }}
+      name: {{ include "statewave.inlineSecretName" . }}
+      key: STATEWAVE_DATABASE_URL
+      {{- end }}
+{{- end }}
+
+{{/*
+Runtime environment — only emitted by the Deployment. Pulls in the
+common block plus everything the API process needs at request time.
+The migration Job intentionally only needs the DB URL.
+*/}}
+{{- define "statewave.runtimeEnv" -}}
+{{ include "statewave.commonEnv" . }}
+- name: STATEWAVE_HOST
+  value: "0.0.0.0"
+- name: STATEWAVE_PORT
+  value: "8100"
+
+# Compiler + embedding
+- name: STATEWAVE_COMPILER_TYPE
+  value: {{ .Values.compiler.type | quote }}
+- name: STATEWAVE_EMBEDDING_PROVIDER
+  value: {{ .Values.embedding.provider | quote }}
+- name: STATEWAVE_EMBEDDING_DIMENSIONS
+  value: {{ .Values.embedding.dimensions | quote }}
+
+# LiteLLM (only meaningful when compiler=llm or embedding=litellm)
+- name: STATEWAVE_LITELLM_MODEL
+  value: {{ .Values.llm.model | quote }}
+- name: STATEWAVE_LITELLM_EMBEDDING_MODEL
+  value: {{ .Values.llm.embeddingModel | quote }}
+{{- if .Values.llm.apiBase }}
+- name: STATEWAVE_LITELLM_API_BASE
+  value: {{ .Values.llm.apiBase | quote }}
+{{- end }}
+- name: STATEWAVE_LITELLM_TIMEOUT_SECONDS
+  value: {{ .Values.llm.timeoutSeconds | quote }}
+- name: STATEWAVE_LITELLM_MAX_RETRIES
+  value: {{ .Values.llm.maxRetries | quote }}
+- name: STATEWAVE_LITELLM_TEMPERATURE
+  value: {{ .Values.llm.temperature | quote }}
+{{- if or .Values.llm.apiKey .Values.llm.existingSecret }}
+- name: STATEWAVE_LITELLM_API_KEY
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.llm.existingSecret }}
+      name: {{ .Values.llm.existingSecret }}
+      key: {{ .Values.llm.existingSecretKey }}
+      {{- else }}
+      name: {{ include "statewave.inlineSecretName" . }}
+      key: STATEWAVE_LITELLM_API_KEY
+      {{- end }}
+{{- end }}
+
+# API auth
+{{- if or .Values.auth.apiKey .Values.auth.existingSecret }}
+- name: STATEWAVE_API_KEY
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.auth.existingSecret }}
+      name: {{ .Values.auth.existingSecret }}
+      key: {{ .Values.auth.existingSecretKey }}
+      {{- else }}
+      name: {{ include "statewave.inlineSecretName" . }}
+      key: STATEWAVE_API_KEY
+      {{- end }}
+{{- end }}
+
+# Rate limit + CORS
+- name: STATEWAVE_RATE_LIMIT_RPM
+  value: {{ .Values.rateLimit.rpm | quote }}
+- name: STATEWAVE_CORS_ORIGINS
+  value: {{ .Values.cors.origins | quote }}
+
+# Webhooks
+{{- if .Values.webhooks.url }}
+- name: STATEWAVE_WEBHOOK_URL
+  value: {{ .Values.webhooks.url | quote }}
+- name: STATEWAVE_WEBHOOK_TIMEOUT
+  value: {{ .Values.webhooks.timeoutSeconds | quote }}
+{{- end }}
+
+# Multi-tenant
+{{- if .Values.multiTenant.enabled }}
+- name: STATEWAVE_TENANT_HEADER
+  value: {{ .Values.multiTenant.header | quote }}
+- name: STATEWAVE_REQUIRE_TENANT
+  value: {{ .Values.multiTenant.required | quote }}
+{{- end }}
+
+# Support pack — off by default for self-hosted operators
+- name: STATEWAVE_AUTO_UPDATE_SUPPORT_PACK
+  value: {{ .Values.supportPack.autoUpdate | quote }}
+- name: STATEWAVE_BOOTSTRAP_DOCS_PACK
+  value: {{ .Values.supportPack.bootstrapFromMountedDocs | quote }}
+
+{{- with .Values.extraEnv }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/helm/statewave/templates/deployment.yaml
+++ b/helm/statewave/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "statewave.fullname" . }}
+  labels:
+    {{- include "statewave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "statewave.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        {{- include "statewave.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "statewave.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: api
+          image: {{ include "statewave.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          # Bypass start.sh — Helm runs migrations as a pre-install /
+          # pre-upgrade Job; the support-pack auto-update lives in
+          # start.sh and is opted into via env (off by default).
+          # The Deployment runs uvicorn directly so each replica is a
+          # clean stateless API process with no boot-time side effects.
+          command: ["uvicorn"]
+          args:
+            - server.app:app
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "8100"
+          ports:
+            - name: http
+              containerPort: 8100
+              protocol: TCP
+          env:
+            {{- include "statewave.runtimeEnv" . | nindent 12 }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/statewave/templates/hpa.yaml
+++ b/helm/statewave/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "statewave.fullname" . }}
+  labels:
+    {{- include "statewave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "statewave.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/statewave/templates/ingress.yaml
+++ b/helm/statewave/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "statewave.fullname" . }}
+  labels:
+    {{- include "statewave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "statewave.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/statewave/templates/migrate-job.yaml
+++ b/helm/statewave/templates/migrate-job.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.migrationJob.enabled -}}
+{{/*
+Schema migrations run as a Helm pre-install + pre-upgrade hook Job.
+Helm will not proceed with the install/upgrade until this Job succeeds,
+which guarantees the Deployment never serves traffic against an
+out-of-date schema.
+
+`hook-delete-policy: before-hook-creation,hook-succeeded` cleans up the
+previous Job before the next install/upgrade so the Job name doesn't
+collide across upgrades; the ttlSecondsAfterFinished value provides a
+secondary safety net.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "statewave.fullname" . }}-migrate
+  labels:
+    {{- include "statewave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migrationJob.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.migrationJob.activeDeadlineSeconds }}
+  ttlSecondsAfterFinished: {{ .Values.migrationJob.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "statewave.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+        {{- with .Values.migrationJob.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.migrationJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: OnFailure
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "statewave.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: migrate
+          image: {{ include "statewave.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command: ["alembic"]
+          args: ["upgrade", "head"]
+          env:
+            {{- include "statewave.commonEnv" . | nindent 12 }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.migrationJob.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/statewave/templates/pdb.yaml
+++ b/helm/statewave/templates/pdb.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "statewave.fullname" . }}
+  labels:
+    {{- include "statewave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  {{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "statewave.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+{{- end }}

--- a/helm/statewave/templates/secret.yaml
+++ b/helm/statewave/templates/secret.yaml
@@ -3,6 +3,12 @@ Chart-managed Secret holding inline credentials. Only rendered when at
 least one credential value is supplied inline (and not delegated to an
 existingSecret reference). When operators supply everything via
 existingSecret, no chart-managed Secret is created.
+
+Rendered as a pre-install + pre-upgrade hook at hook-weight=-5 so it
+exists before the migration Job (hook-weight=0) needs to reference it.
+The before-hook-creation delete policy makes upgrades idempotent: the
+prior Secret is deleted right before the new one is created, so values
+changes (rotated API key, rotated DB URL) propagate cleanly.
 */}}
 {{- if eq (include "statewave.shouldRenderInlineSecret" .) "true" }}
 apiVersion: v1
@@ -11,6 +17,10 @@ metadata:
   name: {{ include "statewave.inlineSecretName" . }}
   labels:
     {{- include "statewave.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 stringData:
   {{- if and .Values.database.url (not .Values.database.existingSecret) }}

--- a/helm/statewave/templates/secret.yaml
+++ b/helm/statewave/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{/*
+Chart-managed Secret holding inline credentials. Only rendered when at
+least one credential value is supplied inline (and not delegated to an
+existingSecret reference). When operators supply everything via
+existingSecret, no chart-managed Secret is created.
+*/}}
+{{- if eq (include "statewave.shouldRenderInlineSecret" .) "true" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "statewave.inlineSecretName" . }}
+  labels:
+    {{- include "statewave.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if and .Values.database.url (not .Values.database.existingSecret) }}
+  STATEWAVE_DATABASE_URL: {{ .Values.database.url | quote }}
+  {{- end }}
+  {{- if and .Values.llm.apiKey (not .Values.llm.existingSecret) }}
+  STATEWAVE_LITELLM_API_KEY: {{ .Values.llm.apiKey | quote }}
+  {{- end }}
+  {{- if and .Values.auth.apiKey (not .Values.auth.existingSecret) }}
+  STATEWAVE_API_KEY: {{ .Values.auth.apiKey | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/statewave/templates/service.yaml
+++ b/helm/statewave/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "statewave.fullname" . }}
+  labels:
+    {{- include "statewave.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "statewave.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api

--- a/helm/statewave/templates/serviceaccount.yaml
+++ b/helm/statewave/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "statewave.serviceAccountName" . }}
+  labels:
+    {{- include "statewave.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/statewave/templates/serviceaccount.yaml
+++ b/helm/statewave/templates/serviceaccount.yaml
@@ -1,12 +1,21 @@
 {{- if .Values.serviceAccount.create -}}
+{{/*
+Rendered as a pre-install + pre-upgrade hook at hook-weight=-5 so it
+exists before the migration Job (hook-weight=0) needs to reference it
+via serviceAccountName. The Deployment (rendered as a regular resource
+in the post-hook phase) finds it by name in the cluster.
+*/}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "statewave.serviceAccountName" . }}
   labels:
     {{- include "statewave.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 {{- end }}

--- a/helm/statewave/values.yaml
+++ b/helm/statewave/values.yaml
@@ -1,0 +1,316 @@
+# Default values for the Statewave API chart.
+#
+# This chart deploys the Statewave API ONLY. It does not deploy:
+#   - Postgres (you bring a pgvector-capable Postgres — managed or in-cluster)
+#   - The Statewave admin console (separate chart / overlay)
+#   - Any LLM or embedding model server
+#
+# Every non-trivial knob is documented inline. Required fields are marked
+# REQUIRED at the top of their block.
+
+# ──────────────────────────────────────────────────
+# Image
+# ──────────────────────────────────────────────────
+image:
+  repository: statewavedev/statewave
+  # If empty, falls back to .Chart.AppVersion. Pin a digest in production.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+# - name: regcred
+
+nameOverride: ""
+fullnameOverride: ""
+
+# ──────────────────────────────────────────────────
+# Replica count
+# ──────────────────────────────────────────────────
+# Statewave is stateless and horizontally scales correctly against a
+# shared Postgres (compile queue, webhook DLQ, rate limit, and the L2
+# query embedding cache all coordinate via Postgres). Mind the
+# connection-budget math when raising this:
+#
+#   replicas × (DB pool_size + max_overflow) + headroom < db.max_connections
+#
+# Defaults are pool_size=5, max_overflow=10 → 15 connections per replica
+# under burst. See the Horizontal Scaling Guide for the full runbook:
+# https://github.com/smaramwbc/statewave-docs/blob/main/deployment/horizontal-scaling.md
+replicaCount: 1
+
+# ──────────────────────────────────────────────────
+# Database — REQUIRED
+# ──────────────────────────────────────────────────
+# Statewave needs a Postgres instance with the pgvector extension.
+# This chart does NOT deploy Postgres.
+#
+# Supply the connection URL via ONE of:
+#
+#   1. database.url  (inline value)              ── easy for dev clusters
+#   2. database.existingSecret + database.existingSecretKey
+#                                                ── recommended for prod
+#
+# Format (SQLAlchemy + asyncpg):
+#   postgresql+asyncpg://USER:PASS@HOST:5432/statewave
+database:
+  url: ""
+
+  existingSecret: ""
+  existingSecretKey: "STATEWAVE_DATABASE_URL"
+
+# ──────────────────────────────────────────────────
+# Compiler + LLM provider
+# ──────────────────────────────────────────────────
+# - "heuristic": regex-based, no provider needed. Demo-grade quality.
+# - "llm":       LiteLLM-driven extraction. Set llm.* below.
+compiler:
+  type: llm
+
+# Embedding provider:
+# - "stub":     hash-based; no semantic search. Demo only.
+# - "litellm":  routes through LiteLLM (recommended).
+embedding:
+  provider: litellm
+  dimensions: 1536
+
+# LiteLLM configuration. Required when compiler.type=llm or
+# embedding.provider=litellm. See https://docs.litellm.ai/docs/providers
+# for the model identifier syntax.
+llm:
+  # Model identifier. Examples:
+  #   gpt-4o-mini                              (OpenAI)
+  #   anthropic/claude-3-haiku-20240307        (Anthropic)
+  #   ollama/llama3                            (Ollama, requires apiBase)
+  model: gpt-4o-mini
+  embeddingModel: text-embedding-3-small
+
+  # Optional: override the LiteLLM endpoint (e.g. self-hosted Ollama).
+  apiBase: ""
+
+  timeoutSeconds: 60
+  maxRetries: 2
+  temperature: 0.1
+
+  # API key for the provider. Supply via ONE of:
+  #   1. llm.apiKey            (inline; written to a chart-managed Secret)
+  #   2. llm.existingSecret + llm.existingSecretKey (recommended for prod)
+  apiKey: ""
+  existingSecret: ""
+  existingSecretKey: "STATEWAVE_LITELLM_API_KEY"
+
+# ──────────────────────────────────────────────────
+# API authentication
+# ──────────────────────────────────────────────────
+# When set, every request must carry X-API-Key: <value>.
+# Leave empty for an open API (do this only in trusted networks).
+auth:
+  apiKey: ""
+  existingSecret: ""
+  existingSecretKey: "STATEWAVE_API_KEY"
+
+# ──────────────────────────────────────────────────
+# Rate limiting (per-IP, sliding-window, Postgres-backed)
+# ──────────────────────────────────────────────────
+# 0 = disabled. Postgres-backed rate limit is correct across replicas.
+rateLimit:
+  rpm: 0
+
+# ──────────────────────────────────────────────────
+# CORS
+# ──────────────────────────────────────────────────
+# JSON-array string of allowed origins. ["*"] for development only.
+cors:
+  origins: '["*"]'
+
+# ──────────────────────────────────────────────────
+# Webhooks (optional)
+# ──────────────────────────────────────────────────
+webhooks:
+  url: ""
+  timeoutSeconds: 5.0
+
+# ──────────────────────────────────────────────────
+# Multi-tenant (experimental)
+# ──────────────────────────────────────────────────
+multiTenant:
+  enabled: false
+  header: X-Tenant-ID
+  required: false
+
+# ──────────────────────────────────────────────────
+# Support-pack auto-bootstrap
+# ──────────────────────────────────────────────────
+# Statewave's Docker image bundles a "Statewave Support" docs pack used
+# by statewave.ai. For self-hosted deployments this is OFF by default —
+# operators don't usually want surprise content seeded into their DB.
+# Set to true to enable; the API will reseed (or no-op) on each pod start.
+supportPack:
+  autoUpdate: false
+  bootstrapFromMountedDocs: false
+
+# ──────────────────────────────────────────────────
+# Extra environment variables
+# ──────────────────────────────────────────────────
+# Anything not covered above. Use for STATEWAVE_* knobs we haven't
+# surfaced as first-class values.
+extraEnv: []
+# - name: STATEWAVE_DEBUG
+#   value: "false"
+
+# Mount additional env-vars from existing Secrets / ConfigMaps.
+extraEnvFrom: []
+# - secretRef:
+#     name: statewave-extra-env
+
+# ──────────────────────────────────────────────────
+# Service
+# ──────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  port: 8100
+  annotations: {}
+
+# ──────────────────────────────────────────────────
+# Ingress (off by default)
+# ──────────────────────────────────────────────────
+# Long-running /v1/context calls (cold-start semantic search + embedding
+# RTT) can run 5–30s. If you enable an Ingress, raise the proxy/read
+# timeouts accordingly — see the per-controller annotations below.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # NGINX example:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+  hosts:
+    - host: statewave.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: statewave-tls
+  #    hosts:
+  #      - statewave.example.com
+
+# ──────────────────────────────────────────────────
+# Resources
+# ──────────────────────────────────────────────────
+# Statewave is a small FastAPI process. CPU and RAM are modest; Postgres
+# is what gets bigger. See the Sizing Guide for tier-by-tier advice:
+# https://github.com/smaramwbc/statewave-docs/blob/main/deployment/sizing.md
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+# ──────────────────────────────────────────────────
+# Probes
+# ──────────────────────────────────────────────────
+# /healthz — liveness (process up).
+# /readyz  — readiness (DB reachable, queue healthy, optional LLM check).
+#
+# /readyz can transiently flap during DB restarts; the failureThreshold
+# is set so that one flap doesn't cycle the pod.
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 6
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+# ──────────────────────────────────────────────────
+# Migrations
+# ──────────────────────────────────────────────────
+# Schema migrations run as a Helm pre-install + pre-upgrade Job that
+# executes `alembic upgrade head` against the configured database URL.
+# The Job blocks the install/upgrade until migrations succeed; the
+# Deployment never serves traffic against an out-of-date schema.
+#
+# Disable only if you run migrations out-of-band (e.g. a CI step).
+migrationJob:
+  enabled: true
+  backoffLimit: 3
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 300
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  podAnnotations: {}
+  podLabels: {}
+
+# ──────────────────────────────────────────────────
+# Pod-level configuration
+# ──────────────────────────────────────────────────
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false  # uvicorn + pip occasionally write tmp files
+
+# ──────────────────────────────────────────────────
+# ServiceAccount
+# ──────────────────────────────────────────────────
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# ──────────────────────────────────────────────────
+# Autoscaling
+# ──────────────────────────────────────────────────
+# Off by default. When enabling, remember the connection-budget math —
+# every additional replica adds ~15 Postgres connections under burst.
+# At higher replica counts add a transaction-mode PgBouncer in front of
+# Postgres rather than raising max_connections indefinitely.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: ~
+
+# ──────────────────────────────────────────────────
+# PodDisruptionBudget
+# ──────────────────────────────────────────────────
+# Off by default — only meaningful with replicaCount > 1.
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# ──────────────────────────────────────────────────
+# Scheduling
+# ──────────────────────────────────────────────────
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []


### PR DESCRIPTION
## Summary

Closes the v0.7 roadmap item for an in-tree Helm chart. API-only by design.

- New chart at [`helm/statewave/`](helm/statewave/) — Chart.yaml, values.yaml (every knob documented inline), templates for Deployment, Service, ServiceAccount, Secret, Ingress (off), HPA (off), PDB (off), and the migration Job.
- Schema migrations run as a Helm **pre-install + pre-upgrade Job** (`alembic upgrade head`). The Deployment never serves traffic against an out-of-date schema, and replicas no longer race the migration on startup.
- The Deployment **bypasses `start.sh`** and runs `uvicorn` directly. Each pod is a clean stateless API process — no boot-time docs bootstrap or support-pack auto-update unless explicitly enabled (`supportPack.autoUpdate=false` by default for self-hosted operators, since the bundled docs pack is statewave.ai-specific content).
- Two credential patterns: inline values (chart-managed `<release>-credentials` Secret) for dev, or `existingSecret` references for production secret-manager integration. When all three credentials (`database`, `llm`, `auth`) are externalised, no chart-managed Secret is rendered.
- Probes wired to `/healthz` (liveness) and `/readyz` (readiness) with a `failureThreshold: 6` that survives a single DB flap without cycling the pod.
- `.dockerignore` excludes `helm/` from the API image build context — the chart is for k8s deploys, not for the runtime image.

## Scope explicitly excluded

| Excluded | Why |
|---|---|
| Bundled Postgres | Lifecycle (backups, PITR, vacuum tuning) doesn't belong inside an application chart. Operators bring their own pgvector-capable instance. |
| Admin console (`statewave-admin`) | Separate deployable with its own auth surface; bundle it via a separate chart or overlay. |
| Self-hosted model server (vLLM / Ollama / TEI) | GPU scheduling + its own runbook live in their own chart. |
| NetworkPolicy | Cluster-wide policy is operator-defined; the chart would be either too permissive or too restrictive for any given environment. |

## Validation

- `helm lint helm/statewave` → clean (1 chart linted, 0 failed).
- `helm template` rendered across four scenarios:
  1. Minimal inline credentials → 5 resources (SA, Secret, Service, Deployment, migrate Job).
  2. All-external secrets → 4 resources (no chart-managed Secret as expected).
  3. Autoscaling + Ingress + PDB + `replicaCount=3` → 8 resources (HPA, Ingress, PDB all rendered).
  4. Full env-block path with webhooks + multi-tenant + custom rate-limit → all conditional `STATEWAVE_*` env vars rendered correctly with valid `secretKeyRef` wiring.
- All 8 rendered manifests in scenario 3 parse as valid YAML.

## Companion docs

A full deployment guide (`deployment/kubernetes.md` in `statewave-docs`, with the roadmap tick-off and cross-links from `sizing.md` / `horizontal-scaling.md`) is the follow-on PR.

## Test plan

- [ ] `helm lint helm/statewave` (clean)
- [ ] `helm template smoke helm/statewave --set database.url='…' --set llm.apiKey='…'` produces valid manifests
- [ ] Install against a kind/minikube cluster with a real pgvector-capable Postgres reachable; verify the migration Job runs to completion before the Deployment becomes Ready
- [ ] Upgrade the release with a new image tag; verify the pre-upgrade Job runs again
- [ ] Toggle `existingSecret` paths and confirm no chart-managed Secret is created
- [ ] Toggle `ingress.enabled=true` with realistic timeouts; verify `/v1/context` does not 504 on cold starts