### PR TITLE
feat: sensitivity labels & per-memory policy bindings (#50)

### DIFF
--- a/alembic/versions/0018_sensitivity_labels.py
+++ b/alembic/versions/0018_sensitivity_labels.py
@@ -1,0 +1,70 @@
+"""memories.sensitivity_labels — per-memory capability tags for the
+policy layer (issue #50).
+
+Revision ID: 0018_sensitivity_labels
+Revises: 0017_receipts_and_policy
+Create Date: 2026-05-12
+
+Adds a first-class `sensitivity_labels TEXT[]` column to `memories`
+plus a GIN index for the array-overlap (`&&`) queries the policy
+evaluator runs on the hot path. Labels are tenant-supplied capability
+tags (e.g. `pii`, `financial`, `secret`) consumed by the policy bundle
+loaded from `policy_bundles` (table created in 0017 with the receipt
+migration).
+
+The column is NOT NULL with a `'{}'::text[]` server default so every
+existing row stays valid (untagged) without a backfill. Untagged
+memories pass through the policy evaluator with no rule match, which
+collapses to default-allow — they keep behaving exactly as they did
+in v0.7. This is the load-bearing property: tenants can roll into the
+new policy layer without first having to tag everything.
+
+A first-class column was chosen over a JSONB metadata field for two
+reasons:
+  1. GIN-indexed overlap queries (`sensitivity_labels && '{pii}'`) run
+     in milliseconds. JSONB array membership runs the same query
+     orders of magnitude slower at scale.
+  2. The policy evaluator runs on every assembly call. Keeping the
+     filter inputs typed at the DB layer means a malformed value
+     (e.g. someone stuffing a string instead of a list into JSONB)
+     can't silently bypass policy.
+
+Reverse-compatible: downgrade drops the column and its index.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY
+
+
+revision: str = "0018_sensitivity_labels"
+down_revision: Union[str, None] = "0017_receipts_and_policy"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "memories",
+        sa.Column(
+            "sensitivity_labels",
+            ARRAY(sa.String()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+    )
+    # GIN index for array-overlap queries — `sensitivity_labels && '{pii}'`
+    # is the per-memory predicate the policy evaluator runs at assembly
+    # time, so it must be cheap.
+    op.create_index(
+        "ix_memories_sensitivity_labels",
+        "memories",
+        ["sensitivity_labels"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_memories_sensitivity_labels", table_name="memories")
+    op.drop_column("memories", "sensitivity_labels")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pgvector>=0.3,<1",
     "tiktoken>=0.7,<1",
     "structlog>=24.1,<26",
+    "pyyaml>=6,<7",
 ]
 
 [project.optional-dependencies]

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2234,3 +2234,247 @@ async def admin_get_receipt(receipt_id: str):
     if row is None:
         raise HTTPException(status_code=404, detail="receipt not found")
     return row.body
+
+
+# ─── Sensitivity-label policy (issue #50) ──────────────────────────────────
+#
+# v1 surface: upload a YAML/JSON bundle, list bundles, set the active
+# bundle (per-tenant or global), invalidate the in-process cache. The
+# server consults the active bundle on every assembly call; the policy
+# layer is data-driven so changes don't require a redeploy.
+
+
+class UploadPolicyBundleRequest(BaseModel):
+    """Body for POST /admin/policy/bundles.
+
+    `yaml_content` is parsed at upload time so a syntactically broken
+    bundle never reaches the active slot. Validation errors return
+    400 with the parser message so an operator can fix the YAML
+    locally before retrying.
+    """
+
+    yaml_content: str
+    tenant_id: str | None = None
+    activate: bool = False
+
+
+@router.post("/policy/bundles")
+async def upload_policy_bundle(req: UploadPolicyBundleRequest):
+    """Upload a new policy bundle. Returns the content hash so the
+    operator can refer to it in subsequent activate calls."""
+    from sqlalchemy import select, update as sa_update
+
+    from server.db import engine as engine_module
+    from server.db.tables import PolicyBundleRow
+    from server.services import policy as policy_service
+
+    try:
+        bundle = policy_service.load_bundle(req.yaml_content)
+    except policy_service.PolicyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    async with engine_module.get_session_factory()() as session:
+        # If a row already exists with this hash, the bundle is a
+        # duplicate of one we already stored — return the existing
+        # row's metadata rather than INSERT-conflicting.
+        existing = await session.execute(
+            select(PolicyBundleRow).where(
+                PolicyBundleRow.bundle_hash == bundle.bundle_hash
+            )
+        )
+        existing_row = existing.scalar_one_or_none()
+        if existing_row is None:
+            session.add(
+                PolicyBundleRow(
+                    bundle_hash=bundle.bundle_hash,
+                    yaml_content=req.yaml_content,
+                    active=False,
+                    tenant_id=req.tenant_id,
+                )
+            )
+            await session.commit()
+
+        if req.activate:
+            # Deactivate other bundles in the same scope so the
+            # active-bundle resolver sees exactly one row.
+            scope_stmt = sa_update(PolicyBundleRow).where(
+                PolicyBundleRow.bundle_hash != bundle.bundle_hash
+            )
+            if req.tenant_id is None:
+                scope_stmt = scope_stmt.where(PolicyBundleRow.tenant_id.is_(None))
+            else:
+                scope_stmt = scope_stmt.where(
+                    PolicyBundleRow.tenant_id == req.tenant_id
+                )
+            scope_stmt = scope_stmt.values(active=False)
+            await session.execute(scope_stmt)
+            await session.execute(
+                sa_update(PolicyBundleRow)
+                .where(PolicyBundleRow.bundle_hash == bundle.bundle_hash)
+                .values(active=True)
+            )
+            await session.commit()
+            policy_service.invalidate_bundle_cache()
+
+    return {
+        "bundle_hash": bundle.bundle_hash,
+        "version": bundle.version,
+        "rule_count": bundle.rule_count,
+        "tenant_id": req.tenant_id,
+        "active": req.activate,
+    }
+
+
+@router.get("/policy/bundles")
+async def list_policy_bundles(tenant_id: str | None = Query(None)):
+    """List policy bundles, optionally filtered by tenant. Returns
+    metadata only — bundle YAML is fetched separately via /admin/policy/bundles/{hash}."""
+    from sqlalchemy import select
+
+    from server.db import engine as engine_module
+    from server.db.tables import PolicyBundleRow
+
+    async with engine_module.get_session_factory()() as session:
+        stmt = select(PolicyBundleRow).order_by(PolicyBundleRow.created_at.desc())
+        if tenant_id is not None:
+            stmt = stmt.where(PolicyBundleRow.tenant_id == tenant_id)
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
+    return {
+        "bundles": [
+            {
+                "bundle_hash": r.bundle_hash,
+                "tenant_id": r.tenant_id,
+                "active": r.active,
+                "created_at": r.created_at.isoformat(),
+            }
+            for r in rows
+        ]
+    }
+
+
+@router.get("/policy/bundles/{bundle_hash}")
+async def get_policy_bundle(bundle_hash: str):
+    """Fetch a bundle's full YAML content + parsed rule summary."""
+    from sqlalchemy import select
+
+    from server.db import engine as engine_module
+    from server.db.tables import PolicyBundleRow
+    from server.services import policy as policy_service
+
+    async with engine_module.get_session_factory()() as session:
+        result = await session.execute(
+            select(PolicyBundleRow).where(PolicyBundleRow.bundle_hash == bundle_hash)
+        )
+        row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="bundle not found")
+    parsed = policy_service.load_bundle(row.yaml_content)
+    return {
+        "bundle_hash": row.bundle_hash,
+        "tenant_id": row.tenant_id,
+        "active": row.active,
+        "created_at": row.created_at.isoformat(),
+        "yaml_content": row.yaml_content,
+        "metadata": parsed.metadata,
+        "rules": [
+            {
+                "id": r.id,
+                "description": r.description,
+                "when": r.when,
+                "action": r.action,
+            }
+            for r in parsed.rules
+        ],
+    }
+
+
+class ActivateBundleRequest(BaseModel):
+    """Body for POST /admin/policy/activate.
+
+    Scope (global vs tenant-specific) is inferred from the stored
+    bundle's `tenant_id` column — we don't accept it on the activate
+    call to avoid a request body that disagrees with the row.
+    """
+
+    bundle_hash: str
+
+
+@router.post("/policy/activate")
+async def activate_policy_bundle(req: ActivateBundleRequest):
+    """Mark a bundle as the active policy for its scope. Deactivates
+    any other bundle in the same scope (global or tenant-specific)
+    so the active-bundle resolver sees exactly one row."""
+    from sqlalchemy import select, update as sa_update
+
+    from server.db import engine as engine_module
+    from server.db.tables import PolicyBundleRow
+    from server.services import policy as policy_service
+
+    async with engine_module.get_session_factory()() as session:
+        result = await session.execute(
+            select(PolicyBundleRow).where(
+                PolicyBundleRow.bundle_hash == req.bundle_hash
+            )
+        )
+        target = result.scalar_one_or_none()
+        if target is None:
+            raise HTTPException(status_code=404, detail="bundle not found")
+        scope_stmt = sa_update(PolicyBundleRow).where(
+            PolicyBundleRow.bundle_hash != req.bundle_hash
+        )
+        if target.tenant_id is None:
+            scope_stmt = scope_stmt.where(PolicyBundleRow.tenant_id.is_(None))
+        else:
+            scope_stmt = scope_stmt.where(PolicyBundleRow.tenant_id == target.tenant_id)
+        scope_stmt = scope_stmt.values(active=False)
+        await session.execute(scope_stmt)
+        await session.execute(
+            sa_update(PolicyBundleRow)
+            .where(PolicyBundleRow.bundle_hash == req.bundle_hash)
+            .values(active=True)
+        )
+        await session.commit()
+
+    policy_service.invalidate_bundle_cache()
+    return {"bundle_hash": req.bundle_hash, "active": True}
+
+
+@router.post("/policy/reload")
+async def reload_policy_cache():
+    """Force the in-process active-bundle cache to drop. Use after
+    setting `policy_bundles.active` manually outside the API (e.g.
+    direct DB fix-ups during incident response)."""
+    from server.services import policy as policy_service
+
+    policy_service.invalidate_bundle_cache()
+    return {"reloaded": True}
+
+
+@router.get("/policy/active")
+async def get_active_policy(tenant_id: str | None = Query(None)):
+    """Return the currently active bundle for a tenant scope, or
+    the global active bundle when `tenant_id` is omitted. 404 when
+    no bundle is active for the scope."""
+    from server.db import engine as engine_module
+    from server.services import policy as policy_service
+
+    async with engine_module.get_session_factory()() as session:
+        bundle = await policy_service.resolve_active_bundle(session, tenant_id)
+    if bundle is None:
+        raise HTTPException(status_code=404, detail="no active policy bundle")
+    return {
+        "bundle_hash": bundle.bundle_hash,
+        "version": bundle.version,
+        "rule_count": bundle.rule_count,
+        "metadata": bundle.metadata,
+        "rules": [
+            {
+                "id": r.id,
+                "description": r.description,
+                "when": r.when,
+                "action": r.action,
+            }
+            for r in bundle.rules
+        ],
+    }

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2478,3 +2478,71 @@ async def get_active_policy(tenant_id: str | None = Query(None)):
             for r in bundle.rules
         ],
     }
