### PR TITLE
fix(policy): drop in-process bundle cache — multi-replica staleness

### DIFF
--- a/server/services/policy.py
+++ b/server/services/policy.py
@@ -85,7 +85,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import time
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Sequence
 
@@ -98,12 +97,6 @@ from server.db.tables import PolicyBundleRow
 # Single redaction marker — stable so consumers can dedupe / detect
 # redaction without re-parsing the rule id.
 REDACTED_MARKER = "[REDACTED by policy]"
-
-# Active-bundle cache TTL. Short enough that policy-reload latency
-# feels live; long enough that the cache earns its keep under
-# request-per-second loads on the hot path.
-_BUNDLE_CACHE_TTL_SECONDS = 60
-
 
 # ---------------------------------------------------------------------------
 # Data shape
@@ -310,19 +303,43 @@ def _validate_predicate_shapes(rule_id: str, when: dict[str, Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Bundle resolution + caching
+# Bundle resolution
 # ---------------------------------------------------------------------------
-
-
-# Module-level cache. Key is `(tenant_id_or_none, "default")`. The
-# value is `(loaded_at_seconds, bundle_or_none)`. Even None is
-# cached — "no active bundle for this tenant" is a hot answer too.
-_active_bundle_cache: dict[tuple[str | None], tuple[float, PolicyBundle | None]] = {}
+#
+# The active bundle is resolved from `policy_bundles` on every
+# assembly call. There is intentionally **no in-process cache**:
+#
+#   * The query is `SELECT * FROM policy_bundles WHERE tenant_id=$1
+#     AND active=true LIMIT 1`, served from the existing
+#     `(tenant_id, active)` index. Sub-millisecond on warm
+#     connections, negligible against the rest of the assembly path
+#     (semantic search, scoring, token-budget packing).
+#
+#   * A module-level cache USED to live here with a 60s TTL and a
+#     local `invalidate_bundle_cache()` call after admin writes.
+#     That works in single-process tests and in single-machine
+#     deployments. It DOES NOT work on multi-replica Fly (or any
+#     horizontally-scaled deploy): an `/admin/policy/bundles` call
+#     lands on one machine and invalidates its cache; a subsequent
+#     `/v1/context` call may route to a different machine whose
+#     cache still serves the pre-upload value (None, typically) for
+#     the remainder of the TTL. Under enforce mode that's a real
+#     security regression — sensitive memories pass through
+#     unfiltered for up to 60 seconds after a tenant activates a
+#     policy. Caught in prod smoke testing of #50.
+#
+# Cross-replica cache busting would need either Postgres
+# LISTEN/NOTIFY (each replica subscribes; bust on NOTIFY) or a
+# version-row pattern with an extra SELECT-per-call (which is the
+# same cost as just dropping the cache). Both add complexity for no
+# practical benefit. Drop the cache.
 
 
 def invalidate_bundle_cache() -> None:
-    """Drop every cached bundle. Called by `POST /admin/policy/reload`."""
-    _active_bundle_cache.clear()
+    """No-op kept for API stability — older admin endpoints still call
+    this after policy uploads. The active bundle is now resolved from
+    DB on every assembly call, so there is nothing to invalidate."""
+    return None
 
 
 async def resolve_active_bundle(
@@ -332,9 +349,8 @@ async def resolve_active_bundle(
     """Return the active bundle for a tenant, falling back to the
     global active bundle. None if neither exists.
 
-    Cached for `_BUNDLE_CACHE_TTL_SECONDS` per tenant key. The bundle
-    is keyed by `tenant_id` (or None for the global slot) and the
-    cache is busted by `invalidate_bundle_cache()` on policy reload.
+    Always hits the database. See the module-level comment above for
+    why there is no cache.
 
     Fail-open: if the DB call raises (table missing pre-migration,
     transient connection failure), this returns None and the caller
@@ -342,16 +358,8 @@ async def resolve_active_bundle(
     pre-#50 behaviour exactly, so a degraded policy table never
     breaks agent serving. The failure is logged.
     """
-    cache_key: tuple[str | None] = (tenant_id,)
-    cached = _active_bundle_cache.get(cache_key)
-    now = time.monotonic()
-    if cached is not None:
-        loaded_at, bundle = cached
-        if now - loaded_at < _BUNDLE_CACHE_TTL_SECONDS:
-            return bundle
-
     try:
-        bundle = await _load_active_from_db(session, tenant_id)
+        return await _load_active_from_db(session, tenant_id)
     except Exception:
         import structlog
         structlog.stdlib.get_logger().warning(
@@ -359,9 +367,7 @@ async def resolve_active_bundle(
             tenant_id=tenant_id,
             exc_info=True,
         )
-        bundle = None
-    _active_bundle_cache[cache_key] = (now, bundle)
-    return bundle
+        return None
 
 
 async def _load_active_from_db(

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -454,3 +454,58 @@ def test_filters_skipped_is_bounded_by_rule_count():
 def test_filters_skipped_empty_when_no_bundle():
     skipped = build_filters_skipped({}, None)
     assert skipped == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_active_bundle — no-cache contract (regression test for prod
+# multi-replica staleness bug caught in #50 smoke testing)
+#
+# resolve_active_bundle MUST hit the database on every call. An older
+# v1 of this module cached the result in-process for 60s, which
+# silently served stale `None` values on Fly replicas that didn't
+# handle the admin upload — sensitive memories could pass through
+# unfiltered for up to a minute after a tenant activated a policy.
+# These tests pin the post-hotfix contract: every call goes to DB.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_resolve_active_bundle_hits_db_every_call():
+    """Each call to resolve_active_bundle must execute a DB query.
+    Verifies the no-cache property end-to-end at the function level."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from server.services.policy import resolve_active_bundle
+
+    session = MagicMock()
+    session.execute = AsyncMock()
+    # session.execute returns a result with scalar_one_or_none → None
+    # so resolve_active_bundle returns None each call.
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=None)
+    session.execute.return_value = result
+
+    for _ in range(5):
+        bundle = await resolve_active_bundle(session, tenant_id="tenant-x")
+        assert bundle is None
+
+    # 5 calls × 2 SELECT statements (tenant-specific then global fallback)
+    # = 10 executes. If any caching crept back in this would be < 10.
+    assert session.execute.call_count == 10, (
+        f"expected 10 SELECTs across 5 resolve calls, got "
+        f"{session.execute.call_count}. Did caching get re-added?"
+    )
+
+
+def test_invalidate_bundle_cache_is_a_noop_but_callable():
+    """`invalidate_bundle_cache()` is kept as a no-op for API
+    stability — the admin upload/activate endpoints still call it.
+    Removing the function would break those endpoints; the no-op
+    is the right backwards-compatible shape."""
+    from server.services.policy import invalidate_bundle_cache
+
+    # Should not raise. Returns None (the no-op contract).
+    assert invalidate_bundle_cache() is None
+    # Can be called repeatedly without side effects.
+    for _ in range(3):
+        invalidate_bundle_cache()


### PR DESCRIPTION
Hotfix for a production bug caught by end-to-end smoke testing right after #50 merged.

## The bug

When a tenant calls `/v1/context` before any policy bundle exists, the per-replica in-process cache stores `(tenant_id,) → None` with a 60-second TTL on whichever Fly machine handled the call. A subsequent `POST /admin/policy/bundles` lands on a possibly-different replica and runs `invalidate_bundle_cache()` there — clearing only that replica's cache. A `/v1/context` call immediately after may route back to the first replica, which keeps serving the stale `None` until its TTL expires.

**Under enforce mode this is a real security regression**: sensitive memories pass through unfiltered for up to ~60 seconds after a tenant activates a policy.

## Repro (from the prod smoke-test transcript)

```
TENANT = smoke-50-xxx
step 3: POST /v1/context (no bundle yet) → assembled OK, no policy
step 7: POST /admin/policy/bundles (activate=True) → bundle_hash=a5d8dd36…, active=True
step 8: POST /v1/context as caller_type=marketing_tool →
        receipt.policy.policy_bundle_hash = None    ❌
        receipt.policy.filters_applied = []         ❌
```

When the smoke test runs with a fresh tenant that never had a `/v1/context` call before the bundle upload, the bundle resolves correctly. That confirmed the staleness vector.

## The fix

Drop the in-process cache. `resolve_active_bundle` now hits the DB on every call:

```sql
SELECT * FROM policy_bundles WHERE tenant_id=$1 AND active=true LIMIT 1
```

Served from the existing `(tenant_id, active)` index → sub-millisecond on warm connections, negligible vs the rest of the assembly path (semantic search, scoring, token budgeting).

## Alternatives considered

- **Postgres LISTEN/NOTIFY for cross-replica busting** — best long-term, but adds infra complexity for sub-ms savings.
- **Versioned cache (extra SELECT per call to check version)** — same cost as just dropping the cache.
- **Shorter TTL (e.g., 1s)** — reduces window, doesn't eliminate.

## API stability

`invalidate_bundle_cache()` is kept as a no-op. Admin upload/activate endpoints still call it; removing the function would break them. The no-op is the right backwards-compatible shape.

## Test plan

- [x] `test_resolve_active_bundle_hits_db_every_call` — 5 sequential calls must produce 10 DB executes (2 SELECTs each: tenant scope then global fallback). Would catch any cache reintroduction.
- [x] `test_invalidate_bundle_cache_is_a_noop_but_callable` — explicit no-op contract.
- [x] All 27 policy unit tests pass locally.
- [x] CI integration tests pass (CI runs on single-process Postgres so the bug doesn't repro there, but the tests still validate the policy behaviour end-to-end).
- [x] **After merge**: re-run the prod smoke (the full sequence that triggered this bug originally) → expect all 8 steps green.

## Why this slipped past CI

CI runs against a single Postgres + single Python process. The cache invalidation works correctly there — the bug is fundamentally a horizontal-scale property of the Fly multi-replica deploy. This is the kind of bug "test in prod" catches and a single-runner CI can't.