### PR TITLE
chore: bump README status to v0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Everything is organised around **subjects** — a user, account, agent, repo, or
 
 Statewave is **not** a chatbot framework, a vector database, a RAG pipeline, or a hosted service. It is infrastructure you run alongside your application.
 
-> **Status:** v0.7.1 — actively developed. Full support-agent intelligence stack: session-aware context, resolution tracking, handoff packs, health scoring, SLA tracking, proactive alerts. See [current limitations](#current-limitations) below.
+> **Status:** v0.7.2 — actively developed. Per-kind memory TTL with hourly tombstone sweep, Helm chart for ops, cross-machine query embedding cache (L1 + L2), on top of the full support-agent intelligence stack from v0.7.1: session-aware context, resolution tracking, handoff packs, health scoring, SLA tracking, proactive alerts. See [current limitations](#current-limitations) below.
 
 ## 🎯 Try it
 
@@ -238,7 +238,7 @@ pytest tests/ -v
 
 ## Current limitations
 
-Statewave is in active development (v0.7.1). Honest status:
+Statewave is in active development (v0.7.2). Honest status:
 
 - **Rate limiting is per-IP** — distributed (Postgres-backed), but keyed by IP only, not per-tenant or per-API-key yet
 - **Multi-tenant is app-layer** — real query-scoped isolation (v0.5), no Postgres RLS yet


### PR DESCRIPTION
## Summary
- README's `Status:` and "active development" lines still said v0.7.1 while pyproject.toml and the workspace CHANGELOG are at v0.7.2. This is a pre-launch alignment fix.
- Updated headline blurb to mention the v0.7.2 additions (per-kind memory TTL with hourly tombstone sweep, Helm chart, cross-machine query embedding cache L1 + L2) on top of v0.7.1's support-agent intelligence stack.

## Test plan
- [x] No code changed — README copy only
- [x] After merge, the GitHub repo landing page reflects v0.7.2