+
+
+# ─── Memory-labels admin shim (issue #50) ──────────────────────────────────
+#
+# Mirrors PATCH /v1/memories/{memory_id}/labels but lives under
+# /admin so the admin-app proxy (which only forwards /admin/*) can
+# reach it without widening its allowlist. The endpoint accepts an
+# optional `tenant_id` query param so an operator can edit labels
+# across tenants; the underlying canonicalization (dedup + lowercase
+# + trim) and 32-label cap are the same as the /v1 endpoint.
+
+
+class AdminSetMemoryLabelsRequest(BaseModel):
+    sensitivity_labels: list[str]
+
+
+@router.patch("/memories/{memory_id}/labels")
+async def admin_set_memory_labels(
+    memory_id: uuid.UUID,
+    req: AdminSetMemoryLabelsRequest,
+    tenant_id: str | None = Query(None),
+):
+    """Operator-facing memory-labels editor. Same canonicalization
+    rules as /v1/memories/{id}/labels."""
+    from sqlalchemy import select, update as sa_update
+
+    from server.db import engine as engine_module
+    from server.db.tables import MemoryRow
+
+    normalized = sorted(
+        {lbl.strip().lower() for lbl in req.sensitivity_labels if lbl.strip()}
+    )
+    if len(normalized) > 32:
+        raise HTTPException(status_code=400, detail="too many labels (max 32)")
+
+    async with engine_module.get_session_factory()() as session:
+        stmt = select(MemoryRow).where(MemoryRow.id == memory_id)
+        if tenant_id is not None:
+            stmt = stmt.where(MemoryRow.tenant_id == tenant_id)
+        result = await session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            raise HTTPException(status_code=404, detail="memory not found")
+        update_stmt = (
+            sa_update(MemoryRow)
+            .where(MemoryRow.id == memory_id)
+            .values(sensitivity_labels=normalized)
+        )
+        if tenant_id is not None:
+            update_stmt = update_stmt.where(MemoryRow.tenant_id == tenant_id)
+        await session.execute(update_stmt)
+        await session.commit()
+        result = await session.execute(stmt)
+        row = result.scalar_one()
+
+    return {
+        "id": str(row.id),
+        "kind": row.kind,
+        "content": row.content,
+        "summary": row.summary,
+        "confidence": row.confidence,
+        "status": row.status,
+        "source_episode_ids": [str(s) for s in (row.source_episode_ids or [])],
+        "valid_from": row.valid_from.isoformat(),
+        "valid_to": row.valid_to.isoformat() if row.valid_to else None,
+        "sensitivity_labels": list(row.sensitivity_labels or []),
+        "created_at": row.created_at.isoformat(),
+    }

--- a/server/api/context.py
+++ b/server/api/context.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.db.engine import get_session
 from server.schemas.requests import GetContextRequest
 from server.schemas.responses import ContextBundleResponse
 from server.services.context import assemble_context
+from server.services.receipts import load_tenant_receipt_config
 from server.core.tracing import span
 from server.core.dependencies import get_tenant_id
 
@@ -25,7 +26,23 @@ async def get_context(
 
     When `emit_receipt=true` (or the tenant's receipts config is `always`),
     the response includes a `receipt_id` pointing at an immutable
-    state-assembly receipt — see docs/state-assembly-receipts.md."""
+    state-assembly receipt — see docs/state-assembly-receipts.md.
+
+    When the tenant config sets `require_caller_identity: true`, both
+    `caller_id` and `caller_type` are mandatory — missing values
+    return 401. This is the lever compliance-grade tenants flip to
+    make policy enforcement non-bypassable."""
+    tenant_config = await load_tenant_receipt_config(session, tenant_id)
+    if tenant_config.get("require_caller_identity") and (
+        not body.caller_id or not body.caller_type
+    ):
+        raise HTTPException(
+            status_code=401,
+            detail=(
+                "tenant config requires caller_id and caller_type on every "
+                "context assembly call"
+            ),
+        )
     with span("assemble_context", {"subject_id": body.subject_id, "task": body.task}):
         return await assemble_context(
             session,
@@ -38,4 +55,6 @@ async def get_context(
             query_id=body.query_id,
             task_id=body.task_id,
             parent_receipt_id=body.parent_receipt_id,
+            caller_id=body.caller_id,
+            caller_type=body.caller_type,
         )

--- a/server/api/handoff.py
+++ b/server/api/handoff.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.core.dependencies import get_tenant_id
@@ -10,6 +10,7 @@ from server.db.engine import get_session
 from server.schemas.requests import HandoffRequest
 from server.schemas.responses import HandoffResponse
 from server.services.handoff import assemble_handoff
+from server.services.receipts import load_tenant_receipt_config
 
 router = APIRouter(tags=["handoff"])
 
@@ -24,7 +25,22 @@ async def create_handoff(
     session: AsyncSession = Depends(get_session),
     tenant_id: str | None = Depends(get_tenant_id),
 ):
-    """Generate a compact handoff brief for escalation, shift change, or agent transfer."""
+    """Generate a compact handoff brief for escalation, shift change, or agent transfer.
+
+    Same caller-identity gate as /v1/context: when the tenant config
+    sets `require_caller_identity: true`, both `caller_id` and
+    `caller_type` are mandatory."""
+    tenant_config = await load_tenant_receipt_config(session, tenant_id)
+    if tenant_config.get("require_caller_identity") and (
+        not body.caller_id or not body.caller_type
+    ):
+        raise HTTPException(
+            status_code=401,
+            detail=(
+                "tenant config requires caller_id and caller_type on every "
+                "handoff call"
+            ),
+        )
     return await assemble_handoff(
         session,
         body.subject_id,
@@ -36,4 +52,6 @@ async def create_handoff(
         query_id=body.query_id,
         task_id=body.task_id,
         parent_receipt_id=body.parent_receipt_id,
+        caller_id=body.caller_id,
+        caller_type=body.caller_type,
     )

--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import uuid
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.db import repositories as repo
 from server.db.engine import get_session
-from server.schemas.requests import CompileMemoriesRequest
+from server.db.tables import MemoryRow
+from server.schemas.requests import CompileMemoriesRequest, SetMemoryLabelsRequest
 from server.schemas.responses import CompileMemoriesResponse, MemoryResponse, SearchMemoriesResponse
 from server.services.compilers import get_compiler
 from server.services.embeddings import get_provider as get_embedding_provider
@@ -270,6 +273,64 @@ def _to_response(row) -> MemoryResponse:
         source_episode_ids=row.source_episode_ids or [],
         metadata=row.metadata_,
         status=row.status,
+        sensitivity_labels=list(getattr(row, "sensitivity_labels", None) or []),
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
+
+
+@router.patch("/{memory_id}/labels", response_model=MemoryResponse)
+async def set_memory_labels(
+    memory_id: uuid.UUID,
+    body: SetMemoryLabelsRequest,
+    session: AsyncSession = Depends(get_session),
+    tenant_id: str | None = Depends(get_tenant_id),
+):
+    """Replace a memory's `sensitivity_labels` with the supplied list.
+
+    Tenant-scoped: a memory belonging to another tenant returns 404,
+    not 403, so a tenant cannot probe another tenant's id space by
+    PATCHing an id and looking at the error code.
+
+    Labels are deduplicated, lowercased, and stripped of surrounding
+    whitespace before write — operator-supplied strings are
+    notoriously inconsistent, and the policy evaluator does exact
+    match, so normalizing at the write boundary is the only place to
+    do it safely. An empty list clears all labels (the memory becomes
+    untagged → policy default-allow).
+    """
+    # Canonicalize labels so policy evaluation is stable regardless of
+    # how the operator typed them. Cap at 32 entries (Pydantic
+    # validation already enforces this; defensive recheck here).
+    normalized = sorted({lbl.strip().lower() for lbl in body.sensitivity_labels if lbl.strip()})
+    if len(normalized) > 32:
+        raise HTTPException(status_code=400, detail="too many labels (max 32)")
+
+    stmt = select(MemoryRow).where(MemoryRow.id == memory_id)
+    if tenant_id is not None:
+        stmt = stmt.where(MemoryRow.tenant_id == tenant_id)
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="memory not found")
+
+    update_stmt = (
+        update(MemoryRow)
+        .where(MemoryRow.id == memory_id)
+        .values(sensitivity_labels=normalized)
+    )
+    if tenant_id is not None:
+        update_stmt = update_stmt.where(MemoryRow.tenant_id == tenant_id)
+    await session.execute(update_stmt)
+    await session.commit()
+
+    # Re-fetch so the response carries the post-write timestamp.
+    result = await session.execute(stmt)
+    row = result.scalar_one()
+    logger.info(
+        "memory_labels_set",
+        memory_id=str(memory_id),
+        tenant_id=tenant_id,
+        labels=normalized,
+    )
+    return _to_response(row)

--- a/server/api/timeline.py
+++ b/server/api/timeline.py
@@ -51,6 +51,7 @@ async def get_timeline(
                 source_episode_ids=m.source_episode_ids or [],
                 metadata=m.metadata_,
                 status=m.status,
+                sensitivity_labels=list(m.sensitivity_labels or []),
                 created_at=m.created_at,
                 updated_at=m.updated_at,
             )

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -73,6 +73,13 @@ class MemoryRow(Base):
     )
     metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
     status: Mapped[str] = mapped_column(String(32), nullable=False, default="active")
+    # Per-memory capability tags consumed by the policy layer (issue #50).
+    # Empty list = untagged = policy default-allow. See migration 0018 for
+    # the GIN index that makes `sensitivity_labels && '{pii}'` cheap on the
+    # hot path.
+    sensitivity_labels: Mapped[list[str]] = mapped_column(
+        ARRAY(String()), nullable=False, default=list
+    )
     # Stored as pgvector `vector(EMBEDDING_DIMENSIONS)` since migration 0013.
     # Reads/writes happen as `list[float]` — the pgvector SQLAlchemy adapter
     # serializes/deserializes transparently. Cosine search uses the SQL `<=>`

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -72,6 +72,25 @@ class GetContextRequest(BaseModel):
         max_length=26,
         description="ULID of a parent receipt to chain this assembly to.",
     )
+    caller_id: str | None = Field(
+        None,
+        max_length=256,
+        description=(
+            "Identity of the caller making the request — consumed by the "
+            "sensitivity-label policy layer (#50). When the tenant config "
+            "sets `require_caller_identity: true`, this and `caller_type` "
+            "are mandatory and missing values return 401."
+        ),
+    )
+    caller_type: str | None = Field(
+        None,
+        max_length=64,
+        description=(
+            "Category of caller (e.g. 'support_agent', 'marketing_tool', "
+            "'eval_harness'). Used by policy predicates to express "
+            "tool-class-level rules without per-caller policy authoring."
+        ),
+    )
 
 
 class CreateResolutionRequest(BaseModel):
@@ -100,6 +119,28 @@ class HandoffRequest(BaseModel):
     query_id: str | None = Field(None, max_length=64)
     task_id: str | None = Field(None, max_length=64)
     parent_receipt_id: str | None = Field(None, max_length=26)
+    caller_id: str | None = Field(None, max_length=256)
+    caller_type: str | None = Field(None, max_length=64)
+
+
+class SetMemoryLabelsRequest(BaseModel):
+    """Body for PATCH /v1/memories/{memory_id}/labels.
+
+    Replaces the memory's sensitivity_labels with the supplied list.
+    Empty list clears all labels (memory becomes untagged → policy
+    default-allow). See docs/sensitivity-labels.md for the label
+    vocabulary recommendations and policy interaction.
+    """
+
+    sensitivity_labels: list[str] = Field(
+        default_factory=list,
+        max_length=32,
+        description=(
+            "Replacement label list. Capped at 32 entries to keep "
+            "policy evaluation bounded — labels are not free-form "
+            "metadata, they're an enumerable capability vocabulary."
+        ),
+    )
 
 
 class LLMChatMessage(BaseModel):

--- a/server/schemas/responses.py
+++ b/server/schemas/responses.py
@@ -41,6 +41,13 @@ class MemoryResponse(BaseModel):
     source_episode_ids: list[uuid.UUID]
     metadata: dict[str, Any]
     status: MemoryStatus
+    sensitivity_labels: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Per-memory capability tags consumed by the policy layer (#50). "
+            "Empty list = untagged = default-allow under any policy."
+        ),
+    )
     created_at: datetime
     updated_at: datetime
 

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -28,6 +28,7 @@ from server.schemas.responses import (
     MemoryResponse,
     SessionInfo,
 )
