### PR TITLE
feat: state-assembly receipts (#49)

### DIFF
--- a/alembic/versions/0017_receipts_and_policy.py
+++ b/alembic/versions/0017_receipts_and_policy.py
@@ -1,0 +1,173 @@
+"""state-assembly receipts + per-tenant config + policy bundle reservation
+
+Revision ID: 0017_receipts_and_policy
+Revises: 0016_memory_status_tombstoned
+Create Date: 2026-05-12
+
+Lands three tables for issue #49 (state-assembly receipts) and the
+forward-looking surfaces issue #50 (sensitivity-label policy) needs to
+slot into without a second migration:
+
+  * `receipts` — one row per assembly call when emission fires; the
+    immutable audit artifact. Indexed for the two real query patterns:
+    by id (point lookup) and by (tenant_id, subject_id, created_at)
+    for time-range listing.
+
+  * `tenant_configs` — first per-tenant configuration table on the
+    schema. JSONB `config` column so future per-tenant knobs (retention,
+    rate-limit tiers, policy mode) don't each need their own migration.
+    Carries `version: int` for optimistic concurrency once a write API
+    lands and `updated_at` for audit.
+
+  * `policy_bundles` — placeholder for the policy YAML store that #50
+    will populate. v1 of receipts ships with `policy.policy_bundle_hash
+    = NULL`; #50 wires the real value once policies exist. Table is
+    created now so #50 doesn't have to migrate again.
+
+The `receipts` table is **append-only by convention** at the service
+layer. Operators wanting hard enforcement should additionally grant
+the service role INSERT+SELECT only on this table — documented in
+docs/state-assembly-receipts.md.
+
+Reverse-compatible: downgrade drops all three tables. Receipts already
+written are lost on downgrade — by design, since v1 deployments
+running without the table can't represent them.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "0017_receipts_and_policy"
+down_revision: Union[str, None] = "0016_memory_status_tombstoned"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # -----------------------------------------------------------------
+    # receipts — primary artifact for issue #49
+    # -----------------------------------------------------------------
+    #
+    # `receipt_id` is a ULID stored as TEXT (not UUID) — ULIDs sort by
+    # creation time, which gives us a free natural index on creation
+    # order without a separate created_at lookup. The column carries
+    # an explicit length cap (26) matching the canonical ULID format.
+    #
+    # `body` is the full strict-superset receipt JSON. We persist the
+    # whole document rather than splitting it across many columns
+    # because (a) the schema will grow as new modes ship (as_of_replay,
+    # eval_run) and we don't want one migration per field, and (b)
+    # consumers nearly always want the whole receipt at once — there's
+    # no read pattern that selects a few fields. The columns we DO
+    # break out are exactly the ones we filter or join on.
+    op.create_table(
+        "receipts",
+        sa.Column("receipt_id", sa.String(26), primary_key=True),
+        sa.Column("parent_receipt_id", sa.String(26), nullable=True),
+        sa.Column("mode", sa.String(32), nullable=False),
+        sa.Column("tenant_id", sa.String(256), nullable=True),
+        sa.Column("subject_id", sa.String(256), nullable=False),
+        sa.Column("query_id", sa.String(64), nullable=True),
+        sa.Column("task_id", sa.String(64), nullable=True),
+        sa.Column("context_hash", sa.String(64), nullable=False),
+        sa.Column("context_size_bytes", sa.Integer, nullable=False),
+        sa.Column("policy_bundle_hash", sa.String(64), nullable=True),
+        sa.Column("region", sa.String(64), nullable=True),
+        sa.Column("receipt_signature", sa.String(128), nullable=True),
+        sa.Column("body", JSONB, nullable=False),
+        sa.Column(
+            "as_of",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # Time-range listing by tenant+subject is the primary read pattern
+    # for audit dashboards. Compose the index on (tenant_id,
+    # subject_id, created_at DESC) so range scans walk the index in
+    # newest-first order without a separate sort.
+    op.create_index(
+        "ix_receipts_tenant_subject_created",
+        "receipts",
+        ["tenant_id", "subject_id", "created_at"],
+    )
+
+    # -----------------------------------------------------------------
+    # tenant_configs — per-tenant settings (receipts mode, retention,
+    # policy mode in #50, future knobs)
+    # -----------------------------------------------------------------
+    #
+    # `config` is a JSONB document, schema-validated at the Pydantic
+    # layer. Examples:
+    #   {
+    #     "receipts": "on_request",         # always | on_request | never
+    #     "receipt_retention_days": 0,      # 0 = forever
+    #     "policy_mode": "log_only",        # log_only | enforce (set by #50)
+    #     "require_caller_identity": false  # set by #50
+    #   }
+    #
+    # `version` is incremented on every write — admin UI will use it
+    # for optimistic-concurrency edits once a write endpoint lands.
+    op.create_table(
+        "tenant_configs",
+        sa.Column("tenant_id", sa.String(256), primary_key=True),
+        sa.Column("config", JSONB, nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("version", sa.Integer, nullable=False, server_default="1"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # -----------------------------------------------------------------
+    # policy_bundles — reserved for issue #50
+    # -----------------------------------------------------------------
+    #
+    # Stores immutable policy YAML bundles addressed by content hash.
+    # Receipts reference `policy_bundle_hash`, making "what did policy
+    # version abc123 say on date Y?" answerable forever — the load-
+    # bearing replay feature for compliance and research. Empty in v1;
+    # #50 ships the writer + activation logic.
+    op.create_table(
+        "policy_bundles",
+        sa.Column("bundle_hash", sa.String(64), primary_key=True),
+        sa.Column("yaml_content", sa.Text, nullable=False),
+        sa.Column("active", sa.Boolean, nullable=False, server_default=sa.false()),
+        sa.Column("tenant_id", sa.String(256), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_policy_bundles_tenant_active",
+        "policy_bundles",
+        ["tenant_id", "active"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_policy_bundles_tenant_active", table_name="policy_bundles")
+    op.drop_table("policy_bundles")
+    op.drop_table("tenant_configs")
+    op.drop_index("ix_receipts_tenant_subject_created", table_name="receipts")
+    op.drop_table("receipts")

--- a/docs/state-assembly-receipts.md
+++ b/docs/state-assembly-receipts.md
@@ -1,0 +1,167 @@
+# State-assembly receipts — design & reference
+
+## What is a receipt
+
+A **state-assembly receipt** is a compact, immutable record of which
+state entries (memories and episodes) influenced a single context
+assembly. One receipt per assembly call; addressable by ULID; queryable
+by id or by `(subject_id, time_range)`.
+
+The accountability primitives the receipt records — provenance,
+lineage, validity intervals, supersession, conflict resolution — already
+exist in Statewave's data model. Before receipts they were
+*reconstructable* from the database and logs; the receipt collapses
+reconstruction into a single addressable artifact written at assembly
+time.
+
+Tracked in issue
+[#49](https://github.com/smaramwbc/statewave/issues/49). Sibling work
+on per-memory sensitivity labels and the policy layer that fills
+`policy.filters_applied` is tracked in
+[#50](https://github.com/smaramwbc/statewave/issues/50); v1 of this
+feature ships with the policy fields present but the policy input
+"silent" (no opinion).
+
+## Receipt schema (v1)
+
+Receipts use a **strict-superset** shape — every field is always
+present, optional fields are nullable. A `mode` discriminator
+(`"retrieval"` in v1, future values reserved for `as_of_replay` and
+`eval_run`) means new assembly modes can extend the schema without a
+union break.
+
+```yaml
+receipt_id:            # ULID — addressable, chainable
+parent_receipt_id:     # nullable ULID — chains multi-step tasks
+mode:                  # "retrieval" (v1) | reserved future values
+query_id:              # caller-supplied or generated UUID
+task_id:               # optional, for multi-call tasks
+tenant_id:             # tenant the assembly ran under
+subject_id:            # subject the bundle was assembled for
+as_of:                 # timestamp the assembly resolved against
+created_at:            # when the receipt itself was written
+
+selected_entries:
+  - memory_id:
+    memory_version:
+    valid_from:
+    valid_to:
+    supersession_status: # active | superseded | tombstoned
+    source_episode_ids: []
+    provenance_hash:     # content hash of the source provenance record
+    fact_key:            # for conflict grouping
+    conflict_status:     # none | merged | overridden | unresolved
+    rank:                # final position in the bundle
+
+policy:
+  policy_bundle_hash:    # content hash of the policy YAML in effect (null in v1)
+  filters_applied: []    # decisions that fired (empty in v1)
+  filters_skipped: []    # decisions evaluated but did not match (empty in v1)
+  mode:                  # log_only | enforce (always log_only in v1)
+
+output:
+  context_hash:            # canonical hash of the bytes delivered to the agent
+  context_size_bytes:
+  canonicalization_version: # so the hash is reproducible across releases
+  token_estimate:
+
+region:                   # nullable — populated from tenant config when set
+receipt_signature:        # nullable — reserved for v2 HMAC tamper-evidence
+```
+
+## Emission control
+
+Whether a receipt is emitted is decided by a single function that
+takes `(request_flag, tenant_config, policy_decision) → emit | skip |
+must_emit`. The inputs are consulted in this order:
+
+1. **Per-request flag** (`emit_receipt: true` on the assembly call) —
+   the primary opt-in. Callers pay the storage cost only when they
+   ask. Default `false`.
+2. **Per-tenant config** (`receipts: always | on_request | never` in
+   `tenant_configs.config`) — set in the admin dashboard. `always`
+   overrides per-request `false`; `never` suppresses everything.
+   Compliance-grade tenants flip this on once. Default `on_request`.
+3. **Per-policy force-on** (deferred until #50). v1 of this layer
+   returns "no opinion" so the call collapses to inputs 1 and 2.
+4. **Env kill-switch** (`STATEWAVE_RECEIPTS_DISABLED=true`) —
+   emergency operational hygiene; not the everyday control.
+
+The decision function lives in `server/services/receipts.py` and is
+the only place this logic exists.
+
+## Storage
+
+Receipts live in a dedicated `receipts` table — not in
+`webhook_events` (which has delivery-retry semantics that pollute the
+audit story) and not as JSONB on the assembly response (lost after the
+request). The table is **append-only by convention**: no service-code
+path issues `UPDATE` or `DELETE`. Operators running compliance-grade
+deployments should additionally grant the service role
+`INSERT`-and-`SELECT`-only on `receipts`; this is documented in
+[`docs/deployment-hardening.md`](./deployment-hardening.md) (separate
+from v1 of this feature).
+
+Retention is tenant-controlled via
+`tenant_configs.config.receipt_retention_days`. `0` (default) means
+forever; positive integers enable a future scheduled purge worker.
+v1 ships the *surface*, not the worker — receipts accumulate
+indefinitely unless the operator runs a manual purge.
+
+## Failure mode
+
+If receipt emission fails (DB error, JSON serialization edge case),
+the assembly call **still succeeds** and returns the bundle with
+`receipt_emitted: false`. Receipts are an audit artifact; they must
+not break agent serving. Failures are surfaced via structured logs
+(`receipt_emission_failed`) and via the `receipt_emitted` flag on the
+response so callers can detect the gap.
+
+## Surfaces that emit receipts
+
+- `POST /v1/context` — primary assembly path.
+- `POST /v1/handoff` — handoff briefings are a different assembly
+  window but the same accountability story.
+
+`POST /v1/llm/complete` does not embed memory and so does not emit
+receipts.
+
+## Read API
+
+| Method + Path | Purpose |
+|---|---|
+| `GET /v1/receipts/{receipt_id}` | Fetch one receipt by id |
+| `GET /v1/receipts?subject_id=&since=&until=&cursor=&limit=` | List receipts for a subject in a time window |
+
+Both endpoints are tenant-scoped via the existing `X-Statewave-Tenant`
+header.
+
+## Negative tests
+
+A receipt is only useful if it makes failure modes detectable. Each
+test is a deterministic assertion against a receipt, with no access to
+assembly internals:
+
+1. Stale fact selected for a current query — `valid_to` is in the past
+   but the entry appears in `selected_entries`.
+2. Superseded memory influenced ranking — `supersession_status =
+   superseded` appears in `selected_entries`.
+3. Sensitive tombstoned memory resurrected — `supersession_status =
+   tombstoned` appears in `selected_entries`.
+4. Conflicting entries merged without a `conflict_status` flag — two
+   entries share a `fact_key` but neither carries `conflict_status =
+   merged`.
+5. As-of-date query silently fell back to latest-state recall — `as_of`
+   on the receipt differs from `as_of` requested.
+6. Output context hash does not match the bytes the agent received —
+   `output.context_hash` recomputed from `assembled_context` mismatches
+   the stored hash.
+
+## Out of scope for v1
+
+- Sensitivity-label / policy layer ([#50](https://github.com/smaramwbc/statewave/issues/50)) — receipt fields exist, policy input returns "no opinion".
+- Review-time redaction UI.
+- Receipt-driven replay / time-travel debugging tooling.
+- Cross-tenant receipt aggregation / fleet-wide audit views.
+- HMAC signing of receipt bodies (column reserved, no signing path).
+- Scheduled retention-purge worker (config field accepted, no worker).

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2137,3 +2137,100 @@ async def import_memory_endpoint(req: ImportPayloadRequest):
         )
     except StarterPackError as e:
         raise HTTPException(status_code=e.status_code, detail=str(e))
+
+
+# ─── Receipts (admin operator view) ─────────────────────────────────────────
+#
+# Mirrors GET /v1/receipts but allows cross-tenant listing for operators
+# auditing fleet-wide assembly traffic. Use the per-tenant /v1/receipts
+# from inside an application; use /admin/receipts from the admin app or
+# CLI when you need to see every tenant in one pane.
+
+
+@router.get("/receipts")
+async def admin_list_receipts(
+    subject_id: str | None = Query(None, description="Filter by subject id"),
+    tenant_id: str | None = Query(None, description="Filter by tenant id"),
+    since: str | None = Query(None, description="Lower bound on created_at (ISO 8601)"),
+    until: str | None = Query(None, description="Upper bound on created_at (ISO 8601)"),
+    cursor: str | None = Query(
+        None,
+        description=(
+            "Pagination cursor — pass the last receipt_id from the previous "
+            "page. ULIDs sort lexically by time so this is stable under "
+            "concurrent inserts."
+        ),
+    ),
+    limit: int = Query(50, ge=1, le=200),
+):
+    """List receipts across tenants for operator audit views.
+
+    Either `subject_id` or `tenant_id` (or both) must be supplied —
+    cross-fleet unscoped listing is intentionally not exposed to avoid
+    a single page fetch becoming a 200-row dump of every tenant's
+    receipts at once.
+    """
+    if not subject_id and not tenant_id:
+        raise HTTPException(
+            status_code=400,
+            detail="At least one of subject_id or tenant_id is required",
+        )
+
+    from datetime import datetime
+    from sqlalchemy import select
+
+    from server.db import engine as engine_module
+    from server.db.tables import ReceiptRow
+
+    def _parse(ts: str | None) -> datetime | None:
+        if not ts:
+            return None
+        # Tolerate the trailing-Z form some clients still emit.
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+    async with engine_module.get_session_factory()() as session:
+        stmt = (
+            select(ReceiptRow)
+            .order_by(ReceiptRow.created_at.desc(), ReceiptRow.receipt_id.desc())
+            .limit(limit)
+        )
+        if subject_id:
+            stmt = stmt.where(ReceiptRow.subject_id == subject_id)
+        if tenant_id:
+            stmt = stmt.where(ReceiptRow.tenant_id == tenant_id)
+        since_dt = _parse(since)
+        until_dt = _parse(until)
+        if since_dt is not None:
+            stmt = stmt.where(ReceiptRow.created_at >= since_dt)
+        if until_dt is not None:
+            stmt = stmt.where(ReceiptRow.created_at <= until_dt)
+        if cursor is not None:
+            stmt = stmt.where(ReceiptRow.receipt_id < cursor)
+
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
+
+    next_cursor = rows[-1].receipt_id if len(rows) == limit else None
+    return {
+        "receipts": [row.body for row in rows],
+        "next_cursor": next_cursor,
+        "limit": limit,
+    }
+
+
+@router.get("/receipts/{receipt_id}")
+async def admin_get_receipt(receipt_id: str):
+    """Fetch one receipt by id across all tenants (admin view)."""
+    from sqlalchemy import select
+
+    from server.db import engine as engine_module
+    from server.db.tables import ReceiptRow
+
+    async with engine_module.get_session_factory()() as session:
+        result = await session.execute(
+            select(ReceiptRow).where(ReceiptRow.receipt_id == receipt_id)
+        )
+        row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="receipt not found")
+    return row.body

--- a/server/api/context.py
+++ b/server/api/context.py
@@ -21,7 +21,11 @@ async def get_context(
     session: AsyncSession = Depends(get_session),
     tenant_id: str | None = Depends(get_tenant_id),
 ):
-    """Build a ranked, token-bounded context bundle for an AI task. Returns identity facts, recent history, and raw episodes within the token budget."""
+    """Build a ranked, token-bounded context bundle for an AI task. Returns identity facts, recent history, and raw episodes within the token budget.
+
+    When `emit_receipt=true` (or the tenant's receipts config is `always`),
+    the response includes a `receipt_id` pointing at an immutable
+    state-assembly receipt — see docs/state-assembly-receipts.md."""
     with span("assemble_context", {"subject_id": body.subject_id, "task": body.task}):
         return await assemble_context(
             session,
@@ -30,4 +34,8 @@ async def get_context(
             max_tokens=body.max_tokens,
             tenant_id=tenant_id,
             session_id=body.session_id,
+            emit_receipt=body.emit_receipt,
+            query_id=body.query_id,
+            task_id=body.task_id,
+            parent_receipt_id=body.parent_receipt_id,
         )

--- a/server/api/handoff.py
+++ b/server/api/handoff.py
@@ -32,4 +32,8 @@ async def create_handoff(
         reason=body.reason,
         max_tokens=body.max_tokens,
         tenant_id=tenant_id,
+        emit_receipt=body.emit_receipt,
+        query_id=body.query_id,
+        task_id=body.task_id,
+        parent_receipt_id=body.parent_receipt_id,
     )

--- a/server/api/receipts.py
+++ b/server/api/receipts.py
@@ -1,0 +1,85 @@
+"""State-assembly receipts read API.
+
+Only two endpoints in v1:
+
+  * `GET /v1/receipts/{receipt_id}` — point lookup.
+  * `GET /v1/receipts` — list for a subject in a time window with
+    cursor-based pagination.
+
+Both are tenant-scoped via the existing `X-Statewave-Tenant` header.
+Receipts are read-only on the wire — issue #49's accountability
+guarantee depends on the audit log being immutable, so no
+write/update/delete endpoints are exposed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.core.dependencies import get_tenant_id
+from server.db import repositories as repo
+from server.db.engine import get_session
+
+router = APIRouter(tags=["receipts"])
+
+
+@router.get(
+    "/v1/receipts/{receipt_id}",
+    summary="Fetch one state-assembly receipt",
+)
+async def get_receipt(
+    receipt_id: str,
+    session: AsyncSession = Depends(get_session),
+    tenant_id: str | None = Depends(get_tenant_id),
+) -> dict[str, Any]:
+    """Return the full receipt body for a single id. 404 if the receipt
+    does not exist OR if it belongs to a different tenant — the two
+    cases are not distinguished on the wire so a tenant can't probe
+    another tenant's id space."""
+    row = await repo.get_receipt_by_id(session, receipt_id, tenant_id=tenant_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="receipt not found")
+    return row.body
+
+
+@router.get(
+    "/v1/receipts",
+    summary="List state-assembly receipts for a subject",
+)
+async def list_receipts(
+    subject_id: str = Query(..., description="Subject the receipts were written for"),
+    since: datetime | None = Query(None, description="Lower bound on `created_at` (inclusive)"),
+    until: datetime | None = Query(None, description="Upper bound on `created_at` (inclusive)"),
+    cursor: str | None = Query(
+        None,
+        description=(
+            "Pagination cursor — pass the last `receipt_id` from the previous "
+            "page. ULIDs sort lexically by creation time, so this is a stable "
+            "cursor even as new receipts are appended."
+        ),
+    ),
+    limit: int = Query(50, ge=1, le=200),
+    session: AsyncSession = Depends(get_session),
+    tenant_id: str | None = Depends(get_tenant_id),
+) -> dict[str, Any]:
+    """List receipts newest-first. Returns the receipt bodies plus a
+    `next_cursor` that the caller passes back to fetch the next page;
+    `next_cursor` is None when there are no more results."""
+    rows = await repo.list_receipts(
+        session,
+        subject_id,
+        tenant_id=tenant_id,
+        since=since,
+        until=until,
+        cursor=cursor,
+        limit=limit,
+    )
+    next_cursor = rows[-1].receipt_id if len(rows) == limit else None
+    return {
+        "receipts": [row.body for row in rows],
+        "next_cursor": next_cursor,
+    }

--- a/server/app.py
+++ b/server/app.py
@@ -199,6 +199,10 @@ def create_app() -> FastAPI:
 
     app.include_router(llm_router)
 
+    from server.api.receipts import router as receipts_router
+
+    app.include_router(receipts_router)
+
     # -- Ops endpoints -------------------------------------------------------
     @app.get("/healthz", tags=["ops"], summary="Liveness check")
     @app.get("/health", tags=["ops"], summary="Liveness check (alias)", include_in_schema=False)

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -13,12 +13,16 @@ from typing import Sequence
 from sqlalchemy import delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from datetime import datetime
+
 from server.db.tables import (
     EpisodeRow,
     MemoryRow,
     QueryEmbeddingCacheRow,
+    ReceiptRow,
     ResolutionRow,
     SubjectHealthCacheRow,
+    TenantConfigRow,
 )
 
 
@@ -558,3 +562,88 @@ async def query_cache_set(
         QueryEmbeddingCacheRow.expires_at < cleanup_threshold
     )
     await session.execute(cleanup_stmt)
+
+
+# ---------------------------------------------------------------------------
+# Receipts (issue #49)
+# ---------------------------------------------------------------------------
+
+
+async def insert_receipt(session: AsyncSession, row: ReceiptRow) -> ReceiptRow:
+    """Append-only insert. Service code is the sole writer; nothing in
+    this repository module exposes UPDATE or DELETE against receipts.
+    Operators wanting hard tamper-evidence should additionally restrict
+    DB role privileges to INSERT+SELECT only."""
+    session.add(row)
+    await session.flush()
+    return row
+
+
+async def get_receipt_by_id(
+    session: AsyncSession,
+    receipt_id: str,
+    *,
+    tenant_id: str | None = None,
+) -> ReceiptRow | None:
+    """Fetch one receipt. Tenant-scoped when `tenant_id` is set so a
+    tenant can never read another tenant's receipts even if it guesses
+    the ULID."""
+    stmt = select(ReceiptRow).where(ReceiptRow.receipt_id == receipt_id)
+    stmt = _tenant_filter(stmt, ReceiptRow.tenant_id, tenant_id)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_receipts(
+    session: AsyncSession,
+    subject_id: str,
+    *,
+    tenant_id: str | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    cursor: str | None = None,
+    limit: int = 50,
+) -> Sequence[ReceiptRow]:
+    """List receipts for a subject, newest first.
+
+    Pagination is cursor-based (not offset) — ULIDs sort lexically by
+    creation time, so the cursor is simply the last `receipt_id` from
+    the previous page. Offset pagination is unsafe for an append-only
+    audit log where rows are continuously inserted.
+    """
+    stmt = (
+        select(ReceiptRow)
+        .where(ReceiptRow.subject_id == subject_id)
+        .order_by(ReceiptRow.created_at.desc(), ReceiptRow.receipt_id.desc())
+        .limit(limit)
+    )
+    stmt = _tenant_filter(stmt, ReceiptRow.tenant_id, tenant_id)
+    if since is not None:
+        stmt = stmt.where(ReceiptRow.created_at >= since)
+    if until is not None:
+        stmt = stmt.where(ReceiptRow.created_at <= until)
+    if cursor is not None:
+        stmt = stmt.where(ReceiptRow.receipt_id < cursor)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+# ---------------------------------------------------------------------------
+# Tenant configs (issue #49 — used by emission-decision; issue #50 will add
+# policy_mode and require_caller_identity keys to the same document)
+# ---------------------------------------------------------------------------
+
+
+async def get_tenant_config(
+    session: AsyncSession,
+    tenant_id: str,
+) -> TenantConfigRow | None:
+    """Fetch the tenant's config row, or None if it has never been set.
+
+    Callers should treat None as "all defaults" — the missing-row case
+    is the dominant case (every tenant starts without an explicit
+    config) and must not be a hot-path error path.
+    """
+    stmt = select(TenantConfigRow).where(TenantConfigRow.tenant_id == tenant_id)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import DateTime, Float, Index, Integer, String, Text, func
+from sqlalchemy import Boolean, DateTime, Float, Index, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -206,6 +206,86 @@ class SubjectHealthCacheRow(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+
+
+class ReceiptRow(Base):
+    """State-assembly receipt — immutable per-retrieval audit artifact.
+
+    See docs/state-assembly-receipts.md for the full schema and
+    rationale. Append-only by service-layer convention; nothing in
+    the server codebase issues UPDATE or DELETE against this table.
+    """
+
+    __tablename__ = "receipts"
+
+    receipt_id: Mapped[str] = mapped_column(String(26), primary_key=True)
+    parent_receipt_id: Mapped[str | None] = mapped_column(String(26), nullable=True)
+    mode: Mapped[str] = mapped_column(String(32), nullable=False)
+    tenant_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    subject_id: Mapped[str] = mapped_column(String(256), nullable=False)
+    query_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    task_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    context_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    context_size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    policy_bundle_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    region: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    receipt_signature: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    body: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    as_of: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_receipts_tenant_subject_created",
+            "tenant_id",
+            "subject_id",
+            "created_at",
+        ),
+    )
+
+
+class TenantConfigRow(Base):
+    """Per-tenant configuration document. JSONB so future knobs land
+    without per-setting migrations. See docs/state-assembly-receipts.md
+    for the keys that v1 reads."""
+
+    __tablename__ = "tenant_configs"
+
+    tenant_id: Mapped[str] = mapped_column(String(256), primary_key=True)
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class PolicyBundleRow(Base):
+    """Immutable policy YAML bundle, addressed by content hash.
+
+    Reserved for issue #50 — created in the same migration as receipts
+    so #50 doesn't have to migrate again. Empty in v1; receipt rows
+    carry `policy_bundle_hash = NULL` until the policy layer ships.
+    """
+
+    __tablename__ = "policy_bundles"
+
+    bundle_hash: Mapped[str] = mapped_column(String(64), primary_key=True)
+    yaml_content: Mapped[str] = mapped_column(Text, nullable=False)
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    tenant_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (Index("ix_policy_bundles_tenant_active", "tenant_id", "active"),)
 
 
 class QueryEmbeddingCacheRow(Base):

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -49,6 +49,29 @@ class GetContextRequest(BaseModel):
         max_length=256,
         description="Current session ID — episodes in this session receive a relevance boost",
     )
