### PR TITLE
docs: refresh connector status table — Tier 2 push-receiver wave shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,13 @@ Statewave is not limited to live chat transcripts. **Connectors** feed real-worl
 | MCP server | Copilot / Claude / Cursor / agent memory | ✅ shipped |
 | GitHub | Issues, pull requests, reviews, releases → repo memory | ✅ shipped |
 | Markdown | Local docs, ADRs, RFCs → decision memory | ✅ shipped |
-| Slack | Channel + thread history → team memory | ✅ shipped |
+| Slack | Channel + thread history (pull) + Events-API webhook (push, with opt-in DMs and group DMs) → team memory | ✅ shipped |
 | n8n | Workflow runs, failures, per-node errors → workflow memory | ✅ shipped |
 | Zapier | "Webhooks by Zapier" → push-mode helper for any zap | ✅ shipped |
-| Discord | Community and team support memory | _planned_ |
-| Notion | Decision docs, architecture pages | _planned_ |
-| Zendesk / Intercom / Freshdesk | Customer support memory | _planned_ |
-| Gmail / email | Relationship and inbox memory | _planned_ |
+| Discord | Server channel + thread history → community memory | ✅ shipped |
+| Notion | Pages + opt-in body content + database scoping → decision memory | ✅ shipped |
+| Zendesk / Intercom / Freshdesk | Tickets + replies + notes (pull) and real-time webhook receivers (push) → customer memory | ✅ shipped |
+| Gmail | Query-scoped messages (pull, with History-API delta sync) and Cloud Pub/Sub push receiver → relationship memory | ✅ shipped |
 
 Connectors live in their own repository so this core stays focused on the runtime. They are **modular** — install only what you need:
 


### PR DESCRIPTION
## Summary

The README's connector status table marked six connectors as `_planned_` even though they all shipped in the [statewave-connectors ecosystem](https://github.com/smaramwbc/statewave-connectors). Mark them all shipped and enrich each row's memory-shape blurb to reflect what's actually on offer.

## Changes (single table row each)

- **Slack** — was just "Channel + thread history". Now mentions the Events-API webhook receiver (push) with opt-in DMs and group DMs (`slack.dm.*`, `slack.mpim.*`).
- **Discord** — was `_planned_` → `✅ shipped` (v0.2.1, server channel + thread history).
- **Notion** — was `_planned_` → `✅ shipped` (v0.4.3 + v0.6.0, pages + opt-in body content + database scoping).
- **Zendesk / Intercom / Freshdesk** — was `_planned_` → `✅ shipped`. Each ships pull mode (v0.4.0 / v0.4.1 / v0.4.2) plus a real-time webhook receiver from the v0.8/v0.9/v0.10 Tier 2 wave.
- **Gmail / email** — was `_planned_` → `✅ shipped` (v0.4.4 + Cloud Pub/Sub push in v0.11.0; History-API delta sync via `--cursor`).

## Test plan

- [x] No code changes
- [x] Single table edit; no link changes; no flow changes
- [x] CI green on this PR