+from server.services import policy as policy_service
 from server.services import receipts as receipts_service
 from server.services.compilers.heuristic import extract_payload_text
 from server.services.embeddings import get_provider as get_embedding_provider
@@ -120,6 +121,8 @@ async def assemble_context(
     query_id: str | None = None,
     task_id: str | None = None,
     parent_receipt_id: str | None = None,
+    caller_id: str | None = None,
+    caller_type: str | None = None,
 ) -> ContextBundleResponse:
     """Build a deterministic, token-bounded, ranked context bundle.
 
@@ -250,6 +253,68 @@ async def assemble_context(
         fact_rows = list(fact_rows) + added_facts
         procedure_rows = list(procedure_rows) + added_procs
         summary_rows = list(summary_rows) + added_summaries
+
+    # -- Apply sensitivity-label policy (#50) -------------------------------
+    # Evaluate each candidate memory against the active policy bundle BEFORE
+    # scoring, so denied rows never enter the ranker and the receipt's
+    # `policy.filters_applied` records every fired rule. In log_only mode
+    # (the default) no row is removed — the decisions are still recorded
+    # into the receipt so tenants can audit what *would* be filtered before
+    # flipping to enforce.
+    tenant_config = await receipts_service.load_tenant_receipt_config(
+        session, tenant_id
+    )
+    policy_mode = (tenant_config or {}).get("policy_mode", "log_only")
+    policy_enforce = policy_mode == "enforce"
+    active_bundle = await policy_service.resolve_active_bundle(session, tenant_id)
+    policy_context = policy_service.PolicyContext(
+        caller_id=caller_id,
+        caller_type=caller_type,
+        tenant_id=tenant_id,
+    )
+
+    all_memory_rows_pre_policy = (
+        list(fact_rows) + list(procedure_rows) + list(summary_rows)
+    )
+    policy_decisions: dict[Any, policy_service.MemoryPolicyDecision] = {}
+    for row in all_memory_rows_pre_policy:
+        decision = policy_service.evaluate_memory(
+            memory_labels=list(getattr(row, "sensitivity_labels", None) or []),
+            bundle=active_bundle,
+            context=policy_context,
+        )
+        if decision.action != "allow":
+            policy_decisions[row.id] = decision
+
+    if policy_enforce and policy_decisions:
+        # Filter the per-kind buckets so the rest of the assembly path
+        # never sees a denied row. Redact is applied in place by
+        # apply_decisions and the row is kept.
+        kept_facts, _ = policy_service.apply_decisions(
+            fact_rows, policy_decisions, enforce=True
+        )
+        kept_procs, _ = policy_service.apply_decisions(
+            procedure_rows, policy_decisions, enforce=True
+        )
+        kept_summaries, _ = policy_service.apply_decisions(
+            summary_rows, policy_decisions, enforce=True
+        )
+        fact_rows = kept_facts
+        procedure_rows = kept_procs
+        summary_rows = kept_summaries
+        denied_count = sum(
+            1 for d in policy_decisions.values() if d.action == "deny"
+        )
+        redacted_count = sum(
+            1 for d in policy_decisions.values() if d.action == "redact"
+        )
+        logger.info(
+            "policy_enforced",
+            tenant_id=tenant_id,
+            bundle_hash=active_bundle.bundle_hash if active_bundle else None,
+            denied=denied_count,
+            redacted=redacted_count,
+        )
 
     # -- Score all candidates ------------------------------------------------
     task_tokens = _tokenize_for_relevance(task)
@@ -577,6 +642,12 @@ async def assemble_context(
         task_id=task_id,
         parent_receipt_id=parent_receipt_id,
         mode="retrieval",
+        caller_id=caller_id,
+        caller_type=caller_type,
+        tenant_config=tenant_config,
+        policy_bundle=active_bundle,
+        policy_mode=policy_mode,
+        policy_decisions=policy_decisions,
     )
 
     return ContextBundleResponse(
@@ -610,19 +681,26 @@ async def _maybe_emit_receipt(
     task_id: str | None,
     parent_receipt_id: str | None,
     mode: str,
+    caller_id: str | None = None,
+    caller_type: str | None = None,
+    tenant_config: dict[str, Any] | None = None,
+    policy_bundle: policy_service.PolicyBundle | None = None,
+    policy_mode: str = "log_only",
+    policy_decisions: dict[Any, policy_service.MemoryPolicyDecision] | None = None,
 ) -> tuple[str | None, bool]:
     """Decide, build, and persist a receipt. Returns (receipt_id, emitted).
 
     Both surfaces that emit receipts (`/v1/context` and `/v1/handoff`)
     share this routine — keeping the decision logic and the write path
     in a single place avoids divergence as the schema grows."""
-    tenant_config = await receipts_service.load_tenant_receipt_config(
-        session, tenant_id
-    )
+    if tenant_config is None:
+        tenant_config = await receipts_service.load_tenant_receipt_config(
+            session, tenant_id
+        )
     decision = receipts_service.decide_emission(
         request_flag=emit_receipt,
         tenant_config=tenant_config,
-        policy_decision=None,  # reserved for #50
+        policy_decision=None,  # reserved for force-on (#50 v2)
     )
     if not decision.emit:
         logger.debug(
@@ -634,6 +712,11 @@ async def _maybe_emit_receipt(
         return None, False
 
     context_hash, context_size_bytes = receipts_service.canonicalize_context(assembled)
+    policy_decisions = policy_decisions or {}
+    filters_applied = policy_service.build_filters_applied(policy_decisions)
+    filters_skipped = policy_service.build_filters_skipped(
+        policy_decisions, policy_bundle
+    )
 
     selected_memories = [
         receipts_service.SelectedMemory(
@@ -675,6 +758,12 @@ async def _maybe_emit_receipt(
         query_id=query_id,
         task_id=task_id,
         parent_receipt_id=parent_receipt_id,
+        policy_bundle_hash=policy_bundle.bundle_hash if policy_bundle else None,
+        policy_mode=policy_mode,
+        filters_applied=filters_applied,
+        filters_skipped=filters_skipped,
+        caller_id=caller_id,
+        caller_type=caller_type,
     )
     written_id = await receipts_service.write_receipt(
         session, receipt_body=body, as_of=as_of
@@ -691,6 +780,10 @@ async def _maybe_emit_receipt(
         memory_count=len(selected_memories),
         episode_count=len(selected_episodes),
         context_size_bytes=context_size_bytes,
+        policy_filters_applied=len(filters_applied),
+        policy_bundle_hash=(
+            policy_bundle.bundle_hash if policy_bundle else None
+        ),
     )
     return written_id, True
 
@@ -991,6 +1084,7 @@ def _memory_response(row: Any) -> MemoryResponse:
         source_episode_ids=row.source_episode_ids or [],
         metadata=row.metadata_,
         status=row.status,
+        sensitivity_labels=list(getattr(row, "sensitivity_labels", None) or []),
         created_at=row.created_at,
         updated_at=row.updated_at,
     )

--- a/server/services/handoff.py
+++ b/server/services/handoff.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from server.core.config import settings
 from server.db import repositories as repo
 from server.schemas.responses import HandoffResponse, HealthFactorResponse, ResolutionSummaryItem
+from server.services import policy as policy_service
 from server.services import receipts as receipts_service
 from server.services.compilers.heuristic import extract_payload_text
 from server.services.health import compute_health
@@ -40,6 +41,8 @@ async def assemble_handoff(
     query_id: str | None = None,
     task_id: str | None = None,
     parent_receipt_id: str | None = None,
+    caller_id: str | None = None,
+    caller_type: str | None = None,
 ) -> HandoffResponse:
     """Build a compact handoff context pack for agent escalation/transfer."""
     budget = max_tokens or 4000
@@ -56,6 +59,36 @@ async def assemble_handoff(
     resolution_rows = await repo.list_resolutions(
         session, subject_id, tenant_id=tenant_id, limit=20
     )
+
+    # -- Sensitivity-label policy (#50) --------------------------------------
+    # Handoff briefs are sent to agents/operators downstream, so they go
+    # through the same policy gate as /v1/context. The active bundle is
+    # the same one /v1/context resolves; log_only vs enforce is the same
+    # per-tenant flag.
+    tenant_config = await receipts_service.load_tenant_receipt_config(
+        session, tenant_id
+    )
+    policy_mode = (tenant_config or {}).get("policy_mode", "log_only")
+    policy_enforce = policy_mode == "enforce"
+    active_bundle = await policy_service.resolve_active_bundle(session, tenant_id)
+    policy_context = policy_service.PolicyContext(
+        caller_id=caller_id,
+        caller_type=caller_type,
+        tenant_id=tenant_id,
+    )
+    policy_decisions: dict[Any, policy_service.MemoryPolicyDecision] = {}
+    for row in fact_rows:
+        decision = policy_service.evaluate_memory(
+            memory_labels=list(getattr(row, "sensitivity_labels", None) or []),
+            bundle=active_bundle,
+            context=policy_context,
+        )
+        if decision.action != "allow":
+            policy_decisions[row.id] = decision
+    if policy_enforce and policy_decisions:
+        fact_rows, _ = policy_service.apply_decisions(
+            fact_rows, policy_decisions, enforce=True
+        )
 
     # -- Key facts ----------------------------------------------------------
     key_facts = [row.content for row in fact_rows if row.status == "active"]
@@ -246,6 +279,12 @@ async def assemble_handoff(
         query_id=query_id,
         task_id=task_id,
         parent_receipt_id=parent_receipt_id,
+        caller_id=caller_id,
+        caller_type=caller_type,
+        tenant_config=tenant_config,
+        policy_bundle=active_bundle,
+        policy_mode=policy_mode,
+        policy_decisions=policy_decisions,
     )
 
     return HandoffResponse(
@@ -290,15 +329,22 @@ async def _maybe_emit_handoff_receipt(
     query_id: str | None,
     task_id: str | None,
     parent_receipt_id: str | None,
+    caller_id: str | None = None,
+    caller_type: str | None = None,
+    tenant_config: dict[str, Any] | None = None,
+    policy_bundle: policy_service.PolicyBundle | None = None,
+    policy_mode: str = "log_only",
+    policy_decisions: dict[Any, policy_service.MemoryPolicyDecision] | None = None,
 ) -> tuple[str | None, bool]:
     """Decide-and-write a handoff receipt. Mirrors the /v1/context flow
     but uses `mode="retrieval"` (v1 has one mode; future handoff-specific
     modes can subdivide if needed). Receipt task text is the synthetic
     `handoff:{reason}` string so audit dashboards can filter handoffs
     cleanly from regular retrievals."""
-    tenant_config = await receipts_service.load_tenant_receipt_config(
-        session, tenant_id
-    )
+    if tenant_config is None:
+        tenant_config = await receipts_service.load_tenant_receipt_config(
+            session, tenant_id
+        )
     decision = receipts_service.decide_emission(
         request_flag=emit_receipt,
         tenant_config=tenant_config,
@@ -309,6 +355,11 @@ async def _maybe_emit_handoff_receipt(
 
     context_hash, context_size_bytes = receipts_service.canonicalize_context(
         handoff_notes
+    )
+    policy_decisions = policy_decisions or {}
+    filters_applied = policy_service.build_filters_applied(policy_decisions)
+    filters_skipped = policy_service.build_filters_skipped(
+        policy_decisions, policy_bundle
     )
 
     rank = 0
@@ -355,6 +406,12 @@ async def _maybe_emit_handoff_receipt(
         query_id=query_id,
         task_id=task_id,
         parent_receipt_id=parent_receipt_id,
+        policy_bundle_hash=policy_bundle.bundle_hash if policy_bundle else None,
+        policy_mode=policy_mode,
+        filters_applied=filters_applied,
+        filters_skipped=filters_skipped,
+        caller_id=caller_id,
+        caller_type=caller_type,
     )
     written_id = await receipts_service.write_receipt(
         session, receipt_body=body, as_of=as_of

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0017_receipts_and_policy"
+EXPECTED_HEAD = "0018_sensitivity_labels"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/server/services/policy.py
+++ b/server/services/policy.py
@@ -1,0 +1,555 @@
+"""Sensitivity-label policy layer (issue #50).
+
+The policy layer reads per-memory `sensitivity_labels` (added in
+migration 0018) and decides, for each memory in a context assembly,
+whether the caller is allowed to receive it. Decisions are always
+recorded into the state-assembly receipt's `policy.filters_applied`
+field; whether they're *enforced* (memory dropped or redacted) is
+governed by the tenant's `policy_mode` config:
+
+  * `log_only` (default) — decisions go into the receipt; nothing is
+    filtered from the response. This is the safe-rollout mode: a
+    tenant can observe what *would* be filtered for a week or two
+    before flipping to enforce.
+  * `enforce` — decisions are applied. `deny` drops the memory from
+    `selected_entries`; `redact` replaces its content with a stable
+    redaction marker (the memory still appears so the receipt records
+    that the policy fired).
+
+## Policy format
+
+Policy bundles are YAML (or JSON — both parse with `yaml.safe_load`).
+Each bundle is content-hashed at load time; receipts reference the
+hash, which makes "what did policy abc123 say on date Y?" answerable
+forever — the load-bearing replay feature.
+
+    version: 1
+    metadata:
+      description: "Production policy bundle v3"
+      authored_by: "security-team@example.com"
+    rules:
+      - id: deny-pii-for-marketing-tools
+        description: PII memories cannot be read by marketing tools
+        when:
+          memory_has_any_label: [pii, sensitive_personal]
+          caller_type: marketing_tool
+        action: deny
+      - id: redact-secrets-for-non-admin
+        when:
+          memory_has_any_label: [secret, api_key]
+          caller_type_not_in: [admin, security]
+        action: redact
+
+## v1 predicates and actions
+
+Predicates (inside `when:`):
+  * `memory_has_any_label: [tag, ...]` — fires when the memory's
+    `sensitivity_labels` overlaps the list (disjunctive).
+  * `memory_has_all_labels: [tag, ...]` — fires only when every
+    listed label is present (conjunctive).
+  * `caller_type: "..."` — exact-match on the request's caller_type.
+  * `caller_type_in: [...]` — list-membership.
+  * `caller_type_not_in: [...]` — negated list-membership.
+  * `caller_id: "..."` — exact-match on caller_id.
+
+All listed predicates within a single `when:` are AND-ed. A rule with
+no predicates is a load-time validation error (it would match every
+memory, which is almost always a bug).
+
+Actions:
+  * `deny` — exclude the memory under enforce mode.
+  * `redact` — keep the memory but replace `content` with the
+    redaction marker under enforce mode.
+
+Rules are evaluated in declaration order; the first matching rule
+wins. A memory that matches no rule falls through to default-allow.
+Regex predicates and explicit `allow` rules are deferred to v2 — the
+schema reserves the space for them.
+
+## Bundle resolution
+
+For an assembly call running under tenant `T`:
+  1. Look up the `active=true` row in `policy_bundles` where
+     `tenant_id = T`. If one exists, use it.
+  2. Otherwise, look up the global active row (`tenant_id = NULL`).
+     If one exists, use it.
+  3. Otherwise, no policy is loaded — every memory is default-allow,
+     `filters_applied` and `filters_skipped` on the receipt stay
+     empty, and `policy_bundle_hash` stays null.
+
+Caching: the active bundle for a tenant is cached in-process for
+60 seconds. `POST /admin/policy/reload` busts the cache immediately.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+import yaml
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.db.tables import PolicyBundleRow
+
+# Single redaction marker — stable so consumers can dedupe / detect
+# redaction without re-parsing the rule id.
+REDACTED_MARKER = "[REDACTED by policy]"
+
+# Active-bundle cache TTL. Short enough that policy-reload latency
+# feels live; long enough that the cache earns its keep under
+# request-per-second loads on the hot path.
+_BUNDLE_CACHE_TTL_SECONDS = 60
+
+
+# ---------------------------------------------------------------------------
+# Data shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    """One rule inside a bundle. Predicates are stored as a dict so a
+    rule's serialization round-trips through YAML/JSON unchanged for
+    the content-hash to remain stable across releases."""
+
+    id: str
+    description: str
+    when: dict[str, Any]
+    action: str  # "deny" | "redact"
+
+
+@dataclass(frozen=True)
+class PolicyBundle:
+    """Immutable loaded policy. Identified by its content hash."""
+
+    bundle_hash: str
+    version: int
+    metadata: dict[str, Any]
+    rules: tuple[PolicyRule, ...]
+    yaml_content: str
+
+    @property
+    def rule_count(self) -> int:
+        return len(self.rules)
+
+
+@dataclass(frozen=True)
+class PolicyContext:
+    """The per-request inputs the evaluator consults."""
+
+    caller_id: str | None
+    caller_type: str | None
+    tenant_id: str | None
+
+
+@dataclass(frozen=True)
+class MemoryPolicyDecision:
+    """Decision for a single (memory, request) pair."""
+
+    action: str  # "allow" | "deny" | "redact"
+    rule_id: str | None
+    matched_labels: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Bundle loading + validation
+# ---------------------------------------------------------------------------
+
+
+# Predicate keys the v1 evaluator understands. Anything else in a
+# rule's `when:` block is a load-time validation error — unknown
+# predicates can't silently pass through as no-ops because a tenant
+# would think their rule is firing when it isn't.
+_KNOWN_PREDICATES = frozenset(
+    [
+        "memory_has_any_label",
+        "memory_has_all_labels",
+        "caller_type",
+        "caller_type_in",
+        "caller_type_not_in",
+        "caller_id",
+    ]
+)
+
+_KNOWN_ACTIONS = frozenset(["deny", "redact"])
+
+
+class PolicyError(ValueError):
+    """Raised on policy load-time validation failures."""
+
+
+def load_bundle(yaml_or_json: str) -> PolicyBundle:
+    """Parse + validate a policy bundle. Computes the content hash
+    over a canonical JSON form so the same logical rules hash to the
+    same value regardless of YAML formatting / comments / key order.
+    """
+    try:
+        doc = yaml.safe_load(yaml_or_json)
+    except yaml.YAMLError as e:
+        raise PolicyError(f"invalid YAML/JSON: {e}") from e
+    if not isinstance(doc, dict):
+        raise PolicyError("policy bundle must be a mapping at the top level")
+
+    version = doc.get("version")
+    if version != 1:
+        raise PolicyError("only policy schema version 1 is supported in v1")
+
+    metadata = doc.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        raise PolicyError("metadata must be a mapping")
+
+    rules_raw = doc.get("rules") or []
+    if not isinstance(rules_raw, list):
+        raise PolicyError("rules must be a list")
+
+    rules: list[PolicyRule] = []
+    seen_ids: set[str] = set()
+    for idx, r in enumerate(rules_raw):
+        if not isinstance(r, dict):
+            raise PolicyError(f"rule #{idx} must be a mapping")
+        rid = r.get("id")
+        if not isinstance(rid, str) or not rid:
+            raise PolicyError(f"rule #{idx} is missing a non-empty `id`")
+        if rid in seen_ids:
+            raise PolicyError(f"duplicate rule id: {rid!r}")
+        seen_ids.add(rid)
+        when = r.get("when") or {}
+        if not isinstance(when, dict) or not when:
+            raise PolicyError(
+                f"rule {rid!r}: `when` must be a non-empty mapping — a rule "
+                "with no predicates would match every memory"
+            )
+        unknown = set(when.keys()) - _KNOWN_PREDICATES
+        if unknown:
+            raise PolicyError(
+                f"rule {rid!r}: unknown predicate(s): {sorted(unknown)}"
+            )
+        _validate_predicate_shapes(rid, when)
+        action = r.get("action")
+        if action not in _KNOWN_ACTIONS:
+            raise PolicyError(
+                f"rule {rid!r}: action must be one of {sorted(_KNOWN_ACTIONS)}, "
+                f"got {action!r}"
+            )
+        description = r.get("description") or ""
+        if not isinstance(description, str):
+            raise PolicyError(f"rule {rid!r}: description must be a string")
+        rules.append(
+            PolicyRule(
+                id=rid,
+                description=description,
+                when=dict(when),
+                action=action,
+            )
+        )
+
+    # Content hash: canonical JSON with sorted keys so YAML reflow,
+    # comments, or key reordering don't change the hash.
+    canonical = json.dumps(
+        {
+            "version": version,
+            "metadata": metadata,
+            "rules": [
+                {
+                    "id": r.id,
+                    "description": r.description,
+                    "when": r.when,
+                    "action": r.action,
+                }
+                for r in rules
+            ],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    bundle_hash = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    return PolicyBundle(
+        bundle_hash=bundle_hash,
+        version=version,
+        metadata=metadata,
+        rules=tuple(rules),
+        yaml_content=yaml_or_json,
+    )
+
+
+def _validate_predicate_shapes(rule_id: str, when: dict[str, Any]) -> None:
+    """Each predicate's value must be the right Python type — a typo
+    that swaps `caller_type: x` for `caller_type: [x]` would silently
+    never match, which is exactly the failure mode we don't want."""
+    for key, value in when.items():
+        if key in {"memory_has_any_label", "memory_has_all_labels"}:
+            if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+                raise PolicyError(
+                    f"rule {rule_id!r}: {key} must be a list of strings"
+                )
+            if not value:
+                raise PolicyError(
+                    f"rule {rule_id!r}: {key} cannot be empty — an empty "
+                    "label-set match is ambiguous"
+                )
+        elif key in {"caller_type_in", "caller_type_not_in"}:
+            if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+                raise PolicyError(
+                    f"rule {rule_id!r}: {key} must be a list of strings"
+                )
+            if not value:
+                raise PolicyError(
+                    f"rule {rule_id!r}: {key} cannot be empty"
+                )
+        elif key in {"caller_type", "caller_id"}:
+            if not isinstance(value, str) or not value:
+                raise PolicyError(
+                    f"rule {rule_id!r}: {key} must be a non-empty string"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Bundle resolution + caching
+# ---------------------------------------------------------------------------
+
+
+# Module-level cache. Key is `(tenant_id_or_none, "default")`. The
+# value is `(loaded_at_seconds, bundle_or_none)`. Even None is
+# cached — "no active bundle for this tenant" is a hot answer too.
+_active_bundle_cache: dict[tuple[str | None], tuple[float, PolicyBundle | None]] = {}
+
+
+def invalidate_bundle_cache() -> None:
+    """Drop every cached bundle. Called by `POST /admin/policy/reload`."""
+    _active_bundle_cache.clear()
+
+
+async def resolve_active_bundle(
+    session: AsyncSession,
+    tenant_id: str | None,
+) -> PolicyBundle | None:
+    """Return the active bundle for a tenant, falling back to the
+    global active bundle. None if neither exists.
+
+    Cached for `_BUNDLE_CACHE_TTL_SECONDS` per tenant key. The bundle
+    is keyed by `tenant_id` (or None for the global slot) and the
+    cache is busted by `invalidate_bundle_cache()` on policy reload.
+
+    Fail-open: if the DB call raises (table missing pre-migration,
+    transient connection failure), this returns None and the caller
+    defaults to "no bundle loaded → everything allowed." That matches
+    pre-#50 behaviour exactly, so a degraded policy table never
+    breaks agent serving. The failure is logged.
+    """
+    cache_key: tuple[str | None] = (tenant_id,)
+    cached = _active_bundle_cache.get(cache_key)
+    now = time.monotonic()
+    if cached is not None:
+        loaded_at, bundle = cached
+        if now - loaded_at < _BUNDLE_CACHE_TTL_SECONDS:
+            return bundle
+
+    try:
+        bundle = await _load_active_from_db(session, tenant_id)
+    except Exception:
+        import structlog
+        structlog.stdlib.get_logger().warning(
+            "policy_bundle_resolution_failed",
+            tenant_id=tenant_id,
+            exc_info=True,
+        )
+        bundle = None
+    _active_bundle_cache[cache_key] = (now, bundle)
+    return bundle
+
+
+async def _load_active_from_db(
+    session: AsyncSession,
+    tenant_id: str | None,
+) -> PolicyBundle | None:
+    """Try tenant-specific first, then global. Returns the parsed
+    bundle or None when neither slot has an active row."""
+    if tenant_id is not None:
+        stmt = (
+            select(PolicyBundleRow)
+            .where(PolicyBundleRow.tenant_id == tenant_id)
+            .where(PolicyBundleRow.active.is_(True))
+            .order_by(PolicyBundleRow.created_at.desc())
+            .limit(1)
+        )
+        result = await session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is not None:
+            return load_bundle(row.yaml_content)
+
+    stmt = (
+        select(PolicyBundleRow)
+        .where(PolicyBundleRow.tenant_id.is_(None))
+        .where(PolicyBundleRow.active.is_(True))
+        .order_by(PolicyBundleRow.created_at.desc())
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is not None:
+        return load_bundle(row.yaml_content)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_memory(
+    *,
+    memory_labels: Sequence[str],
+    bundle: PolicyBundle | None,
+    context: PolicyContext,
+) -> MemoryPolicyDecision:
+    """Apply the bundle's rules to one memory in declaration order.
+    First matching rule wins; no match → default-allow.
+
+    Pure function — no DB, no IO. Tested directly in
+    tests/test_policy.py with synthetic rules and memories.
+    """
+    if bundle is None or not bundle.rules:
+        return MemoryPolicyDecision(action="allow", rule_id=None)
+
+    for rule in bundle.rules:
+        matched, matched_labels = _rule_matches(rule, memory_labels, context)
+        if matched:
+            return MemoryPolicyDecision(
+                action=rule.action,
+                rule_id=rule.id,
+                matched_labels=matched_labels,
+            )
+    return MemoryPolicyDecision(action="allow", rule_id=None)
+
+
+def _rule_matches(
+    rule: PolicyRule,
+    memory_labels: Sequence[str],
+    context: PolicyContext,
+) -> tuple[bool, list[str]]:
+    """Returns `(matches, labels_that_matched)`. All predicates inside
+    `when` are AND-ed; if any returns False the whole rule does not
+    match. `labels_that_matched` is the intersection of memory labels
+    with the rule's label set, when label predicates participated."""
+    labels_set = set(memory_labels or [])
+    matched_labels: list[str] = []
+    for key, value in rule.when.items():
+        if key == "memory_has_any_label":
+            overlap = labels_set & set(value)
+            if not overlap:
+                return False, []
+            matched_labels.extend(sorted(overlap))
+        elif key == "memory_has_all_labels":
+            required = set(value)
+            if not required.issubset(labels_set):
+                return False, []
+            matched_labels.extend(sorted(required))
+        elif key == "caller_type":
+            if context.caller_type != value:
+                return False, []
+        elif key == "caller_type_in":
+            if context.caller_type not in value:
+                return False, []
+        elif key == "caller_type_not_in":
+            if context.caller_type in value:
+                return False, []
+        elif key == "caller_id":
+            if context.caller_id != value:
+                return False, []
+    return True, sorted(set(matched_labels))
+
+
+# ---------------------------------------------------------------------------
+# Helpers for the assembly path
+# ---------------------------------------------------------------------------
+
+
+def apply_decisions(
+    rows: Iterable[Any],
+    decisions: dict[Any, MemoryPolicyDecision],
+    *,
+    enforce: bool,
+) -> tuple[list[Any], list[Any]]:
+    """Given a list of memory rows and per-id decisions, return
+    `(kept_rows, denied_rows)`. When `enforce=False` (log-only mode),
+    every row is kept and `denied_rows` is empty — but the decisions
+    dict is still consumed downstream to populate the receipt.
+
+    `redact` is applied by mutating the in-memory row's `content`
+    field in place (the row object is a transient SQLAlchemy ORM
+    instance; the underlying DB row is not touched). The receipt
+    still records the redaction so consumers can detect it.
+    """
+    if not enforce:
+        return list(rows), []
+    kept: list[Any] = []
+    denied: list[Any] = []
+    for row in rows:
+        decision = decisions.get(row.id)
+        if decision is None or decision.action == "allow":
+            kept.append(row)
+        elif decision.action == "deny":
+            denied.append(row)
+        elif decision.action == "redact":
+            # Mutate the transient row — the DB-side memory is
+            # untouched. Downstream rendering sees the marker;
+            # the receipt's selected_entries still records the row.
+            row.content = REDACTED_MARKER
+            kept.append(row)
+        else:  # defensive — load-time validation already gates this
+            kept.append(row)
+    return kept, denied
+
+
+def build_filters_applied(
+    decisions: dict[Any, MemoryPolicyDecision],
+) -> list[dict[str, Any]]:
+    """Build the receipt's `policy.filters_applied` block — one entry
+    per memory where a rule fired (deny or redact). Memories that
+    fell through to default-allow are NOT recorded; doing so would
+    add an entry per memory per call and blow up receipt size at no
+    forensic benefit."""
+    out: list[dict[str, Any]] = []
+    for memory_id, decision in decisions.items():
+        if decision.action == "allow":
+            continue
+        out.append(
+            {
+                "memory_id": str(memory_id),
+                "rule_id": decision.rule_id,
+                "action": decision.action,
+                "matched_labels": list(decision.matched_labels),
+            }
+        )
+    return out
+
+
+def build_filters_skipped(
+    decisions: dict[Any, MemoryPolicyDecision],
+    bundle: PolicyBundle | None,
+) -> list[dict[str, Any]]:
+    """One entry per *rule* that was evaluated but matched zero
+    memories. Bounded by `len(bundle.rules)` — does not scale with
+    memory count.
+
+    This is the answer to issue #49's `filters_skipped`: "evaluated
+    but did not match." Per-memory miss-by-miss would be unbounded
+    and uninteresting; per-rule miss totals are exactly the signal a
+    compliance reviewer wants ("did our PII rule actually fire on
+    anything this hour?")."""
+    if bundle is None:
+        return []
+    fired_rule_ids = {
+        d.rule_id for d in decisions.values() if d.rule_id is not None
+    }
+    return [
+        {"rule_id": rule.id, "action": rule.action, "matched": False}
+        for rule in bundle.rules
+        if rule.id not in fired_rule_ids
+    ]

--- a/server/services/receipts.py
+++ b/server/services/receipts.py
@@ -233,6 +233,11 @@ def build_receipt_body(
     task_id: str | None = None,
     parent_receipt_id: str | None = None,
     policy_bundle_hash: str | None = None,
+    policy_mode: str = "log_only",
+    filters_applied: list[dict[str, Any]] | None = None,
+    filters_skipped: list[dict[str, Any]] | None = None,
+    caller_id: str | None = None,
+    caller_type: str | None = None,
     region: str | None = None,
 ) -> dict[str, Any]:
     """Render the strict-superset receipt body. Pure function — same
@@ -281,15 +286,21 @@ def build_receipt_body(
         "task": task,
         "as_of": _iso(as_of),
         "created_at": _iso(created_at),
+        # Caller identity (#50) — the request fields the policy layer
+        # evaluated against. Null when the caller is anonymous (the
+        # default for tenants that don't `require_caller_identity`).
+        "caller_id": caller_id,
+        "caller_type": caller_type,
         "selected_entries": entries,
         "policy": {
-            # v1 ships with the policy layer absent. Issue #50 fills
-            # these in. The keys exist so consumers can write code now
-            # that won't break when policy lands.
+            # Filled in by the policy layer (#50) when a bundle is
+            # active. Untagged-everywhere tenants and no-bundle
+            # deployments get the same empty shape they got pre-#50,
+            # which is exactly the right answer.
             "policy_bundle_hash": policy_bundle_hash,
-            "filters_applied": [],
-            "filters_skipped": [],
-            "mode": "log_only",
+            "filters_applied": list(filters_applied or []),
+            "filters_skipped": list(filters_skipped or []),
+            "mode": policy_mode,
         },
         "output": {
             "context_hash": context_hash,

--- a/tests/integration/test_policy_api.py
+++ b/tests/integration/test_policy_api.py
@@ -1,0 +1,388 @@
+"""End-to-end policy tests (#50).
+
+Covers the three #50 acceptance-criteria negative tests against the
+real FastAPI app + real Postgres:
+
+  1. Sensitive memory must NOT be delivered to a disallowed caller
+     when policy_mode is `enforce`.
+  2. Filtered memory must NOT influence ranking (it doesn't even
+     reach the ranker — verified by absence from `provenance`).
+  3. A policy version bump must produce receipts that reference the
+     new `policy_bundle_hash` — old receipts pin the old hash, which
+     is the load-bearing replay property.
+
+Plus the happy path: a tenant in `log_only` mode receives unfiltered
+results but the receipt records every decision the policy would have
+made under enforce.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import update
+
+from server.db.tables import MemoryRow, PolicyBundleRow, TenantConfigRow
+from server.services import policy as policy_service
+
+
+PII_BUNDLE_YAML = """
+version: 1
+rules:
+  - id: deny-pii-for-marketing
+    when:
+      memory_has_any_label: [pii]
+      caller_type: marketing_tool
+    action: deny
+  - id: redact-secrets
+    when:
+      memory_has_any_label: [secret]
+    action: redact
+"""
+
+
+async def _seed_subject(client: AsyncClient, subject_id: str) -> None:
+    """Ingest two episodes and compile so the subject has memories
+    we can label."""
+    for ep in [
+        {
+            "source": "support-chat",
+            "type": "conversation",
+            "payload": {
+                "messages": [
+                    {"role": "user", "content": "My email is alice@globex.com."},
+                    {"role": "assistant", "content": "Noted."},
+                ]
+            },
+        },
+        {
+            "source": "support-chat",
+            "type": "conversation",
+            "payload": {
+                "messages": [
+                    {"role": "user", "content": "API key is sk-test-12345."},
+                    {"role": "assistant", "content": "Noted."},
+                ]
+            },
+        },
+    ]:
+        r = await client.post("/v1/episodes", json={**ep, "subject_id": subject_id})
+        assert r.status_code == 201
+    r = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert r.status_code == 200
+
+
+async def _label_first_memory(
+    session_factory, subject_id: str, labels: list[str]
+) -> None:
+    """Stamp `labels` onto the first memory for the subject. Used as
+    a fast in-test fixture — the /v1/memories/{id}/labels API path
+    is exercised by its own test below."""
+    async with session_factory() as session:
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(MemoryRow).where(MemoryRow.subject_id == subject_id).limit(1)
+        )
+        row = result.scalar_one()
+        await session.execute(
+            update(MemoryRow)
+            .where(MemoryRow.id == row.id)
+            .values(sensitivity_labels=labels)
+        )
+        await session.commit()
+
+
+async def _set_tenant_policy_mode(session_factory, tenant_id: str, mode: str) -> None:
+    """Insert/update `tenant_configs.config.policy_mode = mode`."""
+    async with session_factory() as session:
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(TenantConfigRow).where(TenantConfigRow.tenant_id == tenant_id)
+        )
+        existing = result.scalar_one_or_none()
+        if existing is None:
+            session.add(
+                TenantConfigRow(
+                    tenant_id=tenant_id,
+                    config={"policy_mode": mode},
+                )
+            )
+        else:
+            await session.execute(
+                update(TenantConfigRow)
+                .where(TenantConfigRow.tenant_id == tenant_id)
+                .values(config={**existing.config, "policy_mode": mode})
+            )
+        await session.commit()
+
+
+async def _install_active_policy(
+    session_factory, yaml_content: str, tenant_id: str | None = None
+) -> str:
+    """Insert + activate a policy bundle. Returns the hash. Mirrors
+    what `POST /admin/policy/bundles` does."""
+    bundle = policy_service.load_bundle(yaml_content)
+    async with session_factory() as session:
+        # Deactivate prior bundles in the same scope.
+        scope = update(PolicyBundleRow)
+        if tenant_id is None:
+            scope = scope.where(PolicyBundleRow.tenant_id.is_(None))
+        else:
+            scope = scope.where(PolicyBundleRow.tenant_id == tenant_id)
+        await session.execute(scope.values(active=False))
+        session.add(
+            PolicyBundleRow(
+                bundle_hash=bundle.bundle_hash,
+                yaml_content=yaml_content,
+                active=True,
+                tenant_id=tenant_id,
+            )
+        )
+        await session.commit()
+    policy_service.invalidate_bundle_cache()
+    return bundle.bundle_hash
+
+
+@pytest.mark.anyio
+async def test_pii_memory_blocked_for_marketing_caller_under_enforce(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """Issue #50 negative test: sensitive memory must NOT be
+    delivered to a disallowed caller when enforce is on."""
+    tenant_id = "acme"
+    client.headers["X-Tenant-ID"] = tenant_id
+
+    await _seed_subject(client, subject_id)
+    await _label_first_memory(session_factory, subject_id, ["pii"])
+    bundle_hash = await _install_active_policy(session_factory, PII_BUNDLE_YAML)
+    await _set_tenant_policy_mode(session_factory, tenant_id, "enforce")
+
+    r = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "Help the customer",
+            "caller_id": "agent-42",
+            "caller_type": "marketing_tool",
+            "emit_receipt": True,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    # The PII-labeled memory must not appear in the assembled context.
+    assert "alice@globex.com" not in body["assembled_context"]
+
+    # The receipt records the deny so a reviewer can verify the policy
+    # actually fired (rather than the memory just not having been
+    # selected for unrelated reasons).
+    r2 = await client.get(f"/v1/receipts/{body['receipt_id']}")
+    receipt = r2.json()
+    deny_decisions = [
+        f for f in receipt["policy"]["filters_applied"] if f["action"] == "deny"
+    ]
+    assert deny_decisions, "policy.filters_applied must record the deny"
+    assert receipt["policy"]["policy_bundle_hash"] == bundle_hash
+
+
+@pytest.mark.anyio
+async def test_log_only_mode_records_decisions_without_filtering(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """In log_only mode (the default), a tenant sees what *would* be
+    filtered without actually losing memories. This is the safe-
+    rollout property that lets compliance teams audit a policy for a
+    week before flipping enforce on."""
+    tenant_id = "acme-logonly"
+    client.headers["X-Tenant-ID"] = tenant_id
+
+    await _seed_subject(client, subject_id)
+    await _label_first_memory(session_factory, subject_id, ["pii"])
+    await _install_active_policy(session_factory, PII_BUNDLE_YAML)
+    # Explicitly NOT setting policy_mode → defaults to log_only.
+
+    r = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "Help the customer",
+            "caller_type": "marketing_tool",
+            "emit_receipt": True,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    # The memory IS still delivered — log_only doesn't filter.
+    assert "alice@globex.com" in body["assembled_context"]
+
+    r2 = await client.get(f"/v1/receipts/{body['receipt_id']}")
+    receipt = r2.json()
+    # …but the receipt records what would happen under enforce.
+    assert receipt["policy"]["mode"] == "log_only"
+    deny_decisions = [
+        f for f in receipt["policy"]["filters_applied"] if f["action"] == "deny"
+    ]
+    assert deny_decisions, "log_only must still record decisions"
+
+
+@pytest.mark.anyio
+async def test_policy_bundle_hash_changes_invalidate_audit_replay(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """Issue #50 negative test: a policy version bump must surface
+    in the receipts. Two assembly calls under different bundles must
+    record different `policy_bundle_hash` so audit replay can tell
+    which rules were in effect at decision time."""
+    tenant_id = "acme-replay"
+    client.headers["X-Tenant-ID"] = tenant_id
+
+    await _seed_subject(client, subject_id)
+    await _label_first_memory(session_factory, subject_id, ["pii"])
+
+    hash_v1 = await _install_active_policy(session_factory, PII_BUNDLE_YAML)
+    r1 = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "first call",
+            "caller_type": "marketing_tool",
+            "emit_receipt": True,
+        },
+    )
+    body1 = r1.json()
+    receipt1 = (await client.get(f"/v1/receipts/{body1['receipt_id']}")).json()
+
+    # Bump the policy: add a redact rule for a non-existent label.
+    # The bundle hash changes; subsequent receipts pin the new hash.
+    bundle_v2_yaml = PII_BUNDLE_YAML + """
+  - id: redact-internal
+    when: {memory_has_any_label: [internal]}
+    action: redact
+"""
+    hash_v2 = await _install_active_policy(session_factory, bundle_v2_yaml)
+    assert hash_v1 != hash_v2
+
+    r2 = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "second call",
+            "caller_type": "marketing_tool",
+            "emit_receipt": True,
+        },
+    )
+    body2 = r2.json()
+    receipt2 = (await client.get(f"/v1/receipts/{body2['receipt_id']}")).json()
+
+    assert receipt1["policy"]["policy_bundle_hash"] == hash_v1
+    assert receipt2["policy"]["policy_bundle_hash"] == hash_v2
+
+
+@pytest.mark.anyio
+async def test_caller_identity_required_when_tenant_config_flips_it_on(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """`require_caller_identity: true` is the compliance lever that
+    makes policy non-bypassable — unidentified callers can't slip
+    through with `caller_type=None`."""
+    tenant_id = "acme-strict"
+    client.headers["X-Tenant-ID"] = tenant_id
+
+    await _seed_subject(client, subject_id)
+    async with session_factory() as session:
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(TenantConfigRow).where(TenantConfigRow.tenant_id == tenant_id)
+        )
+        existing = result.scalar_one_or_none()
+        if existing is None:
+            session.add(
+                TenantConfigRow(
+                    tenant_id=tenant_id,
+                    config={"require_caller_identity": True},
+                )
+            )
+        else:
+            await session.execute(
+                update(TenantConfigRow)
+                .where(TenantConfigRow.tenant_id == tenant_id)
+                .values(config={**existing.config, "require_caller_identity": True})
+            )
+        await session.commit()
+
+    # Unidentified call → 401.
+    r = await client.post(
+        "/v1/context",
+        json={"subject_id": subject_id, "task": "x"},
+    )
+    assert r.status_code == 401
+
+    # Identified call → 200.
+    r2 = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "x",
+            "caller_id": "agent-1",
+            "caller_type": "support_agent",
+        },
+    )
+    assert r2.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_set_memory_labels_endpoint_normalizes_and_persists(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """PATCH /v1/memories/{id}/labels normalizes (dedup, lowercase,
+    strip) and persists. Read-after-write returns the canonicalized
+    set."""
+    tenant_id = "acme-labels"
+    client.headers["X-Tenant-ID"] = tenant_id
+
+    await _seed_subject(client, subject_id)
+    async with session_factory() as session:
+        from sqlalchemy import select
+
+        result = await session.execute(
+            select(MemoryRow).where(MemoryRow.subject_id == subject_id).limit(1)
+        )
+        memory_id = result.scalar_one().id
+
+    r = await client.patch(
+        f"/v1/memories/{memory_id}/labels",
+        json={"sensitivity_labels": [" PII ", "pii", "Financial", "financial"]},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["sensitivity_labels"] == ["financial", "pii"]
+
+
+@pytest.mark.anyio
+async def test_admin_policy_upload_and_activate_round_trip(client: AsyncClient):
+    """The /admin/policy/* endpoints lifecycle: upload a bundle,
+    list it, activate it, fetch active. Verifies the operator
+    surface end-to-end."""
+    r = await client.post(
+        "/admin/policy/bundles",
+        json={
+            "yaml_content": PII_BUNDLE_YAML,
+            "tenant_id": "acme-policy-admin",
+            "activate": True,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    bundle_hash = body["bundle_hash"]
+    assert body["active"] is True
+
+    r2 = await client.get("/admin/policy/bundles?tenant_id=acme-policy-admin")
+    assert r2.status_code == 200
+    bundles = r2.json()["bundles"]
+    assert any(b["bundle_hash"] == bundle_hash and b["active"] for b in bundles)
+
+    r3 = await client.get("/admin/policy/active?tenant_id=acme-policy-admin")
+    assert r3.status_code == 200
+    assert r3.json()["bundle_hash"] == bundle_hash

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 17
+    assert len(revs) == 18
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 7
+    assert result.pending_count == 8
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 17
+    assert result.pending_count == 18
 
 
 def test_resolve_pending_unknown_revision():

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,456 @@
+"""Unit tests for the sensitivity-label policy layer (#50).
+
+Three layers covered:
+  1. Bundle loading + validation — every documented schema error
+     surfaces a clear `PolicyError` rather than silently mis-parsing.
+  2. Evaluator semantics — the per-rule predicates each behave as
+     documented, AND-semantics inside `when:`, first-match-wins
+     across rules, default-allow when nothing matches.
+  3. Receipt projection — `build_filters_applied` and
+     `build_filters_skipped` produce the exact shape the receipt
+     consumes, including the bounded `filters_skipped` size guarantee.
+
+The integration-level tests for policy log_only vs enforce behaviour
+against a real assembly call live in tests/integration/test_policy_api.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from server.services.policy import (
+    PolicyContext,
+    PolicyError,
+    apply_decisions,
+    build_filters_applied,
+    build_filters_skipped,
+    evaluate_memory,
+    load_bundle,
+    REDACTED_MARKER,
+)
+
+
+# ---------------------------------------------------------------------------
+# load_bundle — schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_load_minimal_bundle_succeeds():
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: r1
+            when: {memory_has_any_label: [pii]}
+            action: deny
+        """
+    )
+    assert b.rule_count == 1
+    assert b.rules[0].id == "r1"
+    assert b.rules[0].action == "deny"
+
+
+def test_load_json_form_also_works():
+    """JSON is a subset of YAML 1.2 — both should load cleanly."""
+    b = load_bundle(
+        '{"version": 1, "rules": [{"id": "r1", "when": {"memory_has_any_label": ["pii"]}, "action": "deny"}]}'
+    )
+    assert b.rule_count == 1
+
+
+def test_load_rejects_wrong_version():
+    with pytest.raises(PolicyError, match="version 1"):
+        load_bundle("version: 2\nrules: []")
+
+
+def test_load_rejects_top_level_list():
+    with pytest.raises(PolicyError, match="mapping at the top level"):
+        load_bundle("- not\n- a\n- bundle")
+
+
+def test_load_rejects_empty_when_block():
+    # A rule that matches every memory is almost always a bug — the
+    # parser refuses rather than silently accepting it.
+    with pytest.raises(PolicyError, match="non-empty mapping"):
+        load_bundle(
+            """
+            version: 1
+            rules:
+              - id: r1
+                when: {}
+                action: deny
+            """
+        )
+
+
+def test_load_rejects_unknown_predicate():
+    with pytest.raises(PolicyError, match="unknown predicate"):
+        load_bundle(
+            """
+            version: 1
+            rules:
+              - id: r1
+                when: {memory_has_any_label: [pii], future_predicate: x}
+                action: deny
+            """
+        )
+
+
+def test_load_rejects_unknown_action():
+    with pytest.raises(PolicyError, match="action must be"):
+        load_bundle(
+            """
+            version: 1
+            rules:
+              - id: r1
+                when: {memory_has_any_label: [pii]}
+                action: log
+            """
+        )
+
+
+def test_load_rejects_duplicate_rule_id():
+    with pytest.raises(PolicyError, match="duplicate rule id"):
+        load_bundle(
+            """
+            version: 1
+            rules:
+              - id: r1
+                when: {memory_has_any_label: [pii]}
+                action: deny
+              - id: r1
+                when: {memory_has_any_label: [financial]}
+                action: deny
+            """
+        )
+
+
+def test_load_rejects_predicate_type_mismatch():
+    """`caller_type: [x]` instead of `caller_type: "x"` would
+    silently never match. The loader refuses."""
+    with pytest.raises(PolicyError, match="must be a non-empty string"):
+        load_bundle(
+            """
+            version: 1
+            rules:
+              - id: r1
+                when: {memory_has_any_label: [pii], caller_type: [mt]}
+                action: deny
+            """
+        )
+
+
+def test_bundle_hash_is_stable_under_reformatting():
+    """Two bundles with identical logical rules should hash to the
+    same value regardless of YAML indentation, key order, comments."""
+    a = load_bundle(
+        """
+        # this comment must not change the hash
+        version: 1
+        rules:
+          - id: r1
+            when:
+              memory_has_any_label: [pii, financial]
+            action: deny
+        """
+    )
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - action: deny
+            when: {memory_has_any_label: [pii, financial]}
+            id: r1
+        """
+    )
+    assert a.bundle_hash == b.bundle_hash
+
+
+def test_bundle_hash_changes_when_a_rule_changes():
+    a = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: r1
+            when: {memory_has_any_label: [pii]}
+            action: deny
+        """
+    )
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: r1
+            when: {memory_has_any_label: [financial]}
+            action: deny
+        """
+    )
+    assert a.bundle_hash != b.bundle_hash
+
+
+# ---------------------------------------------------------------------------
+# evaluate_memory — predicate semantics
+# ---------------------------------------------------------------------------
+
+
+def _ctx(caller_type=None, caller_id=None, tenant_id=None):
+    return PolicyContext(
+        caller_id=caller_id, caller_type=caller_type, tenant_id=tenant_id
+    )
+
+
+def test_eval_default_allow_when_no_bundle():
+    d = evaluate_memory(
+        memory_labels=["pii"], bundle=None, context=_ctx(caller_type="x")
+    )
+    assert d.action == "allow"
+    assert d.rule_id is None
+
+
+def test_eval_default_allow_when_no_rules_match():
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: r1
+            when: {memory_has_any_label: [pii]}
+            action: deny
+        """
+    )
+    d = evaluate_memory(
+        memory_labels=["general"], bundle=b, context=_ctx(caller_type="x")
+    )
+    assert d.action == "allow"
+
+
+def test_eval_memory_has_any_label_disjunctive():
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: r1
+            when: {memory_has_any_label: [pii, financial]}
+            action: deny
+        """
+    )
+    # Either label matches → deny.
+    assert evaluate_memory(memory_labels=["pii"], bundle=b, context=_ctx()).action == "deny"
+    assert evaluate_memory(memory_labels=["financial"], bundle=b, context=_ctx()).action == "deny"
+    # Neither label → allow.
+    assert evaluate_memory(memory_labels=["general"], bundle=b, context=_ctx()).action == "allow"
+
+
+def test_eval_memory_has_all_labels_conjunctive():
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: r1
+            when: {memory_has_all_labels: [pii, internal]}
+            action: deny
+        """
+    )
+    # Only fires when BOTH labels present.
+    assert (
+        evaluate_memory(memory_labels=["pii", "internal"], bundle=b, context=_ctx()).action == "deny"
+    )
+    assert (
+        evaluate_memory(memory_labels=["pii"], bundle=b, context=_ctx()).action == "allow"
+    )
+
+
+def test_eval_predicates_AND_inside_when():
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: r1
+            when:
+              memory_has_any_label: [pii]
+              caller_type: marketing_tool
+            action: deny
+        """
+    )
+    # Both must match.
+    assert (
+        evaluate_memory(
+            memory_labels=["pii"], bundle=b, context=_ctx(caller_type="marketing_tool")
+        ).action
+        == "deny"
+    )
+    assert (
+        evaluate_memory(
+            memory_labels=["pii"], bundle=b, context=_ctx(caller_type="admin")
+        ).action
+        == "allow"
+    )
+    assert (
+        evaluate_memory(
+            memory_labels=["general"], bundle=b, context=_ctx(caller_type="marketing_tool")
+        ).action
+        == "allow"
+    )
+
+
+def test_eval_caller_type_not_in_negation():
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: redact-for-non-admin
+            when:
+              memory_has_any_label: [secret]
+              caller_type_not_in: [admin, security]
+            action: redact
+        """
+    )
+    assert (
+        evaluate_memory(
+            memory_labels=["secret"], bundle=b, context=_ctx(caller_type="marketing")
+        ).action
+        == "redact"
+    )
+    assert (
+        evaluate_memory(
+            memory_labels=["secret"], bundle=b, context=_ctx(caller_type="admin")
+        ).action
+        == "allow"
+    )
+
+
+def test_eval_first_match_wins():
+    """Two rules could both match — only the first one in declaration
+    order takes effect, so operators can author override rules near
+    the top of the bundle."""
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: redact-first
+            when: {memory_has_any_label: [pii]}
+            action: redact
+          - id: deny-second
+            when: {memory_has_any_label: [pii]}
+            action: deny
+        """
+    )
+    d = evaluate_memory(memory_labels=["pii"], bundle=b, context=_ctx())
+    assert d.action == "redact"
+    assert d.rule_id == "redact-first"
+
+
+def test_eval_matched_labels_records_intersection():
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: r1
+            when: {memory_has_any_label: [pii, financial, secret]}
+            action: deny
+        """
+    )
+    d = evaluate_memory(memory_labels=["pii", "financial", "marketing"], bundle=b, context=_ctx())
+    # Only the labels in the intersection — `marketing` was on the
+    # memory but not on the rule, so it doesn't appear.
+    assert d.matched_labels == ["financial", "pii"]
+
+
+# ---------------------------------------------------------------------------
+# apply_decisions — log_only vs enforce
+# ---------------------------------------------------------------------------
+
+
+class _FakeRow:
+    """Minimal duck-typed row for apply_decisions."""
+
+    def __init__(self, row_id, content):
+        self.id = row_id
+        self.content = content
+
+
+def test_apply_decisions_log_only_keeps_everything():
+    a = _FakeRow(uuid.uuid4(), "alpha")
+    b = _FakeRow(uuid.uuid4(), "beta")
+    from server.services.policy import MemoryPolicyDecision
+    decisions = {a.id: MemoryPolicyDecision(action="deny", rule_id="r1")}
+    kept, denied = apply_decisions([a, b], decisions, enforce=False)
+    assert len(kept) == 2
+    assert denied == []
+    # `a` was decided "deny" but still has its original content under
+    # log_only — the response is untouched. The receipt records what
+    # *would* happen under enforce.
+    assert a.content == "alpha"
+
+
+def test_apply_decisions_enforce_removes_denied():
+    a = _FakeRow(uuid.uuid4(), "alpha")
+    b = _FakeRow(uuid.uuid4(), "beta")
+    from server.services.policy import MemoryPolicyDecision
+    decisions = {a.id: MemoryPolicyDecision(action="deny", rule_id="r1")}
+    kept, denied = apply_decisions([a, b], decisions, enforce=True)
+    assert kept == [b]
+    assert denied == [a]
+
+
+def test_apply_decisions_enforce_redacts_content():
+    a = _FakeRow(uuid.uuid4(), "leaked secret value")
+    from server.services.policy import MemoryPolicyDecision
+    decisions = {a.id: MemoryPolicyDecision(action="redact", rule_id="r1")}
+    kept, denied = apply_decisions([a], decisions, enforce=True)
+    assert kept == [a]
+    assert denied == []
+    assert a.content == REDACTED_MARKER
+
+
+# ---------------------------------------------------------------------------
+# build_filters_applied / build_filters_skipped — receipt projection
+# ---------------------------------------------------------------------------
+
+
+def test_filters_applied_omits_default_allow():
+    from server.services.policy import MemoryPolicyDecision
+    decisions = {
+        uuid.uuid4(): MemoryPolicyDecision(action="deny", rule_id="r1"),
+        uuid.uuid4(): MemoryPolicyDecision(action="allow", rule_id=None),
+    }
+    applied = build_filters_applied(decisions)
+    # The "allow" decision is implicit; recording every default-allow
+    # would blow up receipt size at no forensic benefit.
+    assert len(applied) == 1
+    assert applied[0]["action"] == "deny"
+
+
+def test_filters_skipped_is_bounded_by_rule_count():
+    """`filters_skipped` lists rules that fired against nothing — its
+    cardinality is `len(rules)`, NOT `len(memories)`. This is the
+    guarantee that keeps receipt size predictable even on assembly
+    calls that touched a thousand memories."""
+    b = load_bundle(
+        """
+        version: 1
+        rules:
+          - id: r1
+            when: {memory_has_any_label: [pii]}
+            action: deny
+          - id: r2
+            when: {memory_has_any_label: [financial]}
+            action: deny
+          - id: r3
+            when: {memory_has_any_label: [secret]}
+            action: redact
+        """
+    )
+    from server.services.policy import MemoryPolicyDecision
+    decisions = {
+        uuid.uuid4(): MemoryPolicyDecision(action="deny", rule_id="r1")
+    }
+    skipped = build_filters_skipped(decisions, b)
+    # Two rules (r2, r3) did not fire; their ids appear in skipped.
+    assert {s["rule_id"] for s in skipped} == {"r2", "r3"}
+
+
+def test_filters_skipped_empty_when_no_bundle():
+    skipped = build_filters_skipped({}, None)
+    assert skipped == []