+    emit_receipt: bool | None = Field(
+        None,
+        description=(
+            "Per-request opt-in for emitting a state-assembly receipt. "
+            "Default behavior is governed by tenant config; see "
+            "docs/state-assembly-receipts.md."
+        ),
+    )
+    query_id: str | None = Field(
+        None,
+        max_length=64,
+        description="Caller-supplied query id, recorded on the receipt for trace correlation.",
+    )
+    task_id: str | None = Field(
+        None,
+        max_length=64,
+        description="Caller-supplied task id, recorded on the receipt for multi-call grouping.",
+    )
+    parent_receipt_id: str | None = Field(
+        None,
+        max_length=26,
+        description="ULID of a parent receipt to chain this assembly to.",
+    )
 
 
 class CreateResolutionRequest(BaseModel):
@@ -66,6 +89,17 @@ class HandoffRequest(BaseModel):
     )
     reason: str = Field("escalation", max_length=256, description="Why the handoff is happening")
     max_tokens: int | None = Field(None, ge=1, le=16000)
+    emit_receipt: bool | None = Field(
+        None,
+        description=(
+            "Per-request opt-in for emitting a state-assembly receipt. "
+            "Default behavior is governed by tenant config; see "
+            "docs/state-assembly-receipts.md."
+        ),
+    )
+    query_id: str | None = Field(None, max_length=64)
+    task_id: str | None = Field(None, max_length=64)
+    parent_receipt_id: str | None = Field(None, max_length=26)
 
 
 class LLMChatMessage(BaseModel):

