### PR TITLE
ci: gate release on cross-repo version consistency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,44 @@ on:
     tags: ["v*"]
 
 jobs:
+  verify-workspace-versions:
+    name: Verify workspace version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out statewave
+        uses: actions/checkout@v6
+        with:
+          path: statewave
+
+      - name: Check out statewave-py
+        uses: actions/checkout@v6
+        with:
+          repository: smaramwbc/statewave-py
+          path: statewave-py
+
+      - name: Check out statewave-ts
+        uses: actions/checkout@v6
+        with:
+          repository: smaramwbc/statewave-ts
+          path: statewave-ts
+
+      - name: Check out statewave-docs
+        uses: actions/checkout@v6
+        with:
+          repository: smaramwbc/statewave-docs
+          path: statewave-docs
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Verify mechanical version refs match statewave/pyproject.toml
+        run: python statewave-docs/tools/check-versions.py
+
   release:
     runs-on: ubuntu-latest
+    needs: verify-workspace-versions
     permissions:
       contents: write
 


### PR DESCRIPTION
## Why

The v0.7.2 launch surfaced version drift across 4 repos — fixing it required 5 PRs because nothing was catching it at release time. This adds the gate that would have caught it.

## What

- New `verify-workspace-versions` job in `release.yml` triggers on `v*` tag push (same trigger as the existing release job).
- Checks out all 4 repos (`statewave`, `statewave-py`, `statewave-ts`, `statewave-docs`) as siblings in the workflow workspace.
- Runs `python statewave-docs/tools/check-versions.py` — uses the tool added in [statewave-docs#21](https://github.com/smaramwbc/statewave-docs/pull/21).
- Existing `release` job now `needs:` this job — drift blocks the GitHub Release from being created.

## Behaviour notes

- **Tag is not blocked, release is.** Once a tag is pushed, the workflow can't "untag". But the GitHub Release artifact (and any subsequent publish steps that depend on it) doesn't get created until the verify passes. Fix the drift, re-run the workflow.
- **Cross-repo reads.** All four repos are public, so default `GITHUB_TOKEN` is sufficient — no PAT needed.
- **Lockstep assumption.** The check assumes the SDK versions track the server one-to-one. If you later decouple SDK versioning, remove the SDK targets from `statewave-docs/tools/_targets.py`.

## Test plan
- [x] Workflow YAML validated locally (proper indentation, valid action references match existing repo convention `@v6`)
- [ ] Next tag push (v0.7.3) exercises the gate. To pre-test before tagging: manually trigger via a tag on a temporary branch (e.g. `v0.7.2-test`) — the verify should pass since the workspace is already at v0.7.2
- [ ] If SDKs lag on a future release, the verify should fail loudly with the exact files that drift