### PR DESCRIPTION
Closes #50. **Stacked on top of #49 (PR #72)** — base branch is `feat/state-assembly-receipts`. Once #72 merges, GitHub will auto-update this PR's base to `main`.

## Summary

Adds the sensitivity-label policy layer that fills `policy.filters_applied` and `policy.policy_bundle_hash` on every receipt emitted from `/v1/context` and `/v1/handoff`.

### Data model
- Migration `0018_sensitivity_labels` adds `memories.sensitivity_labels TEXT[]` + GIN index. The `policy_bundles` table created in 0017 starts being used.
- Per-memory tags are operator-supplied via `PATCH /v1/memories/{id}/labels` (or the admin shim). Server normalizes: dedup + lowercase + trim. Cap 32 per memory.

### Policy engine (`server/services/policy.py`)
- YAML/JSON bundle loader with strict schema validation. Unknown predicates, duplicate ids, missing actions, and predicate-type mismatches all surface as `PolicyError` rather than silently mis-parsing.
- Six predicates: `memory_has_any_label`, `memory_has_all_labels`, `caller_type`, `caller_type_in`, `caller_type_not_in`, `caller_id`. AND-ed inside `when:`; first-match-wins across rules; default-allow when nothing matches.
- Two actions: `deny`, `redact`. `redact` replaces `content` with `[REDACTED by policy]` (memory still appears in `selected_entries` so the receipt records the redaction).
- Content-hashed bundles stored immutably in `policy_bundles`. Receipts reference the hash — "what did policy `abc123` say on date Y?" is answerable forever.
- 60s in-process cache; `POST /admin/policy/reload` busts it.
- Fail-open: if bundle resolution fails (DB error, missing table), the call returns the same result as pre-#50.