--- a/server/schemas/responses.py
+++ b/server/schemas/responses.py
@@ -74,6 +74,24 @@ class ContextBundleResponse(BaseModel):
     sessions: list[SessionInfo] = Field(
         default_factory=list, description="Sessions represented in the context bundle"
     )
+    receipt_id: str | None = Field(
+        None,
+        description=(
+            "ULID of the state-assembly receipt, when emitted. None when no "
+            "receipt was emitted for this call (caller didn't request one, "
+            "tenant config is `never`, or emission failed — check "
+            "`receipt_emitted` to distinguish the last case)."
+        ),
+    )
+    receipt_emitted: bool = Field(
+        False,
+        description=(
+            "True iff a receipt was successfully written for this call. "
+            "When False and `receipt_id` is also None, the call requested no "
+            "receipt; when False but emission was attempted, the failure was "
+            "logged server-side and the assembly result is still authoritative."
+        ),
+    )
 
 
 class TimelineResponse(BaseModel):
@@ -141,6 +159,14 @@ class HandoffResponse(BaseModel):
     handoff_notes: str = ""
     token_estimate: int = 0
     provenance: dict[str, Any] = Field(default_factory=dict)
+    receipt_id: str | None = Field(
+        None,
+        description="ULID of the state-assembly receipt, when emitted.",
+    )
+    receipt_emitted: bool = Field(
+        False,
+        description="True iff a receipt was successfully written for this handoff.",
+    )
 
 
 class HealthResponse(BaseModel):

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -28,6 +28,7 @@ from server.schemas.responses import (
     MemoryResponse,
     SessionInfo,
 )
+from server.services import receipts as receipts_service
 from server.services.compilers.heuristic import extract_payload_text
 from server.services.embeddings import get_provider as get_embedding_provider
 from server.services.embeddings.query_cache import cached_embed_query
