### PR TITLE
feat(memory): per-kind TTL with retrieval filter + cleanup tombstoning (v0.7)

### DIFF
--- a/alembic/versions/0016_memory_status_tombstoned.py
+++ b/alembic/versions/0016_memory_status_tombstoned.py
@@ -1,0 +1,50 @@
+"""memories.status — rename `deleted` to `tombstoned` (defensive)
+
+Revision ID: 0016_memory_status_tombstoned
+Revises: 0015_episode_occurred_at
+Create Date: 2026-05-10
+
+The Python `MemoryStatus` enum had three values until v0.7:
+`active | superseded | deleted`. The `deleted` value was aspirational —
+no code path ever wrote it (grep across the v0.6.0 codebase confirmed
+this) — so this migration is **almost** a no-op for any real deployment.
+
+It is shipped anyway because:
+
+  1. **Defence against external writers.** The status column is a plain
+     `String(32)` (no DB-level enum constraint), so anything writing to
+     `memories.status` outside our service code — a manual SQL fix-up,
+     a third-party importer, an old branch — could have stamped
+     `'deleted'` in the wild. This migration normalises any such row
+     to the new `'tombstoned'` value the v0.7 TTL cleanup uses.
+  2. **Vocabulary alignment with issue #49.** State-assembly receipts
+     specify `supersession_status: active | superseded | tombstoned`.
+     Renaming now means we never have to migrate a value later when
+     receipts ship.
+  3. **Visible breadcrumb.** Future readers tracing why the enum value
+     changed land on this migration's commit + docstring instead of
+     having to chase a rename across the codebase.
+
+Reverse-compatible: the downgrade flips `'tombstoned'` rows back to
+`'deleted'`. v0.7 introduces `tombstoned` for TTL-expired memories so
+running the downgrade on a TTL-active deployment will lose the
+distinction between "never expired" and "actively tombstoned by TTL"
+— operators rolling back should disable TTL first
+(`STATEWAVE_KIND_TTL_DAYS=''`) to keep the inverse meaningful.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0016_memory_status_tombstoned"
+down_revision: Union[str, None] = "0015_episode_occurred_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE memories SET status = 'tombstoned' WHERE status = 'deleted'")
+
+
+def downgrade() -> None:
+    op.execute("UPDATE memories SET status = 'deleted' WHERE status = 'tombstoned'")

--- a/server/app.py
+++ b/server/app.py
@@ -33,9 +33,11 @@ def get_app_version() -> str:
 
 async def _cleanup_loop():
     """Periodically clean up stale ephemeral demo subjects and old compile jobs."""
+    from server.db.engine import get_session_factory
     from server.services.snapshots import cleanup_ephemeral_subjects
     from server.services.compile_jobs_durable import cleanup_old_jobs
     from server.services.ratelimit import cleanup_expired_windows
+    from server.services.memory_ttl import cleanup_expired_memories
 
     while True:
         await asyncio.sleep(3600)  # every hour
@@ -62,6 +64,20 @@ async def _cleanup_loop():
             except Exception as exc:
                 logger.warning("rate_limit_cleanup_error", error=str(exc))
 
+        # Memory TTL — backstop tombstoning of expired memories. Retrieval
+        # already filters `valid_to <= now()` rows out, so this loop is
+        # not on the hot path; it just transitions stale rows to the
+        # `tombstoned` status that the receipts surface (issue #49) reads.
+        if settings.kind_ttl_days:
+            try:
+                async with get_session_factory()() as session:
+                    tombstoned = await cleanup_expired_memories(session)
+                    await session.commit()
+                if tombstoned:
+                    logger.info("memory_ttl_cleanup_done", tombstoned=tombstoned)
+            except Exception as exc:
+                logger.warning("memory_ttl_cleanup_error", error=str(exc))
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -73,12 +89,13 @@ async def lifespan(app: FastAPI):
     webhooks.configure(url=settings.webhook_url, timeout=settings.webhook_timeout)
     await webhooks.start_worker()
 
-    # Start background cleanup (snapshots + compile job retention + rate limit)
+    # Start background cleanup (snapshots + compile job retention + rate limit + memory TTL)
     cleanup_task = None
     needs_cleanup = (
         settings.enable_snapshots
         or settings.compile_job_retention_hours > 0
         or (settings.rate_limit_rpm > 0 and settings.rate_limit_strategy == "distributed")
+        or bool(settings.kind_ttl_days)
     )
     if needs_cleanup:
         cleanup_task = asyncio.create_task(_cleanup_loop())

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -1,5 +1,10 @@
 """Application configuration via environment variables."""
 
+from __future__ import annotations
+
+import json
+
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -64,6 +69,69 @@ class Settings(BaseSettings):
 
     # Compile job retention (hours, 0 = no cleanup)
     compile_job_retention_hours: int = 168  # 7 days
+
+    # ── Memory TTL / expiry policies ────────────────────────────────
+    # Per-kind expiry windows. Keys are MemoryKind values
+    # ("profile_fact", "episode_summary", "procedure", "artifact_ref");
+    # values are positive integers (days). Memories of a configured kind
+    # get `valid_to = valid_from + days` stamped on insert; the cleanup
+    # loop tombstones any active memory whose `valid_to` has passed,
+    # and `/v1/context` retrieval filters out unexpired-but-not-yet-
+    # cleaned-up rows so the bound is enforced even between cleanup runs.
+    #
+    # Empty dict (default) = no expiry for any kind (backwards compatible).
+    # Missing kind = no expiry for that kind (a kind not listed is forever).
+    # Per-subject / per-tenant TTL policies are out of scope for v0.7
+    # — they belong to the policy layer (issue #50). v0.7 ships per-kind
+    # globals only so the simple primitive lands first.
+    #
+    # Set via env: STATEWAVE_KIND_TTL_DAYS='{"episode_summary":30,"artifact_ref":7}'
+    kind_ttl_days: dict[str, int] = Field(default_factory=dict)
+
+    @field_validator("kind_ttl_days", mode="before")
+    @classmethod
+    def _parse_kind_ttl_days(cls, value):
+        """Accept either a real dict (in-process construction / test fixtures)
+        or a JSON-encoded string (the env-var path). Reject anything else
+        eagerly so misconfiguration surfaces at startup, not at first
+        memory insert."""
+        if value is None or value == "":
+            return {}
+        if isinstance(value, dict):
+            parsed = value
+        elif isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"STATEWAVE_KIND_TTL_DAYS is not valid JSON: {exc.msg}"
+                ) from exc
+            if not isinstance(parsed, dict):
+                raise ValueError(
+                    "STATEWAVE_KIND_TTL_DAYS must decode to a JSON object "
+                    f"(got {type(parsed).__name__})"
+                )
+        else:
+            raise ValueError(
+                f"STATEWAVE_KIND_TTL_DAYS must be a dict or JSON string, got {type(value).__name__}"
+            )
+        # Normalise + validate values. Reject zero / negative explicitly
+        # — a zero-day TTL is almost certainly an operator mistake; the
+        # right way to disable expiry for a kind is to leave it out of
+        # the dict entirely.
+        clean: dict[str, int] = {}
+        for kind, days in parsed.items():
+            if not isinstance(days, int) or isinstance(days, bool):
+                raise ValueError(
+                    f"STATEWAVE_KIND_TTL_DAYS[{kind!r}] must be an integer, got {type(days).__name__}"
+                )
+            if days <= 0:
+                raise ValueError(
+                    f"STATEWAVE_KIND_TTL_DAYS[{kind!r}] must be > 0; "
+                    "remove the kind from the dict to disable expiry for it."
+                )
+            clean[str(kind)] = days
+        return clean
 
     # Webhooks (empty = disabled)
     webhook_url: str | None = None

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import uuid
 from typing import Sequence
 
-from sqlalchemy import delete, func, select, text, update
+from sqlalchemy import delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.db.tables import (
@@ -20,6 +20,21 @@ from server.db.tables import (
     ResolutionRow,
     SubjectHealthCacheRow,
 )
+
+
+def _unexpired(stmt):
+    """Restrict a Memory query to rows whose `valid_to` has not passed.
+
+    Memories with a NULL `valid_to` are forever-valid (no TTL configured
+    for their kind, no conflict-supersession deadline). Memories with a
+    `valid_to` in the future are still authoritative. Memories whose
+    `valid_to` has passed are excluded — even if the hourly TTL cleanup
+    pass has not yet tombstoned them, so retrieval honours the bound
+    immediately on expiry instead of waiting up to an hour for the
+    backstop sweep. See `server.services.memory_ttl` for the cleanup
+    side and the v0.7 memory-TTL design notes.
+    """
+    return stmt.where(or_(MemoryRow.valid_to.is_(None), MemoryRow.valid_to > func.now()))
 
 
 def _tenant_filter(stmt, column, tenant_id: str | None):
@@ -142,6 +157,7 @@ async def search_memories(
         .where(MemoryRow.subject_id == subject_id)
         .where(MemoryRow.status == "active")
     )
+    stmt = _unexpired(stmt)
     stmt = _tenant_filter(stmt, MemoryRow.tenant_id, tenant_id)
     if kind:
         stmt = stmt.where(MemoryRow.kind == kind)
@@ -194,6 +210,7 @@ async def list_active_memories_by_subject(
         .order_by(MemoryRow.created_at.asc())
         .limit(limit)
     )
+    stmt = _unexpired(stmt)
     stmt = _tenant_filter(stmt, MemoryRow.tenant_id, tenant_id)
     result = await session.execute(stmt)
     return result.scalars().all()
@@ -246,6 +263,7 @@ async def search_memories_by_embedding(
         .where(MemoryRow.status == "active")
         .where(MemoryRow.embedding.isnot(None))
     )
+    stmt = _unexpired(stmt)
     stmt = _tenant_filter(stmt, MemoryRow.tenant_id, tenant_id)
     if kind:
         stmt = stmt.where(MemoryRow.kind == kind)

--- a/server/domain/models.py
+++ b/server/domain/models.py
@@ -25,7 +25,13 @@ class MemoryKind(str, Enum):
 class MemoryStatus(str, Enum):
     active = "active"
     superseded = "superseded"
-    deleted = "deleted"
+    # `tombstoned` matches the vocabulary that issue #49
+    # (state-assembly receipts) expects to surface in the receipt's
+    # `supersession_status` field. The previous value was `deleted` —
+    # an aspirational hard-delete state that was never wired up; the
+    # rename happened with the v0.7 memory-TTL work which uses this
+    # status as the soft-tombstone target for expired memories.
+    tombstoned = "tombstoned"
 
 
 # ---------------------------------------------------------------------------

--- a/server/services/compilers/heuristic.py
+++ b/server/services/compilers/heuristic.py
@@ -14,7 +14,9 @@ import uuid
 from datetime import datetime, timezone
 from typing import Sequence
 
+from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
+from server.services.memory_ttl import compute_valid_to
 
 
 class HeuristicCompiler:
@@ -32,6 +34,9 @@ class HeuristicCompiler:
         if not text:
             return results
 
+        ttl = settings.kind_ttl_days
+        ep_valid_from = ep.created_at or datetime.now(timezone.utc)
+
         # Episode summary
         results.append(
             MemoryRow(
@@ -41,7 +46,8 @@ class HeuristicCompiler:
                 content=text[:500],
                 summary=text[:200],
                 confidence=0.8,
-                valid_from=ep.created_at or datetime.now(timezone.utc),
+                valid_from=ep_valid_from,
+                valid_to=compute_valid_to("episode_summary", ep_valid_from, ttl),
                 source_episode_ids=[ep.id],
                 metadata_={},
                 status="active",
@@ -58,7 +64,8 @@ class HeuristicCompiler:
                     content=fact,
                     summary=fact[:200],
                     confidence=0.6,
-                    valid_from=ep.created_at or datetime.now(timezone.utc),
+                    valid_from=ep_valid_from,
+                    valid_to=compute_valid_to("profile_fact", ep_valid_from, ttl),
                     source_episode_ids=[ep.id],
                     metadata_={},
                     status="active",

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -28,9 +28,11 @@ from typing import Any, Sequence
 
 import structlog
 
+from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
 from server.services import llm as llm_adapter
 from server.services.compilers.heuristic import extract_payload_text
+from server.services.memory_ttl import compute_valid_to
 
 logger = structlog.stdlib.get_logger()
 
@@ -216,6 +218,7 @@ class LLMCompiler:
                 else:
                     summary = str(raw_summary)[:200] if raw_summary else content[:200]
 
+                ep_valid_from = source_ep.created_at or datetime.now(timezone.utc)
                 results.append(
                     MemoryRow(
                         id=uuid.uuid4(),
@@ -224,7 +227,8 @@ class LLMCompiler:
                         content=content,
                         summary=summary,
                         confidence=min(max(float(mem.get("confidence", 0.7)), 0.0), 1.0),
-                        valid_from=source_ep.created_at or datetime.now(timezone.utc),
+                        valid_from=ep_valid_from,
+                        valid_to=compute_valid_to(kind, ep_valid_from, settings.kind_ttl_days),
                         source_episode_ids=[source_ep.id],
                         metadata_={"compiler": "llm", "model": self._model},
                         status="active",

--- a/server/services/memory_ttl.py
+++ b/server/services/memory_ttl.py
@@ -1,0 +1,86 @@
+"""Memory TTL / expiry — per-kind global expiry windows.
+
+Two responsibilities:
+
+  1. **Stamp** `valid_to` on freshly-compiled memories whose kind has an
+     operator-configured TTL. Called from each compiler (heuristic + LLM)
+     at the single point where `MemoryRow` is constructed.
+
+  2. **Tombstone** active memories whose `valid_to` has passed. Called
+     from the hourly `_cleanup_loop` in `server.app`. Soft-delete only:
+     rows are kept so the source data is still resolvable for audit and
+     for the receipts surface (issue #49). A future hard-purge knob
+     (post-v0.7) can reclaim storage on tombstoned rows older than a
+     grace window.
+
+The retrieval path in `server.db.repositories` independently filters
+`(valid_to IS NULL OR valid_to > now())` so an expired-but-not-yet-
+cleaned-up memory still cannot surface in `/v1/context` between cleanup
+runs. The cleanup loop is a backstop, not the load-bearing fence.
+
+Per-subject / per-tenant TTL policies are intentionally out of scope
+here — that's the policy layer in issue #50. v0.7 ships per-kind
+globals only so the simple primitive lands first; the policy layer
+will eventually subsume this with a richer expression and treat this
+module's per-kind windows as the default-fallback rule.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Mapping
+
+import structlog
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.db.tables import MemoryRow
+
+logger = structlog.stdlib.get_logger()
+
+
+def compute_valid_to(
+    kind: str,
+    valid_from: datetime,
+    kind_ttl_days: Mapping[str, int],
+) -> datetime | None:
+    """Return the `valid_to` to stamp on a fresh memory of `kind`.
+
+    Returns `None` when the kind has no TTL configured (forever-valid),
+    matching the existing semantics of `MemoryRow.valid_to`. Returns
+    `valid_from + ttl_days` otherwise.
+
+    The function is pure / side-effect-free and does not consult global
+    settings — callers pass the dict explicitly so tests can construct
+    isolated scenarios without monkey-patching the settings singleton.
+    """
+    days = kind_ttl_days.get(kind)
+    if not days:
+        return None
+    if valid_from.tzinfo is None:
+        valid_from = valid_from.replace(tzinfo=timezone.utc)
+    return valid_from + timedelta(days=days)
+
+
+async def cleanup_expired_memories(session: AsyncSession) -> int:
+    """Tombstone active memories whose `valid_to` has passed.
+
+    Single statement — atomic, replica-safe (multiple cleanup loops
+    running against the same DB just write the same idempotent UPDATE).
+    Returns the number of rows transitioned. Soft-tombstone only:
+    `status = 'tombstoned'`, no `DELETE`, the row stays.
+
+    Caller is responsible for committing the session.
+    """
+    stmt = (
+        update(MemoryRow)
+        .where(MemoryRow.status == "active")
+        .where(MemoryRow.valid_to.isnot(None))
+        .where(MemoryRow.valid_to < datetime.now(timezone.utc))
+        .values(status="tombstoned")
+    )
+    result = await session.execute(stmt)
+    count = result.rowcount or 0
+    if count:
+        logger.info("memory_ttl_tombstoned", count=count)
+    return count

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0015_episode_occurred_at"
+EXPECTED_HEAD = "0016_memory_status_tombstoned"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/tests/integration/test_memory_ttl.py
+++ b/tests/integration/test_memory_ttl.py
@@ -1,0 +1,210 @@
+"""Integration tests for memory TTL — DB-backed cleanup + retrieval-filter behaviour.
+
+Unit-level coverage (config parsing, compute_valid_to, compiler stamping) lives
+in `tests/test_memory_ttl.py`.
+
+The load-bearing test in this file is `test_retrieval_excludes_expired_pre_cleanup`:
+it asserts the invariant the v0.7 TTL design is built around — an expired memory
+must not reach `/v1/context` even between the hourly cleanup runs. That's the
+analog of the negative test issue #49 (state-assembly receipts) calls out:
+"Stale fact selected for a current query (`valid_to` passed)".
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+
+from server.db.tables import MemoryRow
+from server.services.memory_ttl import cleanup_expired_memories
+
+
+# ---------------------------------------------------------------------------
+# Helpers — insert a memory directly via the session factory so the test
+# controls valid_to precisely (compiling through the API would stamp valid_to
+# from settings.kind_ttl_days which we'd then have to monkey-patch on the
+# live FastAPI process — clunkier than the direct insert).
+# ---------------------------------------------------------------------------
+
+
+async def _insert_memory(
+    session_factory,
+    *,
+    subject_id: str,
+    valid_to: datetime | None,
+    status: str = "active",
+    kind: str = "episode_summary",
+    content: str = "TTL integration probe",
+) -> uuid.UUID:
+    memory_id = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(
+            MemoryRow(
+                id=memory_id,
+                subject_id=subject_id,
+                kind=kind,
+                content=content,
+                summary=content[:200],
+                confidence=0.9,
+                valid_from=datetime.now(timezone.utc) - timedelta(days=1),
+                valid_to=valid_to,
+                source_episode_ids=[],
+                metadata_={},
+                status=status,
+            )
+        )
+        await session.commit()
+    return memory_id
+
+
+# ---------------------------------------------------------------------------
+# cleanup_expired_memories — backstop tombstoning behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cleanup_tombstones_expired_active_memory(session_factory, subject_id: str):
+    past = datetime.now(timezone.utc) - timedelta(hours=1)
+    memory_id = await _insert_memory(session_factory, subject_id=subject_id, valid_to=past)
+
+    async with session_factory() as session:
+        count = await cleanup_expired_memories(session)
+        await session.commit()
+    assert count >= 1
+
+    async with session_factory() as session:
+        row = await session.get(MemoryRow, memory_id)
+        assert row is not None
+        assert row.status == "tombstoned"
+
+
+@pytest.mark.anyio
+async def test_cleanup_leaves_unexpired_memory_alone(session_factory, subject_id: str):
+    future = datetime.now(timezone.utc) + timedelta(days=7)
+    memory_id = await _insert_memory(session_factory, subject_id=subject_id, valid_to=future)
+
+    async with session_factory() as session:
+        await cleanup_expired_memories(session)
+        await session.commit()
+
+    async with session_factory() as session:
+        row = await session.get(MemoryRow, memory_id)
+        assert row is not None
+        assert row.status == "active"
+
+
+@pytest.mark.anyio
+async def test_cleanup_leaves_null_valid_to_alone(session_factory, subject_id: str):
+    memory_id = await _insert_memory(session_factory, subject_id=subject_id, valid_to=None)
+
+    async with session_factory() as session:
+        await cleanup_expired_memories(session)
+        await session.commit()
+
+    async with session_factory() as session:
+        row = await session.get(MemoryRow, memory_id)
+        assert row is not None
+        assert row.status == "active"
+
+
+@pytest.mark.anyio
+async def test_cleanup_leaves_already_tombstoned_alone(session_factory, subject_id: str):
+    # Idempotency: re-running cleanup should not re-touch already-tombstoned rows.
+    past = datetime.now(timezone.utc) - timedelta(days=1)
+    memory_id = await _insert_memory(
+        session_factory, subject_id=subject_id, valid_to=past, status="tombstoned"
+    )
+
+    async with session_factory() as session:
+        count = await cleanup_expired_memories(session)
+        await session.commit()
+    assert count == 0  # nothing to do — already tombstoned
+
+    async with session_factory() as session:
+        row = await session.get(MemoryRow, memory_id)
+        assert row.status == "tombstoned"
+
+
+@pytest.mark.anyio
+async def test_cleanup_leaves_superseded_alone(session_factory, subject_id: str):
+    # Superseded memories carry valid_to from the conflict-resolution path;
+    # they must not be re-stamped as tombstoned (semantics differ — superseded
+    # is "replaced by a newer fact", tombstoned is "expired by TTL").
+    past = datetime.now(timezone.utc) - timedelta(days=1)
+    memory_id = await _insert_memory(
+        session_factory, subject_id=subject_id, valid_to=past, status="superseded"
+    )
+
+    async with session_factory() as session:
+        await cleanup_expired_memories(session)
+        await session.commit()
+
+    async with session_factory() as session:
+        row = await session.get(MemoryRow, memory_id)
+        assert row.status == "superseded"
+
+
+# ---------------------------------------------------------------------------
+# Retrieval — the load-bearing #49 negative-test analog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_retrieval_excludes_expired_pre_cleanup(
+    client: AsyncClient, session_factory, subject_id: str
+):
+    """`/v1/context` must NOT surface a memory whose valid_to has passed,
+    even when the cleanup loop has not yet tombstoned it (status is still
+    'active'). This is the design-load-bearing fence — without it,
+    expired memories would pollute retrieval for up to one hour every
+    cycle, and #49 receipts would record stale facts as "selected"."""
+
+    # Active memory, but expired one hour ago. Cleanup hasn't run yet.
+    past = datetime.now(timezone.utc) - timedelta(hours=1)
+    expired_id = await _insert_memory(
+        session_factory,
+        subject_id=subject_id,
+        valid_to=past,
+        status="active",
+        kind="episode_summary",
+        content="EXPIRED-MEMORY-MARKER-DO-NOT-SURFACE",
+    )
+
+    # Fresh memory, also active, no TTL.
+    fresh_id = await _insert_memory(
+        session_factory,
+        subject_id=subject_id,
+        valid_to=None,
+        status="active",
+        kind="episode_summary",
+        content="FRESH-MEMORY-MARKER-SURFACE-ME",
+    )
+
+    resp = await client.post(
+        "/v1/context",
+        json={"subject_id": subject_id, "task": "any task"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+
+    surfaced = " ".join(
+        m.get("content", "") for m in body.get("episodes", []) + body.get("facts", [])
+    ) + body.get("assembled_context", "")
+
+    assert "EXPIRED-MEMORY-MARKER-DO-NOT-SURFACE" not in surfaced, (
+        "expired memory leaked into /v1/context — TTL retrieval filter is broken"
+    )
+    assert "FRESH-MEMORY-MARKER-SURFACE-ME" in surfaced, (
+        "fresh memory was incorrectly excluded — TTL retrieval filter is over-aggressive"
+    )
+
+    # Expired row is still present in the DB (soft-tombstone semantics —
+    # rows persist for issue #49 receipts to reference).
+    async with session_factory() as session:
+        expired_row = await session.get(MemoryRow, expired_id)
+        fresh_row = await session.get(MemoryRow, fresh_id)
+        assert expired_row is not None
+        assert fresh_row is not None

--- a/tests/test_memory_ttl.py
+++ b/tests/test_memory_ttl.py
@@ -1,0 +1,171 @@
+"""Unit tests for memory TTL — config parsing, valid_to computation, compiler stamping.
+
+DB-backed cleanup + retrieval-filter behaviour live in
+`tests/integration/test_memory_ttl.py`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from server.core.config import Settings
+from server.services.compilers.heuristic import HeuristicCompiler
+from server.services.memory_ttl import compute_valid_to
+
+
+# ---------------------------------------------------------------------------
+# compute_valid_to
+# ---------------------------------------------------------------------------
+
+
+def test_compute_valid_to_returns_none_when_kind_not_in_dict():
+    assert compute_valid_to("episode_summary", datetime.now(timezone.utc), {}) is None
+
+
+def test_compute_valid_to_returns_none_when_dict_value_is_zero():
+    # Defence in depth — the config validator rejects 0/negative, but the
+    # compute function should also be safe if someone bypasses the validator.
+    assert (
+        compute_valid_to("episode_summary", datetime.now(timezone.utc), {"episode_summary": 0})
+        is None
+    )
+
+
+def test_compute_valid_to_adds_days_when_kind_configured():
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    result = compute_valid_to("episode_summary", base, {"episode_summary": 30})
+    assert result == base + timedelta(days=30)
+
+
+def test_compute_valid_to_upgrades_naive_datetime_to_utc():
+    naive = datetime(2026, 1, 1, 12, 0, 0)  # no tzinfo
+    result = compute_valid_to("episode_summary", naive, {"episode_summary": 7})
+    assert result is not None
+    assert result.tzinfo is timezone.utc
+
+
+def test_compute_valid_to_only_affects_listed_kind():
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    ttl = {"episode_summary": 7}
+    assert compute_valid_to("episode_summary", base, ttl) == base + timedelta(days=7)
+    assert compute_valid_to("profile_fact", base, ttl) is None
+
+
+# ---------------------------------------------------------------------------
+# Settings.kind_ttl_days validator
+# ---------------------------------------------------------------------------
+
+
+def test_settings_kind_ttl_days_defaults_to_empty_dict():
+    s = Settings(_env_file=None)
+    assert s.kind_ttl_days == {}
+
+
+def test_settings_kind_ttl_days_accepts_dict_value():
+    s = Settings(_env_file=None, kind_ttl_days={"episode_summary": 30})
+    assert s.kind_ttl_days == {"episode_summary": 30}
+
+
+def test_settings_kind_ttl_days_parses_json_string():
+    # The env-var path delivers strings; the validator must JSON-decode.
+    s = Settings(_env_file=None, kind_ttl_days='{"episode_summary": 30, "profile_fact": 365}')
+    assert s.kind_ttl_days == {"episode_summary": 30, "profile_fact": 365}
+
+
+def test_settings_kind_ttl_days_empty_string_is_empty_dict():
+    s = Settings(_env_file=None, kind_ttl_days="")
+    assert s.kind_ttl_days == {}
+
+
+def test_settings_kind_ttl_days_rejects_invalid_json():
+    with pytest.raises(ValueError, match="not valid JSON"):
+        Settings(_env_file=None, kind_ttl_days="{not json")
+
+
+def test_settings_kind_ttl_days_rejects_non_object_json():
+    with pytest.raises(ValueError, match="must decode to a JSON object"):
+        Settings(_env_file=None, kind_ttl_days="[1, 2, 3]")
+
+
+def test_settings_kind_ttl_days_rejects_zero_or_negative_days():
+    # Disabling expiry for a kind = leave it out of the dict, not 0.
+    with pytest.raises(ValueError, match="must be > 0"):
+        Settings(_env_file=None, kind_ttl_days={"episode_summary": 0})
+    with pytest.raises(ValueError, match="must be > 0"):
+        Settings(_env_file=None, kind_ttl_days={"episode_summary": -1})
+
+
+def test_settings_kind_ttl_days_rejects_non_integer_days():
+    with pytest.raises(ValueError, match="must be an integer"):
+        Settings(_env_file=None, kind_ttl_days={"episode_summary": "30"})
+    with pytest.raises(ValueError, match="must be an integer"):
+        Settings(_env_file=None, kind_ttl_days={"episode_summary": 30.5})
+
+
+# ---------------------------------------------------------------------------
+# Heuristic compiler — TTL stamping at memory creation
+# ---------------------------------------------------------------------------
+
+
+def _make_episode(payload: dict, subject_id: str = "user-ttl"):
+    from server.db.tables import EpisodeRow
+
+    return EpisodeRow(
+        id=uuid.uuid4(),
+        subject_id=subject_id,
+        source="test",
+        type="conversation",
+        payload=payload,
+        metadata_={},
+        provenance={},
+        created_at=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def test_heuristic_compiler_stamps_valid_to_when_kind_has_ttl(monkeypatch):
+    # The compiler reads settings.kind_ttl_days at invocation time. Monkey-
+    # patch the live singleton — Settings() doesn't have a setter for
+    # kind_ttl_days at runtime, but the attribute is mutable.
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "kind_ttl_days", {"episode_summary": 30})
+
+    ep = _make_episode({"text": "Hello, this is a test message."})
+    memories = HeuristicCompiler().compile([ep])
+
+    summaries = [m for m in memories if m.kind == "episode_summary"]
+    assert summaries, "expected at least one episode_summary memory"
+    expected = ep.created_at + timedelta(days=30)
+    for m in summaries:
+        assert m.valid_to == expected
+
+
+def test_heuristic_compiler_leaves_valid_to_none_when_kind_not_in_ttl(monkeypatch):
+    from server.core.config import settings
+
+    # Configure TTL only for episode_summary; profile_fact must stay None.
+    monkeypatch.setattr(settings, "kind_ttl_days", {"episode_summary": 30})
+
+    ep = _make_episode(
+        {"messages": [{"role": "user", "content": "My name is Alice and I work at Acme."}]}
+    )
+    memories = HeuristicCompiler().compile([ep])
+    facts = [m for m in memories if m.kind == "profile_fact"]
+    assert facts, "expected at least one profile_fact memory"
+    for m in facts:
+        assert m.valid_to is None
+
+
+def test_heuristic_compiler_no_ttl_config_leaves_valid_to_none(monkeypatch):
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "kind_ttl_days", {})
+
+    ep = _make_episode({"text": "Plain content."})
+    memories = HeuristicCompiler().compile([ep])
+    assert memories, "expected at least one memory"
+    for m in memories:
+        assert m.valid_to is None

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 15
+    assert len(revs) == 16
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 5
+    assert result.pending_count == 6
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 15
+    assert result.pending_count == 16
 
 
 def test_resolve_pending_unknown_revision():


### PR DESCRIPTION
## Summary

Closes the last v0.7 roadmap item: **per-kind global memory expiry**. Operators set a JSON env var → the compiler stamps `valid_to = valid_from + ttl_days` on insert → retrieval filters expired rows out of `/v1/context` immediately → an hourly cleanup pass tombstones expired rows so the status surface stays current.

## Coordination with #49 / #50

The design was held to four constraints so this lands without owing a future migration when those issues ship:

1. **Status vocabulary matches [#49](https://github.com/smaramwbc/statewave/issues/49)** — `MemoryStatus` is now `active | superseded | tombstoned`. The previous enum value `deleted` was aspirational and never written by any code path; renamed to `tombstoned` (with defensive alembic 0016 to migrate any stray rows). Receipts can read this field without a vocabulary translation step.
2. **`valid_to` is shared infra** — the field already existed for conflict resolution. TTL writes to the same column with the same semantic ("no longer authoritative as of T"). Conflict resolution and TTL coexist without conflict; superseded memories are not re-stamped as tombstoned.
3. **Expiry filter at query time, not just in the cleanup loop** — `repositories._unexpired` filters `(valid_to IS NULL OR valid_to > now())` on all three user-facing memory fetches (`search_memories`, `search_memories_by_embedding`, `list_active_memories_by_subject`). The retrieval fence is the load-bearing constraint; cleanup is the backstop. Without this, the [#49](https://github.com/smaramwbc/statewave/issues/49) negative test "stale fact selected for a current query" would fire spuriously between hourly cleanup runs.
4. **Per-kind global env-var only** — per-subject / per-tenant / per-policy expiry rules belong to the [#50](https://github.com/smaramwbc/statewave/issues/50) policy layer. This PR ships the simple primitive so it composes cleanly: when #50 lands, the policy layer subsumes per-memory expiry decisions, and these per-kind windows degrade to the default-fallback rule.

## Config surface

```bash
STATEWAVE_KIND_TTL_DAYS='{"episode_summary":30,"profile_fact":365}'
```

- Empty / unset = no expiry for any kind (backwards compatible)
- Keys not listed default to no expiry
- Zero / negative values rejected by the validator (disabling expiry for a kind = leave it out of the dict)
- Validator at startup, not at first memory insert — misconfiguration surfaces loudly

## What changes vs. what doesn't

**Changes:**
- New `server/services/memory_ttl.py` — `compute_valid_to` (pure helper, takes the dict explicitly so tests don't need to monkey-patch the singleton) + `cleanup_expired_memories` (single atomic UPDATE).
- `MemoryStatus.deleted` → `MemoryStatus.tombstoned` (Python enum + alembic 0016 data-safety migration).
- Three memory retrieval functions in `server/db/repositories.py` get an `_unexpired()` filter helper.
- Both compilers (`heuristic.py`, `llm.py`) call `compute_valid_to` when constructing `MemoryRow`.
- `_cleanup_loop` in `server/app.py` gets a TTL pass; lifespan gate now enables when `kind_ttl_days` is non-empty.
- `EXPECTED_HEAD` bumped to `0016_memory_status_tombstoned`; migration-count assertions in `tests/test_migrations.py` adjusted (15 → 16).

**Does NOT change** (deliberately):
- Restore paths (snapshots, backup, memory packs) preserve original `valid_to` from snapshot data — they don't invoke `compute_valid_to`. Re-stamping at restore time would change semantics.
- Admin / operator views don't get the `_unexpired` filter — operators want to see expired memories for diagnostics.
- Hard-delete of tombstoned rows — soft-tombstone only in v0.7. Storage reclamation is a separate post-v0.7 knob (the rows persist for #49 receipts to reference).
- Conflict-resolution semantics — superseded memories continue to use `status = "superseded"`, untouched by TTL cleanup.

## Test results

| Suite | Result |
|---|---|
| `tests/test_memory_ttl.py` (new, 16 tests) | ✅ all pass |
| `tests/integration/test_memory_ttl.py` (new, 6 tests) | ✅ all pass — including the load-bearing `test_retrieval_excludes_expired_pre_cleanup` |
| Full unit suite (439 tests) | ✅ 439 pass, 1 skipped |
| Integration suite (90+ tests) | ✅ 86 pass; 4 failures (`test_search_filters_by_kind`, `test_list_subjects`, `test_async_compile_creates_memories`, `test_full_lifecycle`) **also fail on `origin/main`** with no TTL changes — pre-existing, not regressions caused by this PR |

The load-bearing test asserts the [#49](https://github.com/smaramwbc/statewave/issues/49) negative-test analog: an active memory whose `valid_to` has passed (cleanup hasn't run yet) MUST NOT surface in `/v1/context`. Without the retrieval filter, this would fail.

## Test plan

- [ ] Re-run unit + integration suites in CI
- [ ] Confirm pre-existing integration failures (4 listed above) are not introduced by this PR
- [ ] Spot-check the alembic migration: `alembic upgrade head` on a DB with no rows of `status = 'deleted'` is a no-op (it should be); on a DB with such rows they transition to `'tombstoned'`
- [ ] Smoke-set `STATEWAVE_KIND_TTL_DAYS='{"episode_summary":1}'` against a dev instance, ingest + compile, watch `valid_to` get stamped at +1 day