### PR TITLE
fix(admin): /admin/policy/active returns 200 + null when no bundle active

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2454,15 +2454,20 @@ async def reload_policy_cache():
 @router.get("/policy/active")
 async def get_active_policy(tenant_id: str | None = Query(None)):
     """Return the currently active bundle for a tenant scope, or
-    the global active bundle when `tenant_id` is omitted. 404 when
-    no bundle is active for the scope."""
+    the global active bundle when `tenant_id` is omitted. Returns
+    JSON `null` (with HTTP 200) when no bundle is active for the
+    scope — "no policy uploaded yet" is the expected default state
+    on a fresh install, not an error. Returning 404 here used to
+    pollute every operator's browser console on first page load.
+    Admin client treats `null` and the bundle object uniformly via
+    a `ActivePolicyBundle | null` return type."""
     from server.db import engine as engine_module
     from server.services import policy as policy_service
 
     async with engine_module.get_session_factory()() as session:
         bundle = await policy_service.resolve_active_bundle(session, tenant_id)
     if bundle is None:
-        raise HTTPException(status_code=404, detail="no active policy bundle")
+        return None
     return {
         "bundle_hash": bundle.bundle_hash,
         "version": bundle.version,


### PR DESCRIPTION
Operator-console hygiene caught on prod review of the /policy admin page after #50 shipped.

## Before

The Policy page renders an "No active bundle" empty-state card when no policy has been uploaded yet. Behind the scenes it fetched `/admin/policy/active` and got a `404` — semantically correct (entity doesn't exist) but **browsers log every 4xx response to the console regardless of how the JS handles it**. The result: every operator visiting the page on a fresh install sees a red console error, which looks like the app is broken when it isn't.

## After

`/admin/policy/active` now returns `200 OK` with a JSON body of literal `null` when no bundle is active. The admin client already handled the `null` return (it had a `res.status === 404 ? null : ...` branch), so this is wire-compatible. A companion admin PR removes the now-dead 404 check and tightens the return type.

## Rationale

"No policy bundle uploaded yet" is the expected default state on a fresh install, not an error. REST purists can argue for 404 either way; in practice the console pollution costs more than the semantic precision buys. This brings the endpoint in line with `/admin/dashboard`, `/admin/usage`, etc., which all return 200 + sensible defaults rather than 404 on missing config.

## Test plan

- [x] Local: `curl /admin/policy/active` returns `200 null` when no bundle active.
- [x] Existing 7 integration tests for `/admin/policy/*` still pass (none assert on the 404).
- [x] After merge + Fly redeploy: confirm the Policy page in prod loads without the console 404.