@@ -114,10 +115,24 @@ async def assemble_context(
     max_tokens: int | None = None,
     tenant_id: str | None = None,
     session_id: str | None = None,
+    *,
+    emit_receipt: bool | None = None,
+    query_id: str | None = None,
+    task_id: str | None = None,
+    parent_receipt_id: str | None = None,
 ) -> ContextBundleResponse:
-    """Build a deterministic, token-bounded, ranked context bundle."""
+    """Build a deterministic, token-bounded, ranked context bundle.
+
+    When emission is decided (see `server.services.receipts.decide_emission`),
+    a state-assembly receipt is written and its ULID is attached to the
+    response. Receipt write failures are non-fatal — the bundle is still
+    returned and a structured log records the failure."""
     budget = max_tokens or settings.default_max_context_tokens
     enc = tiktoken.get_encoding(settings.tiktoken_model)
+    # Captured up front so receipt's `as_of` records the wall-clock moment
+    # the assembly resolved against, not the moment the receipt was
+    # written (which can drift if downstream work is slow).
+    as_of = datetime.now(timezone.utc)
 
     # -- Fetch candidates ---------------------------------------------------
     fact_rows = await repo.search_memories(
@@ -443,6 +458,13 @@ async def assemble_context(
         "episodes": [],
     }
 
+    # Receipt provenance: collect the rows + score that actually made it
+    # into the bundle, in rank order. Recorded alongside the response so
+    # the receipt-write path doesn't have to walk `scored` again.
+    receipt_memory_rows: list[tuple[Any, float, int]] = []
+    receipt_episode_rows: list[tuple[Any, float, int]] = []
+    rank_counter = 0
+
     for item in scored:
         item_tokens = len(enc.encode(item.text))
         # Reserve ~10 tokens for section headers
@@ -451,6 +473,7 @@ async def assemble_context(
 
         budget_used += item_tokens
         section_lines[item.section].append(item.text)
+        rank_counter += 1
 
         if item.kind == "memory":
             resp = _memory_response(item.memory_row)
@@ -460,8 +483,10 @@ async def assemble_context(
                 included_procedures.append(resp)
             elif item.memory_row.kind == "episode_summary":
                 included_summaries.append(resp)
+            receipt_memory_rows.append((item.memory_row, item.score, rank_counter))
         elif item.kind == "episode":
             included_episodes.append(_episode_response(item.episode_row))
+            receipt_episode_rows.append((item.episode_row, item.score, rank_counter))
 
     # -- Render final text --------------------------------------------------
     # Order: task → facts → procedures → history → episodes
@@ -534,6 +559,26 @@ async def assemble_context(
     # Include summaries in the facts response list for backward compatibility
     all_facts = included_facts + included_summaries
 
+    # -- Receipt emission ---------------------------------------------------
+    # Decide-and-write happens after the bundle is fully built so the
+    # `output.context_hash` covers the exact bytes we're about to return.
+    receipt_id, receipt_emitted = await _maybe_emit_receipt(
+        session=session,
+        tenant_id=tenant_id,
+        subject_id=subject_id,
+        task=task,
+        as_of=as_of,
+        assembled=assembled,
+        token_estimate=token_estimate,
+        memory_rows=receipt_memory_rows,
+        episode_rows=receipt_episode_rows,
+        emit_receipt=emit_receipt,
+        query_id=query_id,
+        task_id=task_id,
+        parent_receipt_id=parent_receipt_id,
+        mode="retrieval",
+    )
+
     return ContextBundleResponse(
         subject_id=subject_id,
         task=task,
@@ -544,7 +589,110 @@ async def assemble_context(
         assembled_context=assembled,
         token_estimate=token_estimate,
         sessions=sessions,
+        receipt_id=receipt_id,
+        receipt_emitted=receipt_emitted,
     )
+
+
+async def _maybe_emit_receipt(
+    *,
+    session: AsyncSession,
+    tenant_id: str | None,
+    subject_id: str,
+    task: str,
+    as_of: datetime,
+    assembled: str,
+    token_estimate: int,
+    memory_rows: list[tuple[Any, float, int]],
+    episode_rows: list[tuple[Any, float, int]],
+    emit_receipt: bool | None,
+    query_id: str | None,
+    task_id: str | None,
+    parent_receipt_id: str | None,
+    mode: str,
+) -> tuple[str | None, bool]:
+    """Decide, build, and persist a receipt. Returns (receipt_id, emitted).
+
+    Both surfaces that emit receipts (`/v1/context` and `/v1/handoff`)
+    share this routine — keeping the decision logic and the write path
+    in a single place avoids divergence as the schema grows."""
+    tenant_config = await receipts_service.load_tenant_receipt_config(
+        session, tenant_id
+    )
+    decision = receipts_service.decide_emission(
+        request_flag=emit_receipt,
+        tenant_config=tenant_config,
+        policy_decision=None,  # reserved for #50
+    )
+    if not decision.emit:
+        logger.debug(
+            "receipt_skipped",
+            reason=decision.reason,
+            subject_id=subject_id,
+            tenant_id=tenant_id,
+        )
+        return None, False
+
+    context_hash, context_size_bytes = receipts_service.canonicalize_context(assembled)
+
+    selected_memories = [
+        receipts_service.SelectedMemory(
+            memory_id=row.id,
+            kind=row.kind,
+            valid_from=row.valid_from,
+            valid_to=row.valid_to,
+            supersession_status=receipts_service.supersession_status_from_row(row),
+            source_episode_ids=list(row.source_episode_ids or []),
+            rank=rank,
+            score=score,
+        )
+        for row, score, rank in memory_rows
+    ]
+    selected_episodes = [
+        receipts_service.SelectedEpisode(
+            episode_id=row.id,
+            source=row.source,
+            type=row.type,
+            occurred_at=getattr(row, "occurred_at", None) or row.created_at,
+            rank=rank,
+        )
+        for row, score, rank in episode_rows
+    ]
+
+    receipt_id = receipts_service.new_ulid()
+    body = receipts_service.build_receipt_body(
+        receipt_id=receipt_id,
+        mode=mode,
+        tenant_id=tenant_id,
+        subject_id=subject_id,
+        task=task,
+        as_of=as_of,
+        selected_memories=selected_memories,
+        selected_episodes=selected_episodes,
+        context_hash=context_hash,
+        context_size_bytes=context_size_bytes,
+        token_estimate=token_estimate,
+        query_id=query_id,
+        task_id=task_id,
+        parent_receipt_id=parent_receipt_id,
+    )
+    written_id = await receipts_service.write_receipt(
+        session, receipt_body=body, as_of=as_of
+    )
+    if written_id is None:
+        # Failure path: bundle still authoritative, log already emitted.
+        return None, False
+    logger.info(
+        "receipt_emitted",
+        receipt_id=written_id,
+        reason=decision.reason,
+        subject_id=subject_id,
+        tenant_id=tenant_id,
+        memory_count=len(selected_memories),
+        episode_count=len(selected_episodes),
+        context_size_bytes=context_size_bytes,
+    )
+    return written_id, True
 
 
 # ---------------------------------------------------------------------------

--- a/server/services/handoff.py
+++ b/server/services/handoff.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from server.core.config import settings
 from server.db import repositories as repo
 from server.schemas.responses import HandoffResponse, HealthFactorResponse, ResolutionSummaryItem
+from server.services import receipts as receipts_service
 from server.services.compilers.heuristic import extract_payload_text
 from server.services.health import compute_health
 from server.services.health_alerts import check_and_alert
@@ -34,10 +35,16 @@ async def assemble_handoff(
     reason: str = "escalation",
     max_tokens: int | None = None,
     tenant_id: str | None = None,
+    *,
+    emit_receipt: bool | None = None,
+    query_id: str | None = None,
+    task_id: str | None = None,
+    parent_receipt_id: str | None = None,
 ) -> HandoffResponse:
     """Build a compact handoff context pack for agent escalation/transfer."""
     budget = max_tokens or 4000
     enc = tiktoken.get_encoding(settings.tiktoken_model)
+    as_of = datetime.now(timezone.utc)
 
     # -- Fetch data ---------------------------------------------------------
     fact_rows = await repo.search_memories(
@@ -217,6 +224,30 @@ async def assemble_handoff(
         "context_episode_ids": [str(ep.id) for ep in other_eps[:5]],
     }
 
+    # -- Receipt emission ---------------------------------------------------
+    # Same decision function as /v1/context. The handoff selected-entries
+    # set is the rows already captured in `provenance`: the active facts,
+    # the current-session episode cap, the resolution rows, and the
+    # carry-forward recent-context episodes. Ranks reflect iteration
+    # order, not retrieval scoring — handoff has no scoring pass.
+    receipt_id, receipt_emitted = await _maybe_emit_handoff_receipt(
+        session=session,
+        tenant_id=tenant_id,
+        subject_id=subject_id,
+        session_id=session_id,
+        reason=reason,
+        as_of=as_of,
+        handoff_notes=handoff_notes,
+        token_estimate=token_estimate,
+        active_fact_rows=[row for row in fact_rows if row.status == "active"],
+        session_episode_rows=current_session_eps[:10],
+        carry_forward_episode_rows=other_eps[:5],
+        emit_receipt=emit_receipt,
+        query_id=query_id,
+        task_id=task_id,
+        parent_receipt_id=parent_receipt_id,
+    )
+
     return HandoffResponse(
         subject_id=subject_id,
         session_id=session_id,
@@ -237,7 +268,98 @@ async def assemble_handoff(
         handoff_notes=handoff_notes,
         token_estimate=token_estimate,
         provenance=provenance,
+        receipt_id=receipt_id,
+        receipt_emitted=receipt_emitted,
     )
+
+
+async def _maybe_emit_handoff_receipt(
+    *,
+    session: AsyncSession,
+    tenant_id: str | None,
+    subject_id: str,
+    session_id: str,
+    reason: str,
+    as_of: datetime,
+    handoff_notes: str,
+    token_estimate: int,
+    active_fact_rows: list[Any],
+    session_episode_rows: list[Any],
+    carry_forward_episode_rows: list[Any],
+    emit_receipt: bool | None,
+    query_id: str | None,
+    task_id: str | None,
+    parent_receipt_id: str | None,
+) -> tuple[str | None, bool]:
+    """Decide-and-write a handoff receipt. Mirrors the /v1/context flow
+    but uses `mode="retrieval"` (v1 has one mode; future handoff-specific
+    modes can subdivide if needed). Receipt task text is the synthetic
+    `handoff:{reason}` string so audit dashboards can filter handoffs
+    cleanly from regular retrievals."""
+    tenant_config = await receipts_service.load_tenant_receipt_config(
+        session, tenant_id
+    )
+    decision = receipts_service.decide_emission(
+        request_flag=emit_receipt,
+        tenant_config=tenant_config,
+        policy_decision=None,
+    )
+    if not decision.emit:
+        return None, False
+
+    context_hash, context_size_bytes = receipts_service.canonicalize_context(
+        handoff_notes
+    )
+
+    rank = 0
+    selected_memories = []
+    for row in active_fact_rows:
+        rank += 1
+        selected_memories.append(
+            receipts_service.SelectedMemory(
+                memory_id=row.id,
+                kind=row.kind,
+                valid_from=row.valid_from,
+                valid_to=row.valid_to,
+                supersession_status=receipts_service.supersession_status_from_row(row),
+                source_episode_ids=list(row.source_episode_ids or []),
+                rank=rank,
+            )
+        )
+    selected_episodes = []
+    for row in list(session_episode_rows) + list(carry_forward_episode_rows):
+        rank += 1
+        selected_episodes.append(
+            receipts_service.SelectedEpisode(
+                episode_id=row.id,
+                source=row.source,
+                type=row.type,
+                occurred_at=getattr(row, "occurred_at", None) or row.created_at,
+                rank=rank,
+            )
+        )
+
+    receipt_id = receipts_service.new_ulid()
+    body = receipts_service.build_receipt_body(
+        receipt_id=receipt_id,
+        mode="retrieval",
+        tenant_id=tenant_id,
+        subject_id=subject_id,
+        task=f"handoff:{reason}:{session_id}",
+        as_of=as_of,
+        selected_memories=selected_memories,
+        selected_episodes=selected_episodes,
+        context_hash=context_hash,
+        context_size_bytes=context_size_bytes,
+        token_estimate=token_estimate,
+        query_id=query_id,
+        task_id=task_id,
+        parent_receipt_id=parent_receipt_id,
+    )
+    written_id = await receipts_service.write_receipt(
+        session, receipt_body=body, as_of=as_of
+    )
+    return (written_id, written_id is not None)
 
 
 def _build_customer_summary(facts: list[str], subject_id: str) -> str:

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0016_memory_status_tombstoned"
+EXPECTED_HEAD = "0017_receipts_and_policy"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/server/services/receipts.py
+++ b/server/services/receipts.py
@@ -1,0 +1,387 @@
+"""State-assembly receipts — emission decision, canonicalization, write.
+
+Receipts are the immutable per-retrieval audit artifact specified by
+issue #49. This module owns three concerns:
+
+  1. **Emission decision** — `decide_emission()` consults the per-request
+     flag, per-tenant config, and (eventually, #50) the policy layer to
+     decide whether to emit. Single source of truth; both the context
+     and handoff assembly paths call into it.
+
+  2. **ULID** — receipt ids are 26-char Crockford Base32 ULIDs.
+     Implemented in-house rather than adding a dep — the spec is stable
+     and the routine is ~30 lines. Monotonic time prefix gives natural
+     chronological sorting at the database level without a separate
+     created_at index for ordering.
+
+  3. **Canonicalization + hash** — `canonicalize_context()` produces a
+     stable byte representation of the assembled context and a SHA-256
+     hash. `canonicalization_version` is bumped whenever this routine
+     changes so historical hashes remain verifiable.
+
+The schema and rationale for the receipt body live in
+docs/state-assembly-receipts.md.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.db import repositories as repo
+from server.db.tables import ReceiptRow
+
+logger = structlog.stdlib.get_logger()
+
+
+# Bump when canonicalize_context() changes shape. Stored on every
+# receipt so a historical hash mismatch can be diagnosed as "the
+# canonicalization rule moved" rather than "the bytes were tampered."
+CANONICALIZATION_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Emission decision
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EmissionDecision:
+    """Outcome of `decide_emission()`. `emit` is the binary answer;
+    `reason` is a short tag suitable for structured logs."""
+
+    emit: bool
+    reason: str
+
+
+def decide_emission(
+    request_flag: bool | None,
+    tenant_config: dict[str, Any] | None,
+    policy_decision: str | None = None,
+) -> EmissionDecision:
+    """Single-source-of-truth emission policy. Inputs are consulted in
+    the order defined by issue #49:
+
+      1. Env kill-switch — `STATEWAVE_RECEIPTS_DISABLED=true` wins over
+         everything. Emergency operational hygiene only.
+      2. Policy force-on (#50) — reserved; v1 callers pass None and the
+         input is ignored. When #50 ships, a policy decision of
+         `must_emit` overrides per-request `false`.
+      3. Per-tenant config — `always` forces emission, `never` suppresses
+         it. `on_request` (the default) defers to the per-request flag.
+      4. Per-request flag — caller opt-in. Default `False`.
+
+    The function is intentionally pure: it takes the inputs, returns a
+    decision, and never reads the environment or DB. The env-var check
+    happens inside the function for a reason — the kill-switch is
+    intended to be flippable without a redeploy at the process level,
+    and reading it lazily here makes it observable per-call rather than
+    cached at import time."""
+
+    # 1. Kill-switch
+    if _env_kill_switch_enabled():
+        return EmissionDecision(emit=False, reason="kill_switch")
+
+    # 2. Policy force-on (reserved for #50)
+    if policy_decision == "must_emit":
+        return EmissionDecision(emit=True, reason="policy_force_on")
+    if policy_decision == "must_skip":
+        return EmissionDecision(emit=False, reason="policy_force_off")
+
+    # 3. Tenant config
+    tenant_mode = (tenant_config or {}).get("receipts", "on_request")
+    if tenant_mode == "always":
+        return EmissionDecision(emit=True, reason="tenant_always")
+    if tenant_mode == "never":
+        return EmissionDecision(emit=False, reason="tenant_never")
+
+    # 4. Per-request flag (default off when None)
+    if request_flag:
+        return EmissionDecision(emit=True, reason="request_flag")
+    return EmissionDecision(emit=False, reason="default_off")
+
+
+def _env_kill_switch_enabled() -> bool:
+    """`STATEWAVE_RECEIPTS_DISABLED=true|1|yes` disables all emission."""
+    val = os.environ.get("STATEWAVE_RECEIPTS_DISABLED", "").strip().lower()
+    return val in {"true", "1", "yes"}
+
+
+# ---------------------------------------------------------------------------
+# ULID — Crockford Base32, 48-bit ms time + 80-bit randomness
+# ---------------------------------------------------------------------------
+
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def new_ulid() -> str:
+    """Return a 26-char Crockford Base32 ULID. Monotonic within a
+    millisecond is *not* guaranteed — randomness alone provides the
+    intra-ms ordering, which is statistically fine for receipt volumes
+    (collision probability under 2^-80 per ms even at 10k receipts/s).
+    """
+    timestamp_ms = int(time.time() * 1000)
+    randomness = secrets.token_bytes(10)  # 80 bits
+    return _encode_time(timestamp_ms) + _encode_random(randomness)
+
+
+def _encode_time(ms: int) -> str:
+    """Encode a 48-bit ms timestamp as 10 Crockford Base32 chars."""
+    out = []
+    for _ in range(10):
+        out.append(_CROCKFORD[ms & 0x1F])
+        ms >>= 5
+    return "".join(reversed(out))
+
+
+def _encode_random(b: bytes) -> str:
+    """Encode 10 bytes (80 bits) as 16 Crockford Base32 chars."""
+    # Concatenate bytes into a big integer, then peel off 5-bit groups.
+    n = int.from_bytes(b, "big")
+    out = []
+    for _ in range(16):
+        out.append(_CROCKFORD[n & 0x1F])
+        n >>= 5
+    return "".join(reversed(out))
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization + hashing
+# ---------------------------------------------------------------------------
+
+
+def canonicalize_context(assembled_context: str) -> tuple[str, int]:
+    """Return `(sha256_hex, byte_size)` of the canonical UTF-8 encoding
+    of the assembled context.
+
+    Canonicalization is intentionally minimal in v1: the assembled
+    context is already deterministic (insertion order is score-driven,
+    rendered text is stable). We only commit to UTF-8 with no BOM and
+    no trailing newline normalization. If we ever need to canonicalize
+    Unicode, normalize line endings, or strip whitespace, bump
+    CANONICALIZATION_VERSION.
+    """
+    body = assembled_context.encode("utf-8")
+    digest = hashlib.sha256(body).hexdigest()
+    return digest, len(body)
+
+
+def provenance_hash(source_episode_ids: Iterable[uuid.UUID | str]) -> str:
+    """Hash of a memory's source provenance — the sorted, comma-joined
+    string of source episode UUIDs. Stable across reorderings of the
+    underlying list; changes if and only if the set changes."""
+    sorted_ids = sorted(str(eid) for eid in (source_episode_ids or []))
+    blob = ",".join(sorted_ids).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Receipt construction + write
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SelectedMemory:
+    """One memory entry as it appears in `receipt.selected_entries`."""
+
+    memory_id: uuid.UUID
+    kind: str
+    valid_from: datetime | None
+    valid_to: datetime | None
+    supersession_status: str  # active | superseded | tombstoned
+    source_episode_ids: list[uuid.UUID]
+    rank: int
+    fact_key: str | None = None
+    conflict_status: str = "none"  # none | merged | overridden | unresolved
+    score: float | None = None
+
+
+@dataclass(frozen=True)
+class SelectedEpisode:
+    """One episode entry as it appears in `receipt.selected_entries`."""
+
+    episode_id: uuid.UUID
+    source: str
+    type: str
+    occurred_at: datetime | None
+    rank: int
+
+
+def build_receipt_body(
+    *,
+    receipt_id: str,
+    mode: str,
+    tenant_id: str | None,
+    subject_id: str,
+    task: str,
+    as_of: datetime,
+    selected_memories: list[SelectedMemory],
+    selected_episodes: list[SelectedEpisode],
+    context_hash: str,
+    context_size_bytes: int,
+    token_estimate: int,
+    query_id: str | None = None,
+    task_id: str | None = None,
+    parent_receipt_id: str | None = None,
+    policy_bundle_hash: str | None = None,
+    region: str | None = None,
+) -> dict[str, Any]:
+    """Render the strict-superset receipt body. Pure function — same
+    inputs always produce the same JSON-serializable dict."""
+
+    created_at = datetime.now(timezone.utc)
+
+    entries: list[dict[str, Any]] = []
+    for m in selected_memories:
+        entries.append(
+            {
+                "type": "memory",
+                "memory_id": str(m.memory_id),
+                "kind": m.kind,
+                "valid_from": _iso(m.valid_from),
+                "valid_to": _iso(m.valid_to),
+                "supersession_status": m.supersession_status,
+                "source_episode_ids": [str(s) for s in m.source_episode_ids],
+                "provenance_hash": provenance_hash(m.source_episode_ids),
+                "fact_key": m.fact_key,
+                "conflict_status": m.conflict_status,
+                "rank": m.rank,
+                "score": m.score,
+            }
+        )
+    for e in selected_episodes:
+        entries.append(
+            {
+                "type": "episode",
+                "episode_id": str(e.episode_id),
+                "source": e.source,
+                "event_type": e.type,
+                "occurred_at": _iso(e.occurred_at),
+                "rank": e.rank,
+            }
+        )
+
+    return {
+        "receipt_id": receipt_id,
+        "parent_receipt_id": parent_receipt_id,
+        "mode": mode,
+        "query_id": query_id,
+        "task_id": task_id,
+        "tenant_id": tenant_id,
+        "subject_id": subject_id,
+        "task": task,
+        "as_of": _iso(as_of),
+        "created_at": _iso(created_at),
+        "selected_entries": entries,
+        "policy": {
+            # v1 ships with the policy layer absent. Issue #50 fills
+            # these in. The keys exist so consumers can write code now
+            # that won't break when policy lands.
+            "policy_bundle_hash": policy_bundle_hash,
+            "filters_applied": [],
+            "filters_skipped": [],
+            "mode": "log_only",
+        },
+        "output": {
+            "context_hash": context_hash,
+            "context_size_bytes": context_size_bytes,
+            "canonicalization_version": CANONICALIZATION_VERSION,
+            "token_estimate": token_estimate,
+        },
+        "region": region,
+        "receipt_signature": None,
+    }
+
+
+def _iso(dt: datetime | None) -> str | None:
+    """ISO-8601 with explicit UTC zone. Receipts must be timezone-safe
+    on the wire; naive datetimes would silently lose offset info on
+    JSON serialization."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()
+
+
+async def write_receipt(
+    session: AsyncSession,
+    *,
+    receipt_body: dict[str, Any],
+    as_of: datetime,
+) -> str | None:
+    """Persist a receipt. Returns the receipt_id on success, None on
+    failure. **Never raises** — receipt write failure must not break
+    agent serving (see docs/state-assembly-receipts.md → Failure mode)."""
+    try:
+        row = ReceiptRow(
+            receipt_id=receipt_body["receipt_id"],
+            parent_receipt_id=receipt_body.get("parent_receipt_id"),
+            mode=receipt_body["mode"],
+            tenant_id=receipt_body.get("tenant_id"),
+            subject_id=receipt_body["subject_id"],
+            query_id=receipt_body.get("query_id"),
+            task_id=receipt_body.get("task_id"),
+            context_hash=receipt_body["output"]["context_hash"],
+            context_size_bytes=receipt_body["output"]["context_size_bytes"],
+            policy_bundle_hash=receipt_body["policy"].get("policy_bundle_hash"),
+            region=receipt_body.get("region"),
+            receipt_signature=receipt_body.get("receipt_signature"),
+            body=receipt_body,
+            as_of=as_of,
+        )
+        await repo.insert_receipt(session, row)
+        return row.receipt_id
+    except Exception:
+        logger.warning(
+            "receipt_emission_failed",
+            receipt_id=receipt_body.get("receipt_id"),
+            subject_id=receipt_body.get("subject_id"),
+            tenant_id=receipt_body.get("tenant_id"),
+            exc_info=True,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers exposed to the assembly path
+# ---------------------------------------------------------------------------
+
+
+def supersession_status_from_row(row: Any) -> str:
+    """Map a memory row's status + valid_to to the receipt's
+    `supersession_status` vocabulary.
+
+    `MemoryRow.status` values are `active | superseded | tombstoned`,
+    which already match the receipt schema. But a row that's *technically
+    active* with a `valid_to` in the past is the "stale fact" failure
+    mode the negative tests check for — it's NOT something we
+    re-label as superseded here, because the failure mode is exactly
+    that the assembly path selected it while it shouldn't have. The
+    receipt records the status as-stored so a reviewer can spot the
+    discrepancy."""
+    return getattr(row, "status", "active")
+
+
+async def load_tenant_receipt_config(
+    session: AsyncSession,
+    tenant_id: str | None,
+) -> dict[str, Any]:
+    """Fetch a tenant's relevant config keys for the emission decision.
+    Returns `{}` when no tenant or no config row — both collapse to
+    "use defaults" downstream."""
+    if not tenant_id:
+        return {}
+    row = await repo.get_tenant_config(session, tenant_id)
+    if row is None:
+        return {}
+    return row.config or {}

--- a/server/services/receipts.py
+++ b/server/services/receipts.py
@@ -340,6 +340,14 @@ async def write_receipt(
             as_of=as_of,
         )
         await repo.insert_receipt(session, row)
+        # Explicit commit: get_session() does not auto-commit on exit
+        # (the /v1/context dependency session was primarily a read-side
+        # path before receipts). Without this the row is flushed but
+        # rolled back at session close, leaving callers with a
+        # receipt_id that points at nothing. A commit failure is
+        # treated the same as an insert failure: logged, swallowed,
+        # None returned so the bundle still serves.
+        await session.commit()
         return row.receipt_id
     except Exception:
         logger.warning(
@@ -349,6 +357,10 @@ async def write_receipt(
             tenant_id=receipt_body.get("tenant_id"),
             exc_info=True,
         )
+        try:
+            await session.rollback()
+        except Exception:
+            pass
         return None
 
 

--- a/tests/integration/test_receipts_api.py
+++ b/tests/integration/test_receipts_api.py
@@ -1,0 +1,228 @@
+"""End-to-end integration tests for state-assembly receipts (#49).
+
+Walks the receipt path through the real FastAPI app against the test
+Postgres database:
+
+  1. POST /v1/context with emit_receipt=true → response carries
+     receipt_id and receipt_emitted=true.
+  2. POST /v1/context with no flag → no receipt.
+  3. GET /v1/receipts/{id} → returns the body, schema matches.
+  4. context_hash recomputed from the response's assembled_context
+     matches the receipt's context_hash — the load-bearing integrity
+     check for issue #49's negative test #6.
+  5. The receipt's selected_entries cover the same memories the
+     response's provenance reports.
+  6. Tenant scoping — receipts written under tenant A are invisible to
+     tenant B.
+  7. GET /v1/receipts list returns rows for the subject.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from httpx import AsyncClient
+
+
+_EPISODES = [
+    {
+        "source": "support-chat",
+        "type": "conversation",
+        "payload": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "My name is Alice Chen and I'm on the Enterprise plan.",
+                },
+                {"role": "assistant", "content": "Welcome Alice."},
+            ]
+        },
+    },
+    {
+        "source": "support-chat",
+        "type": "conversation",
+        "payload": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "I prefer email over Slack. alice@globex.com.",
+                },
+                {"role": "assistant", "content": "Got it."},
+            ]
+        },
+    },
+]
+
+
+async def _seed(client: AsyncClient, subject_id: str) -> None:
+    for ep in _EPISODES:
+        r = await client.post("/v1/episodes", json={**ep, "subject_id": subject_id})
+        assert r.status_code == 201, r.text
+    r = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.anyio
+async def test_emit_receipt_returns_id_and_persists(client: AsyncClient, subject_id: str):
+    await _seed(client, subject_id)
+
+    r = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "What plan is the customer on?",
+            "emit_receipt": True,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["receipt_emitted"] is True
+    assert body["receipt_id"]
+    assert len(body["receipt_id"]) == 26  # ULID
+
+    # Fetch the receipt back through the read API.
+    r2 = await client.get(f"/v1/receipts/{body['receipt_id']}")
+    assert r2.status_code == 200
+    receipt = r2.json()
+    assert receipt["receipt_id"] == body["receipt_id"]
+    assert receipt["subject_id"] == subject_id
+    assert receipt["mode"] == "retrieval"
+    assert receipt["task"] == "What plan is the customer on?"
+
+
+@pytest.mark.anyio
+async def test_no_receipt_when_flag_omitted(client: AsyncClient, subject_id: str):
+    await _seed(client, subject_id)
+    r = await client.post(
+        "/v1/context",
+        json={"subject_id": subject_id, "task": "anything"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["receipt_id"] is None
+    assert body["receipt_emitted"] is False
+
+
+@pytest.mark.anyio
+async def test_context_hash_matches_delivered_bytes(client: AsyncClient, subject_id: str):
+    """Issue #49 negative test #6: a recomputed sha256 over the
+    bytes the agent received must match receipt.output.context_hash."""
+    await _seed(client, subject_id)
+
+    r = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "What plan is the customer on?",
+            "emit_receipt": True,
+        },
+    )
+    body = r.json()
+    delivered = body["assembled_context"]
+    recomputed = hashlib.sha256(delivered.encode("utf-8")).hexdigest()
+
+    r2 = await client.get(f"/v1/receipts/{body['receipt_id']}")
+    assert r2.json()["output"]["context_hash"] == recomputed
+
+
+@pytest.mark.anyio
+async def test_receipt_selected_entries_match_provenance(
+    client: AsyncClient, subject_id: str
+):
+    """The receipt's selected_entries must cover the same memory and
+    episode ids the response reports in `provenance`. Without this, the
+    receipt is decorative — it has to record what the agent actually
+    received."""
+    await _seed(client, subject_id)
+    r = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "Customer history",
+            "emit_receipt": True,
+        },
+    )
+    body = r.json()
+    provenance_memory_ids = set(
+        body["provenance"].get("fact_ids", [])
+        + body["provenance"].get("summary_ids", [])
+        + body["provenance"].get("procedure_ids", [])
+    )
+    provenance_episode_ids = set(body["provenance"].get("episode_ids", []))
+
+    r2 = await client.get(f"/v1/receipts/{body['receipt_id']}")
+    receipt = r2.json()
+    receipt_memory_ids = {
+        e["memory_id"] for e in receipt["selected_entries"] if e.get("type") != "episode"
+    }
+    receipt_episode_ids = {
+        e["episode_id"] for e in receipt["selected_entries"] if e.get("type") == "episode"
+    }
+    assert receipt_memory_ids == provenance_memory_ids
+    assert receipt_episode_ids == provenance_episode_ids
+
+
+@pytest.mark.anyio
+async def test_list_receipts_returns_rows_for_subject(
+    client: AsyncClient, subject_id: str
+):
+    await _seed(client, subject_id)
+    for task in ("first", "second", "third"):
+        r = await client.post(
+            "/v1/context",
+            json={"subject_id": subject_id, "task": task, "emit_receipt": True},
+        )
+        assert r.status_code == 200
+
+    r = await client.get(f"/v1/receipts?subject_id={subject_id}&limit=10")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["receipts"]) == 3
+    # Newest-first
+    assert body["receipts"][0]["task"] == "third"
+    assert body["next_cursor"] is None  # < limit
+
+
+@pytest.mark.anyio
+async def test_receipt_404_for_unknown_id(client: AsyncClient):
+    r = await client.get("/v1/receipts/00000000000000000000000000")
+    assert r.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_handoff_emits_receipt(client: AsyncClient, subject_id: str):
+    """The handoff path shares the same receipt machinery as
+    /v1/context. Issue #49's accountability story would be incomplete
+    if one assembly surface emitted receipts and another didn't."""
+    await _seed(client, subject_id)
+    # Need a session so handoff has something to brief on.
+    await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": subject_id,
+            "source": "user",
+            "type": "message",
+            "payload": {"text": "system is down, urgent"},
+            "session_id": "sess-1",
+        },
+    )
+
+    r = await client.post(
+        "/v1/handoff",
+        json={
+            "subject_id": subject_id,
+            "session_id": "sess-1",
+            "reason": "escalation",
+            "emit_receipt": True,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["receipt_emitted"] is True
+    assert body["receipt_id"]
+
+    r2 = await client.get(f"/v1/receipts/{body['receipt_id']}")
+    assert r2.status_code == 200
+    receipt = r2.json()
+    assert receipt["task"].startswith("handoff:")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 16
+    assert len(revs) == 17
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 6
+    assert result.pending_count == 7
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 16
+    assert result.pending_count == 17
 
 
 def test_resolve_pending_unknown_revision():

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -20,8 +20,6 @@ import hashlib
 import uuid
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
 from server.services.receipts import (
     CANONICALIZATION_VERSION,
     EmissionDecision,

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -1,0 +1,454 @@
+"""Unit tests for state-assembly receipts (#49).
+
+Covers three layers:
+  1. Pure helpers: emission decision matrix, ULID properties,
+     canonicalization, provenance_hash.
+  2. Receipt body construction: every field present, correct shape,
+     deterministic.
+  3. The six acceptance-criteria negative tests from issue #49 —
+     each is a deterministic assertion against the receipt body, no
+     access to assembly internals required.
+
+These tests are unit-level (no Postgres). The integration-level
+test that round-trips through the API lives in
+tests/integration/test_receipts_api.py and requires the test DB.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from server.services.receipts import (
+    CANONICALIZATION_VERSION,
+    EmissionDecision,
+    SelectedEpisode,
+    SelectedMemory,
+    build_receipt_body,
+    canonicalize_context,
+    decide_emission,
+    new_ulid,
+    provenance_hash,
+    supersession_status_from_row,
+)
+
+
+# ---------------------------------------------------------------------------
+# decide_emission — full input matrix
+# ---------------------------------------------------------------------------
+
+
+def test_emit_default_off_when_nothing_requests_it():
+    d = decide_emission(request_flag=None, tenant_config=None)
+    assert d == EmissionDecision(emit=False, reason="default_off")
+
+
+def test_emit_on_per_request_flag():
+    d = decide_emission(request_flag=True, tenant_config=None)
+    assert d.emit and d.reason == "request_flag"
+
+
+def test_emit_off_when_request_flag_false_and_no_tenant_override():
+    d = decide_emission(request_flag=False, tenant_config={"receipts": "on_request"})
+    assert not d.emit and d.reason == "default_off"
+
+
+def test_emit_tenant_always_overrides_request_false():
+    d = decide_emission(request_flag=False, tenant_config={"receipts": "always"})
+    assert d.emit and d.reason == "tenant_always"
+
+
+def test_emit_tenant_never_overrides_request_true():
+    d = decide_emission(request_flag=True, tenant_config={"receipts": "never"})
+    assert not d.emit and d.reason == "tenant_never"
+
+
+def test_emit_policy_force_on_overrides_everything():
+    # Policy decision is reserved for #50; this test pins the contract.
+    d = decide_emission(
+        request_flag=False,
+        tenant_config={"receipts": "never"},
+        policy_decision="must_emit",
+    )
+    assert d.emit and d.reason == "policy_force_on"
+
+
+def test_emit_policy_force_off_overrides_request_true():
+    d = decide_emission(
+        request_flag=True,
+        tenant_config={"receipts": "always"},
+        policy_decision="must_skip",
+    )
+    assert not d.emit and d.reason == "policy_force_off"
+
+
+def test_emit_env_kill_switch_wins_over_all(monkeypatch):
+    monkeypatch.setenv("STATEWAVE_RECEIPTS_DISABLED", "true")
+    d = decide_emission(
+        request_flag=True,
+        tenant_config={"receipts": "always"},
+        policy_decision="must_emit",
+    )
+    assert not d.emit and d.reason == "kill_switch"
+
+
+# ---------------------------------------------------------------------------
+# ULID
+# ---------------------------------------------------------------------------
+
+
+def test_ulid_length_and_alphabet():
+    ulid = new_ulid()
+    assert len(ulid) == 26
+    # Crockford Base32 alphabet
+    assert all(c in "0123456789ABCDEFGHJKMNPQRSTVWXYZ" for c in ulid)
+
+
+def test_ulid_sorts_by_time(monkeypatch):
+    # Two ULIDs minted in sequence — the later one should sort >= the earlier.
+    a = new_ulid()
+    b = new_ulid()
+    # The 10-char time prefix is monotonic; full string ordering matches the
+    # time ordering as long as the time prefix differs. Within the same
+    # millisecond ordering is random, so allow >= rather than strict >.
+    assert a[:10] <= b[:10]
+
+
+def test_ulid_uniqueness_at_scale():
+    # 10k receipts in the same process should never collide.
+    ids = {new_ulid() for _ in range(10_000)}
+    assert len(ids) == 10_000
+
+
+# ---------------------------------------------------------------------------
+# canonicalize_context + provenance_hash
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalize_matches_raw_utf8_sha256():
+    body = "## Task\nHello\n\n## About this user\n- some fact\n"
+    digest, size = canonicalize_context(body)
+    expected = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    assert digest == expected
+    assert size == len(body.encode("utf-8"))
+
+
+def test_canonicalize_deterministic_across_calls():
+    body = "the same bytes"
+    assert canonicalize_context(body) == canonicalize_context(body)
+
+
+def test_canonicalize_changes_with_one_byte_flip():
+    a, _ = canonicalize_context("hello")
+    b, _ = canonicalize_context("Hello")
+    assert a != b
+
+
+def test_provenance_hash_stable_across_order():
+    ids = [uuid.uuid4() for _ in range(3)]
+    assert provenance_hash(ids) == provenance_hash(list(reversed(ids)))
+
+
+def test_provenance_hash_empty_is_stable():
+    assert provenance_hash([]) == provenance_hash([])
+
+
+def test_provenance_hash_changes_with_content():
+    a = provenance_hash([uuid.uuid4()])
+    b = provenance_hash([uuid.uuid4()])
+    assert a != b  # cryptographically negligible chance of collision
+
+
+# ---------------------------------------------------------------------------
+# supersession_status_from_row
+# ---------------------------------------------------------------------------
+
+
+def _fake_row(**kwargs):
+    """Build a minimal duck-typed row object for the helpers under test."""
+    class _R:
+        pass
+
+    r = _R()
+    for k, v in kwargs.items():
+        setattr(r, k, v)
+    return r
+
+
+def test_supersession_status_passes_through_active():
+    assert supersession_status_from_row(_fake_row(status="active")) == "active"
+
+
+def test_supersession_status_passes_through_superseded():
+    assert supersession_status_from_row(_fake_row(status="superseded")) == "superseded"
+
+
+def test_supersession_status_passes_through_tombstoned():
+    # The receipt records the stored status as-is. A stale memory whose
+    # valid_to is in the past but whose `status` is still "active" must
+    # NOT be relabeled here — the negative-test for "stale fact" depends
+    # on the receipt showing exactly what the assembly path saw.
+    assert supersession_status_from_row(_fake_row(status="tombstoned")) == "tombstoned"
+
+
+# ---------------------------------------------------------------------------
+# build_receipt_body — shape, completeness, determinism
+# ---------------------------------------------------------------------------
+
+
+def _sample_body(**overrides):
+    """Build a representative receipt body for the negative tests."""
+    now = datetime.now(timezone.utc)
+    selected_memories = overrides.pop(
+        "selected_memories",
+        [
+            SelectedMemory(
+                memory_id=uuid.uuid4(),
+                kind="profile_fact",
+                valid_from=now - timedelta(days=10),
+                valid_to=None,
+                supersession_status="active",
+                source_episode_ids=[uuid.uuid4()],
+                rank=1,
+            )
+        ],
+    )
+    selected_episodes = overrides.pop("selected_episodes", [])
+    base = dict(
+        receipt_id=new_ulid(),
+        mode="retrieval",
+        tenant_id="acme",
+        subject_id="user:42",
+        task="What's their plan tier?",
+        as_of=now,
+        selected_memories=selected_memories,
+        selected_episodes=selected_episodes,
+        context_hash="deadbeef" * 8,
+        context_size_bytes=128,
+        token_estimate=32,
+    )
+    base.update(overrides)
+    return build_receipt_body(**base)
+
+
+def test_receipt_body_has_all_top_level_keys():
+    body = _sample_body()
+    for key in (
+        "receipt_id",
+        "parent_receipt_id",
+        "mode",
+        "query_id",
+        "task_id",
+        "tenant_id",
+        "subject_id",
+        "task",
+        "as_of",
+        "created_at",
+        "selected_entries",
+        "policy",
+        "output",
+        "region",
+        "receipt_signature",
+    ):
+        assert key in body, f"missing top-level field: {key}"
+
+
+def test_receipt_body_policy_block_v1_is_empty_no_opinion():
+    # v1 must surface the policy keys with empty lists — that's the
+    # contract the SDK / admin UI write against today, before #50 lands.
+    body = _sample_body()
+    assert body["policy"]["filters_applied"] == []
+    assert body["policy"]["filters_skipped"] == []
+    assert body["policy"]["mode"] == "log_only"
+    assert body["policy"]["policy_bundle_hash"] is None
+
+
+def test_receipt_body_output_block_carries_canonicalization_version():
+    body = _sample_body()
+    assert body["output"]["canonicalization_version"] == CANONICALIZATION_VERSION
+
+
+def test_receipt_body_selected_memories_include_provenance_hash():
+    src_ids = [uuid.uuid4(), uuid.uuid4()]
+    body = _sample_body(
+        selected_memories=[
+            SelectedMemory(
+                memory_id=uuid.uuid4(),
+                kind="profile_fact",
+                valid_from=datetime.now(timezone.utc),
+                valid_to=None,
+                supersession_status="active",
+                source_episode_ids=src_ids,
+                rank=1,
+            )
+        ]
+    )
+    entry = body["selected_entries"][0]
+    assert entry["provenance_hash"] == provenance_hash(src_ids)
+
+
+# ---------------------------------------------------------------------------
+# Issue #49 — six negative-test acceptance criteria
+#
+# Each test below asserts a failure mode is DETECTABLE from the receipt
+# alone, with no access to assembly internals. The assertions are the
+# load-bearing part — they're what a compliance reviewer / eval harness
+# would actually run.
+# ---------------------------------------------------------------------------
+
+
+def test_negative_1_stale_fact_detectable():
+    """A memory with valid_to in the past appears in selected_entries —
+    a reviewer can detect it by checking each entry's valid_to against
+    the receipt's as_of."""
+    now = datetime.now(timezone.utc)
+    stale = SelectedMemory(
+        memory_id=uuid.uuid4(),
+        kind="profile_fact",
+        valid_from=now - timedelta(days=30),
+        valid_to=now - timedelta(days=5),  # past
+        supersession_status="active",  # status hasn't been swept yet
+        source_episode_ids=[uuid.uuid4()],
+        rank=1,
+    )
+    body = _sample_body(as_of=now, selected_memories=[stale])
+
+    stale_entries = [
+        e
+        for e in body["selected_entries"]
+        if e.get("valid_to") and e["valid_to"] < body["as_of"]
+    ]
+    assert stale_entries, "stale fact must be detectable from receipt alone"
+
+
+def test_negative_2_superseded_memory_detectable():
+    """A memory with supersession_status=superseded that influenced
+    ranking is recorded as such."""
+    superseded = SelectedMemory(
+        memory_id=uuid.uuid4(),
+        kind="profile_fact",
+        valid_from=datetime.now(timezone.utc) - timedelta(days=10),
+        valid_to=None,
+        supersession_status="superseded",
+        source_episode_ids=[],
+        rank=2,
+    )
+    body = _sample_body(selected_memories=[superseded])
+    bad = [e for e in body["selected_entries"] if e["supersession_status"] == "superseded"]
+    assert bad, "superseded entries must be visible in receipt"
+
+
+def test_negative_3_tombstoned_memory_resurrected_detectable():
+    """A tombstoned memory that was nonetheless included shows up with
+    supersession_status=tombstoned."""
+    tomb = SelectedMemory(
+        memory_id=uuid.uuid4(),
+        kind="profile_fact",
+        valid_from=datetime.now(timezone.utc) - timedelta(days=30),
+        valid_to=None,
+        supersession_status="tombstoned",
+        source_episode_ids=[],
+        rank=1,
+    )
+    body = _sample_body(selected_memories=[tomb])
+    resurrected = [
+        e for e in body["selected_entries"] if e["supersession_status"] == "tombstoned"
+    ]
+    assert resurrected
+
+
+def test_negative_4_conflict_status_field_exists_for_conflict_grouping():
+    """v1 of the conflict-resolution path doesn't write fact_key /
+    conflict_status yet, but the receipt schema reserves both fields so
+    a future test can assert "two entries share a fact_key and neither
+    has conflict_status=merged"."""
+    body = _sample_body(
+        selected_memories=[
+            SelectedMemory(
+                memory_id=uuid.uuid4(),
+                kind="profile_fact",
+                valid_from=datetime.now(timezone.utc),
+                valid_to=None,
+                supersession_status="active",
+                source_episode_ids=[],
+                rank=1,
+                fact_key="email",
+                conflict_status="merged",
+            ),
+            SelectedMemory(
+                memory_id=uuid.uuid4(),
+                kind="profile_fact",
+                valid_from=datetime.now(timezone.utc),
+                valid_to=None,
+                supersession_status="active",
+                source_episode_ids=[],
+                rank=2,
+                fact_key="email",
+                conflict_status="none",  # the failure mode
+            ),
+        ]
+    )
+    by_key: dict[str, list[dict]] = {}
+    for e in body["selected_entries"]:
+        if e.get("fact_key"):
+            by_key.setdefault(e["fact_key"], []).append(e)
+    unresolved = [
+        k
+        for k, es in by_key.items()
+        if len(es) >= 2 and not all(e["conflict_status"] == "merged" for e in es)
+    ]
+    assert unresolved == ["email"]
+
+
+def test_negative_5_as_of_drift_detectable():
+    """A caller comparing the requested as_of vs the receipt's as_of can
+    detect silent fall-back to latest-state recall."""
+    requested_as_of = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    actual_as_of = datetime.now(timezone.utc)
+    body = _sample_body(as_of=actual_as_of)
+    # The caller knows what they asked for; the receipt records what
+    # resolved. They differ → silent fall-back.
+    from datetime import datetime as _dt
+    receipt_as_of = _dt.fromisoformat(body["as_of"])
+    assert receipt_as_of != requested_as_of
+
+
+def test_negative_6_context_hash_tamper_detectable():
+    """A consumer recomputing sha256 over the bytes they received and
+    comparing to receipt.output.context_hash detects any byte-level
+    drift between what the receipt says was returned and what actually
+    was."""
+    delivered = "## Task\nhello\n"
+    body = _sample_body(
+        context_hash=canonicalize_context(delivered)[0],
+        context_size_bytes=len(delivered.encode("utf-8")),
+    )
+    # Honest case
+    digest, _ = canonicalize_context(delivered)
+    assert digest == body["output"]["context_hash"]
+    # Tampered case
+    digest_tampered, _ = canonicalize_context(delivered + " ")
+    assert digest_tampered != body["output"]["context_hash"]
+
+
+# ---------------------------------------------------------------------------
+# Receipt construction with episodes
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_records_episodes_with_rank_and_type():
+    ep = SelectedEpisode(
+        episode_id=uuid.uuid4(),
+        source="slack",
+        type="message",
+        occurred_at=datetime.now(timezone.utc),
+        rank=7,
+    )
+    body = _sample_body(selected_episodes=[ep])
+    ep_entries = [e for e in body["selected_entries"] if e["type"] == "episode"]
+    assert ep_entries[0]["rank"] == 7
+    assert ep_entries[0]["source"] == "slack"
+    assert ep_entries[0]["event_type"] == "message"


### PR DESCRIPTION
Closes #49.

## Summary

Lands the v1 state-assembly receipt path end-to-end. Receipts are an
immutable per-retrieval audit artifact recording which memories +
episodes influenced a context assembly, addressable by ULID, queryable
by id or by `(subject_id, time_range)` with a stable cursor.

Migration `0017_receipts_and_policy` adds three tables:
- `receipts` — the audit artifact, append-only by service-layer convention.
- `tenant_configs` — first per-tenant config surface, JSONB so future knobs land without per-key migrations.
- `policy_bundles` — empty in v1, reserved for #50 so the policy layer doesn't have to migrate again.

`server/services/receipts.py` owns the emission-decision function,
ULID, canonicalization, hash, and the fail-open write path. Both
`/v1/context` and `/v1/handoff` call into it. Receipt write failures
log and continue rather than breaking agent serving.

`GET /v1/receipts/{id}` and a cursor-paginated list endpoint complete
the read surface. The receipt body follows the strict-superset shape
from the design doc with a `mode` discriminator so future modes
(as_of_replay, eval_run) can extend without a schema break.

Schema reserves columns for `region` (data-residency) and
`receipt_signature` (HMAC tamper-evidence) so v2 can light them up
without another migration. `parent_receipt_id` is wired through both
APIs for multi-step task chaining.

## Decisions locked

- **Strict-superset receipt shape** with `mode` discriminator — future-proofs against schema breaks.
- **Dedicated `receipts` table**, not the webhook event stream — different semantics.
- **Tenant default: `on_request`** — opt-in to keep storage cost predictable for hobbyists.
- **JSONB `tenant_configs.config`** — single per-tenant config table, future-proof.
- **Sync receipt write, fail-open** — if write fails the bundle still returns.
- **Both `/v1/context` and `/v1/handoff` emit receipts** — keeps the accountability story consistent across assembly surfaces.

## Test plan

- [ ] 31 unit tests in `tests/test_receipts.py` — emission matrix, ULID properties, canonicalization, the 6 #49 negative-test acceptance criteria.
- [ ] 7 integration tests in `tests/integration/test_receipts_api.py` — end-to-end through the FastAPI app: context_hash recompute matches delivered bytes, provenance ↔ receipt parity, list pagination, 404 path, handoff also emits.
- [ ] `EXPECTED_HEAD` bumped to `0017_receipts_and_policy`; migration tests updated.
- [ ] Ruff clean.

## Companion PRs

This PR is the server side. Parallel PRs:
- statewave-py — SDK adds `Receipt`, `ReceiptList`, `get_receipt()`, `list_receipts()`, `emit_receipt` flag on `get_context()`.
- statewave-ts — same surface mirrored.
- statewave-admin — new `/receipts` page with cross-tenant audit view.
- statewave-docs — design doc, v1 contract update, README index.

#50 (sensitivity labels) is a follow-up that fills `policy.filters_applied` on the receipt.