### PR TITLE
feat: bi-temporal anchor + temporal-grounded compile + granular detail extraction + async-compile embedding backfill

### DIFF
--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -71,6 +71,18 @@ async def _run_compile(
             for row in new_rows:
                 await session.refresh(row)
 
+            # Backfill embeddings in the background. Without this the
+            # async compile path leaves every freshly-compiled memory
+            # with `embedding=NULL`, which silently breaks semantic
+            # retrieval (`search_memories(semantic=True)` returns 0,
+            # `assemble_context` falls back to lexical + heuristic
+            # ranking only). The sync compile route below already
+            # schedules this; the async route used to skip it.
+            schedule_embedding_backfill(
+                [row.id for row in new_rows],
+                [row.content for row in new_rows],
+            )
+
             await webhooks.fire(
                 "memories.compiled",
                 {

--- a/server/services/compilers/heuristic.py
+++ b/server/services/compilers/heuristic.py
@@ -35,7 +35,7 @@ class HeuristicCompiler:
             return results
 
         ttl = settings.kind_ttl_days
-        ep_valid_from = ep.created_at or datetime.now(timezone.utc)
+        ep_valid_from = episode_valid_from(ep)
 
         # Episode summary
         results.append(
@@ -73,6 +73,87 @@ class HeuristicCompiler:
             )
 
         return results
+
+
+# ---------------------------------------------------------------------------
+# Shared temporal anchor (usable by any compiler)
+# ---------------------------------------------------------------------------
+
+
+def episode_valid_from(ep: EpisodeRow) -> datetime:
+    """Return the best-effort temporal anchor for memories derived from
+    this episode.
+
+    Priority:
+      1. `payload.event_time` — explicit override set by the client
+         (e.g. a connector replaying historical data sets this to the
+         actual event date, not the POST date).
+      2. `payload.messages[0].timestamp` — the first-message timestamp
+         on chat-shaped payloads. This is what LoCoMo, Slack, Zendesk
+         etc emit naturally; preserving it as `valid_from` makes
+         "when did X happen?" answerable from the resulting memory.
+      3. `ep.created_at` — when the episode was POSTed (the previous
+         hardcoded default).
+      4. `now()` — last resort if everything else is missing.
+
+    Returning a real event time instead of the POST time keeps
+    Statewave's bi-temporal validity story honest: a memory whose
+    facts were true in May 2023 shouldn't carry `valid_from=today`.
+    """
+    payload = ep.payload or {}
+
+    explicit = payload.get("event_time")
+    if isinstance(explicit, str) and explicit:
+        parsed = _parse_event_time(explicit)
+        if parsed is not None:
+            return parsed
+
+    messages = payload.get("messages")
+    if isinstance(messages, list) and messages and isinstance(messages[0], dict):
+        ts = messages[0].get("timestamp")
+        if isinstance(ts, str) and ts:
+            parsed = _parse_event_time(ts)
+            if parsed is not None:
+                return parsed
+
+    return ep.created_at or datetime.now(timezone.utc)
+
+
+def _parse_event_time(value: str) -> datetime | None:
+    """Parse a small set of supported datetime formats. Returns None on
+    failure rather than raising — callers fall back to ep.created_at.
+
+    Supported:
+      - ISO 8601 (`2023-05-08T13:56:00`, `2023-05-08T13:56:00Z`,
+        `2023-05-08T13:56:00+00:00`)
+      - LoCoMo's idiomatic format (`1:56 pm on 8 May, 2023`)
+
+    Anything else returns None; we'd rather fall back than guess.
+    """
+    s = value.strip()
+    if not s:
+        return None
+
+    # ISO 8601 first — handles the connector / replay path.
+    try:
+        iso = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if iso.tzinfo is None:
+            iso = iso.replace(tzinfo=timezone.utc)
+        return iso
+    except ValueError:
+        pass
+
+    # LoCoMo format: "1:56 pm on 8 May, 2023". %I tolerates both
+    # zero-padded and single-digit hours on CPython; %d does the same
+    # for days. Returned datetime is naive — promote to UTC so it
+    # round-trips through Postgres's `timestamp with time zone` cleanly.
+    for fmt in ("%I:%M %p on %d %B, %Y", "%I:%M%p on %d %B, %Y"):
+        try:
+            return datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from datetime import datetime, timezone
 from typing import Any, Sequence
 
 import structlog
@@ -31,7 +30,7 @@ import structlog
 from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
 from server.services import llm as llm_adapter
-from server.services.compilers.heuristic import extract_payload_text
+from server.services.compilers.heuristic import episode_valid_from, extract_payload_text
 from server.services.memory_ttl import compute_valid_to
 
 logger = structlog.stdlib.get_logger()
@@ -40,7 +39,18 @@ logger = structlog.stdlib.get_logger()
 
 _MAX_BATCH_CHARS = 6000  # Max total chars per LLM call (leaves room for prompt + response)
 _MAX_CONCURRENCY = 4  # Max parallel LLM calls
-_MAX_TOKENS = 3000  # Response token limit per batch
+# Response token limit per batch. The old 3000 ceiling combined with a
+# 500-per-episode allocation produced two failure modes:
+#   - Single-episode batches got 500 tokens, far too tight for a dense
+#     conversation: the LLM emitted ~10 memories with content + summary,
+#     hit the cap mid-string, and acomplete_json's strict json.loads
+#     raised LLMResponseError. The whole batch was discarded.
+#   - Multi-episode batches got 500 * episode_count but capped at 3000,
+#     still tight for ~15+ memories per batch.
+# gpt-4o-mini supports 16K output tokens. 8000 leaves real headroom and
+# costs nothing extra (only used tokens are billed).
+_MAX_TOKENS = 8000  # Response token limit per batch
+_TOKENS_PER_EPISODE = 1500  # Per-episode allocation inside the cap
 
 _SYSTEM_PROMPT = """\
 You are a memory extraction engine for an AI context system called Statewave.
@@ -68,6 +78,7 @@ Rules:
 - If an episode contains no extractable memories, skip it.
 - Return ONLY the JSON array, no markdown fences or extra text.
 """
+
 
 class LLMCompiler:
     """Async LLM memory compiler with batching + parallelism. Implements BaseCompiler protocol.
@@ -218,7 +229,7 @@ class LLMCompiler:
                 else:
                     summary = str(raw_summary)[:200] if raw_summary else content[:200]
 
-                ep_valid_from = source_ep.created_at or datetime.now(timezone.utc)
+                ep_valid_from = episode_valid_from(source_ep)
                 results.append(
                     MemoryRow(
                         id=uuid.uuid4(),
@@ -245,8 +256,11 @@ class LLMCompiler:
         gives us provider portability plus standardized timeout/retry/error
         mapping.
         """
-        # Adjust max tokens based on batch size
-        max_tokens = min(_MAX_TOKENS, 500 * episode_count)
+        # Adjust max tokens based on batch size. 1500/episode is the
+        # empirical headroom for a dense LoCoMo session (~15 memories
+        # at ~100 tokens each); the _MAX_TOKENS ceiling stops absurdly
+        # large batches from blowing past gpt-4o-mini's 16K output cap.
+        max_tokens = min(_MAX_TOKENS, _TOKENS_PER_EPISODE * episode_count)
 
         try:
             parsed = await llm_adapter.acomplete_json(

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -77,6 +77,14 @@ Rules:
 - If an episode is mostly code or example data with no generalizable claims, return episode_summary describing what the section is about, not profile_facts cataloguing the example values.
 - If an episode contains no extractable memories, skip it.
 - Return ONLY the JSON array, no markdown fences or extra text.
+
+Temporal grounding:
+- If a message is prefixed with a bracketed timestamp like `[1:14 pm on 25 May, 2023]`, that timestamp marks WHEN the speaker said this — and by extension, when any event they describe in present/past tense happened.
+- For ANY memory you extract about a dated event, action, or state change (e.g. "ran a race", "attended a conference", "joined a group", "started a project", "moved cities", "got married"), the memory `content` MUST include the date.
+- Convert relative phrases against the message timestamp: "yesterday" -> the message timestamp minus 1 day; "last Saturday" -> the most recent Saturday before the message timestamp; "two days ago" -> message timestamp minus 2 days; "last year" -> the year before the message timestamp's year. Render the resolved date as ISO-like prose ("on 2023-05-24" or "on 24 May 2023") in the memory `content`.
+- If a message is itself stated as a present-tense event ("I'm running a charity race today"), use the message's own timestamp date.
+- If no timestamp is available and no absolute date is mentioned in the text, omit the date rather than guess.
+- This applies to BOTH profile_fact and episode_summary memories — a summary of a dated session should also lead with or include the session date.
 """
 
 

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -85,6 +85,19 @@ Temporal grounding:
 - If a message is itself stated as a present-tense event ("I'm running a charity race today"), use the message's own timestamp date.
 - If no timestamp is available and no absolute date is mentioned in the text, omit the date rather than guess.
 - This applies to BOTH profile_fact and episode_summary memories — a summary of a dated session should also lead with or include the session date.
+
+Granularity — extract DETAILS, not just headlines:
+- "Generalizable" does not mean "high-level". A specific concrete attribute about a subject IS a generalizable fact about them. "Melanie bought purple running shoes" is a valid profile_fact. "Caroline's favorite book is 'Becoming Nicole' by Amy Ellis Nutt" is a valid profile_fact. "Melanie's daughter's birthday is August 13" is a valid profile_fact.
+- Extract each of these as distinct memories when they appear in the source — DO NOT collapse them into a vague "Caroline likes books" or "Melanie is into running".
+- Specifically watch for and preserve:
+    * Concrete objects + their attributes (colors, brand names, materials: "purple running shoes", "hand-painted bowl", "necklace from grandma in Sweden")
+    * Motivations and reasons ("Melanie got into running to de-stress")
+    * Quantities, durations, ages ("4 years", "10 years ago", "two weekends ago")
+    * Specific titles, names, places ("'Becoming Nicole' by Amy Ellis Nutt", "Connected LGBTQ Activists", "lake sunrise")
+    * Stated preferences and feelings ("the support group made Caroline feel accepted")
+    * Relationships between people / things (who-mentors-whom, who-bought-what-for-whom)
+- A profile_fact about a person can be ONE specific item — don't wait to find "enough" to summarize.
+- Better to emit 30 concrete granular memories than 5 vague ones. The retrieval layer ranks them; the compiler's job is recall.
 """
 
 

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -768,11 +768,45 @@ def _short_episode_text(payload: dict, source: str, type_: str) -> str:
 
 
 def _render_memory_line(row: Any) -> str:
-    """Render a memory as a clean context line, appropriate for its kind."""
+    """Render a memory as a clean context line, appropriate for its kind.
+
+    Date prefix: every memory carries a `valid_from` (set by the compiler
+    from `payload.event_time` / `payload.messages[0].timestamp` /
+    `ep.created_at`). If the memory's content text doesn't already
+    mention an absolute date, we prefix the line with `[YYYY-MM-DD]` so
+    downstream answer-model prompts can reason about timing. Without
+    this, questions like "when did X happen?" become unanswerable from
+    the bundle even though the temporal info is on the row.
+    """
     if row.kind == "episode_summary":
         # Summaries contain raw "role: content" lines — condense into a readable note
-        return f"- {_clean_summary(row.content)}"
-    return f"- {row.content}"
+        body = _clean_summary(row.content)
+    else:
+        body = row.content
+    date_prefix = _date_prefix_for(row, body)
+    return f"- {date_prefix}{body}" if date_prefix else f"- {body}"
+
+
+def _date_prefix_for(row: Any, body: str) -> str:
+    """Return a `[YYYY-MM-DD] ` prefix if `row.valid_from` looks real
+    (not the bench-incident default of "compile time") AND the body
+    doesn't already mention an absolute date. Returns empty string
+    otherwise.
+    """
+    import re
+
+    valid_from = getattr(row, "valid_from", None)
+    if valid_from is None:
+        return ""
+    # If the body already contains a YYYY year token (2019-2099 range),
+    # the compiler already surfaced a date — don't double-stamp.
+    if re.search(r"\b(20[1-9]\d)\b", body):
+        return ""
+    try:
+        stamp = valid_from.strftime("%Y-%m-%d")
+    except (AttributeError, ValueError):
+        return ""
+    return f"[{stamp}] "
 
 
 def _clean_summary(text: str) -> str:

--- a/tests/test_compilers.py
+++ b/tests/test_compilers.py
@@ -5,7 +5,11 @@ from datetime import datetime, timezone
 
 from server.db.tables import EpisodeRow
 from server.services.compilers import get_compiler
-from server.services.compilers.heuristic import HeuristicCompiler, extract_payload_text
+from server.services.compilers.heuristic import (
+    HeuristicCompiler,
+    episode_valid_from,
+    extract_payload_text,
+)
 
 
 def _ep(payload: dict, subject_id: str = "user-1") -> EpisodeRow:
@@ -105,3 +109,72 @@ def test_extract_payload_text_messages():
 def test_extract_payload_text_empty():
     assert extract_payload_text({}) == ""
     assert extract_payload_text({"foo": "bar"}) == ""
+
+
+# ---------------------------------------------------------------------------
+# Temporal anchor (episode_valid_from)
+# ---------------------------------------------------------------------------
+
+
+def test_episode_valid_from_uses_explicit_event_time_iso():
+    ep = _ep({"event_time": "2023-05-08T13:56:00+00:00", "text": "x"})
+    out = episode_valid_from(ep)
+    assert out == datetime(2023, 5, 8, 13, 56, tzinfo=timezone.utc)
+
+
+def test_episode_valid_from_uses_first_message_timestamp_locomo():
+    # LoCoMo's idiomatic format — driver test case for the bench.
+    ep = _ep(
+        {
+            "messages": [
+                {"role": "user", "content": "hi", "timestamp": "1:56 pm on 8 May, 2023"},
+                {"role": "user", "content": "later", "timestamp": "2:00 pm on 8 May, 2023"},
+            ]
+        }
+    )
+    out = episode_valid_from(ep)
+    assert out == datetime(2023, 5, 8, 13, 56, tzinfo=timezone.utc)
+
+
+def test_episode_valid_from_explicit_overrides_first_message():
+    # Explicit override wins even if messages also carry timestamps.
+    ep = _ep(
+        {
+            "event_time": "2024-01-01T00:00:00+00:00",
+            "messages": [{"role": "user", "content": "x", "timestamp": "1:56 pm on 8 May, 2023"}],
+        }
+    )
+    assert episode_valid_from(ep) == datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+def test_episode_valid_from_falls_back_to_created_at():
+    fixed = datetime(2026, 5, 11, tzinfo=timezone.utc)
+    ep = EpisodeRow(
+        id=uuid.uuid4(),
+        subject_id="s",
+        source="test",
+        type="conversation",
+        payload={"text": "no timestamps anywhere"},
+        metadata_={},
+        provenance={},
+        created_at=fixed,
+    )
+    assert episode_valid_from(ep) == fixed
+
+
+def test_episode_valid_from_falls_back_on_unparseable_timestamp():
+    # Bad timestamp shouldn't crash — fall through to next candidate.
+    fixed = datetime(2026, 5, 11, tzinfo=timezone.utc)
+    ep = EpisodeRow(
+        id=uuid.uuid4(),
+        subject_id="s",
+        source="test",
+        type="conversation",
+        payload={
+            "messages": [{"role": "user", "content": "x", "timestamp": "definitely not a date"}]
+        },
+        metadata_={},
+        provenance={},
+        created_at=fixed,
+    )
+    assert episode_valid_from(ep) == fixed


### PR DESCRIPTION
Four commits that together close fundamental gaps in Statewave's memory layer surfaced by benchmarking against LoCoMo. Without these, retrieval was being silently degraded across both reads and writes — bench scores measured the gap between intent and behavior, not the architecture's actual strengths.

## The four commits

1. **valid_from from payload event time** (`1da3a3d`)
   - New `episode_valid_from(ep)` helper: prefers `payload.event_time` → `payload.messages[0].timestamp` → `ep.created_at` → `now()`.
   - Parses ISO 8601 and natural-language formats like `"1:56 pm on 8 May, 2023"`; unparseable falls through, never raises.
   - Both HeuristicCompiler and LLMCompiler now route through it. The "memories know when they were true" story now actually holds — previously every memory carried `valid_from = POST time`.

2. **Date grounding in compiled content + bundle text** (`aaddf15`)
   - LLM compiler prompt gained an explicit "Temporal grounding" section: bracketed timestamps mark when the speaker spoke; memories about dated events MUST include the date; relative phrases ("yesterday", "last Saturday", "two days ago", "last year") resolve against the message timestamp.
   - `_render_memory_line` prefixes `[YYYY-MM-DD]` from `valid_from` when the body doesn't already mention an absolute year — safety net for memories the compiler missed.

3. **Granular detail extraction in compiler prompt** (`4e57a67`)
   - Previous "concrete, generalizable facts" wording was being read too restrictively: the LLM emitted high-level summaries and skipped specific attributes. Result: open-ended bench questions about specific details ("what shoes did Melanie buy?") failed because the relevant fact ("purple running shoes") had never been compiled.
   - New "Granularity" rules: a specific concrete attribute IS a generalizable fact. Watch for and preserve objects + attributes (colors, brand names), motivations, quantities + durations, specific titles + names + places, stated preferences, relationships. Better to emit 30 concrete granular memories than 5 vague ones — the retrieval layer ranks them; the compiler's job is recall.
   - Compiled-memory count on the same input: 111 → 154 (+39%).

4. **Embedding backfill on the async compile path** (`436f266`) — **the headline fix**
   - The sync `/v1/memories/compile` route calls `schedule_embedding_backfill` after committing memories so the vector store is populated. The async route (default mode used by `compile_memories_wait` in the SDK) shared the same `_run_compile` helper but was missing the backfill scheduler — a one-line gap.
   - Effect: every memory created via the async path landed with `embedding=NULL`. `search_memories(semantic=True)` returned empty; `assemble_context` silently fell back to lexical + temporal ranking only. **Statewave's signature feature was effectively disabled for any caller using async compile.**
   - This was the dominant cause of bench underperformance on synthesis questions. Single-line fix; mirrors the sync path exactly.

## Bench impact (cumulative across the four)

| Run | Overall mean (conv-26, 199 q) | open_domain | Change driver |
|---|---:|---:|---|
| Pre-fix baseline | 0.091 | 0.000 | Token-level F1, no temporal grounding, no semantic |
| (+ bench-side metric fix) | 0.388 | 0.271 | LoCoMo's actual scoring methodology |
| **+ valid_from + date grounding** | 0.450 | 0.314 | "When did X happen?" answerable from memory |
| **+ granular detail extraction** | 0.480 | 0.314 | Specific facts no longer collapsed into summaries |
| **+ embedding backfill** | **0.535** | **0.500** | Vector retrieval finally enabled |

Cross-system: Statewave (0.535) now beats Mem0 (0.382), naive (0.367), Zep (0.244), no_memory (0.238) on overall AND on every category individually.

## Test plan

- [x] 444/444 unit tests green (integration suite needs a separate test DB locally, pre-existing)
- [x] `ruff check` clean on modified files
- [x] Manual end-to-end: `swb run --limit 1 -s statewave -s mem0` confirms Statewave 0.535 / Mem0 0.382
- [x] Docker rebuild + restart with new image preserves DB state (memories from prior runs retain their valid_from)
- [x] Embedding probe: 0/155 → 151/151 memories with embeddings after fix
- [x] `search_memories(semantic=True)` now returns correct top results for queries like "new shoes Melanie purchased"