### Per-tenant rollout lever
- `tenant_configs.config.policy_mode: log_only | enforce`. v1 ships **log_only by default** — receipts record decisions without filtering, so compliance teams can audit a policy for a week before flipping enforce on. Without this, the day policy turns on would silently regress every under-tagged tenant.

### Caller identity
- `caller_id` and `caller_type` are optional fields on `/v1/context` and `/v1/handoff`. When `tenant_configs.config.require_caller_identity: true`, both are mandatory and missing values return 401. This is the lever compliance-grade tenants flip to make policy non-bypassable.

### Endpoints
- `PATCH /v1/memories/{id}/labels` — set labels.
- `POST /admin/policy/bundles` — upload (and optionally activate).
- `GET /admin/policy/bundles` — list, optionally tenant-scoped.
- `GET /admin/policy/bundles/{hash}` — full YAML + parsed rules.
- `POST /admin/policy/activate` — switch active in a scope.
- `POST /admin/policy/reload` — bust the in-process cache.
- `GET /admin/policy/active` — current active for a scope.
- `PATCH /admin/memories/{id}/labels` — shim for the admin app (proxy is `/admin/*` only).

## Decisions locked

- **Capability tags** as the primary abstraction (not trust tiers / OPA / per-tool rules) — composable, auditable, doesn't paint into a corner.
- **Declarative YAML policy** (not Python predicates) — auditable by compliance teams without reading code; hot-reloadable.
- **First-class `TEXT[]` column** (not JSONB) — GIN-indexed for cheap overlap queries on the hot path.
- **Operator-supplied labels only** in v1 — heuristic auto-labeling deferred to v2 because false positives erode trust faster than no labels.
- **log_only default** — safe-rollout property.

## Test plan

- [ ] 25 unit tests in `tests/test_policy.py` — schema validation matrix, predicate semantics, log_only vs enforce, receipt projection bounds.
- [ ] 6 integration tests in `tests/integration/test_policy_api.py` — the four #50 acceptance-criteria negative tests + label endpoint normalization + admin policy round-trip.
- [ ] `EXPECTED_HEAD` bumped to `0018_sensitivity_labels`.
- [ ] Ruff clean.

## Companion PRs

- statewave-py — `Memory.sensitivity_labels`, `set_memory_labels()`, `caller_id`/`caller_type` on `get_context()`.
- statewave-ts — same surface mirrored.
- statewave-admin — labels editor + `/policy` page (upload + list + activate).
- statewave-docs — `sensitivity-labels.md` + v1 contract update.