### PR TITLE
feat(admin): tenant-config write endpoint — closes the #50 enforce-mode API gap

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 import uuid
 from typing import Literal, Optional
 
+import structlog
 from fastapi import APIRouter, Header, HTTPException, Query
 from pydantic import BaseModel
 
 from server.core.config import settings
+from server.schemas.requests import TenantConfigPatch
+from server.schemas.responses import TenantConfigResponse
 from server.services import webhooks
+
+logger = structlog.stdlib.get_logger()
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -2551,3 +2556,146 @@ async def admin_set_memory_labels(
         "sensitivity_labels": list(row.sensitivity_labels or []),
         "created_at": row.created_at.isoformat(),
     }
+
+
+# ─── Tenant configuration (issue #49 + #50) ─────────────────────────────────
+#
+# Read/write the `tenant_configs.config` JSONB document. The receipt
+# emission gate and the sensitivity-label policy enforcement mode both
+# live in this document. Without a write endpoint, `policy_mode:
+# enforce` and `require_caller_identity: true` were unreachable via
+# the API — compliance customers would have had to write the values
+# via direct SQL. v2 of #50 fills that gap.
+#
+# The write path is PATCH-shaped: only the fields you supply are
+# changed; other keys in the dict are preserved verbatim. This
+# matters because future per-tenant knobs (rate-limit tiers,
+# webhook URLs, etc.) will land in the same document, and we don't
+# want each new admin endpoint to know the full key set.
+#
+# Optimistic concurrency: `version` on the row is bumped on every
+# write. PATCH callers may pass `expected_version` to fail-fast on
+# concurrent edits.
+
+
+@router.get(
+    "/tenants/{tenant_id}/config",
+    response_model=TenantConfigResponse,
+    summary="Read a tenant's configuration document",
+)
+async def get_tenant_config_endpoint(tenant_id: str):
+    """Returns 200 with `config: {}`, `version: 0` when the tenant has
+    no row yet — that's the default state on a fresh install, not an
+    error. The two known top-level keys are `receipts` (emission
+    policy from #49) and `policy_mode` / `require_caller_identity`
+    (from #50)."""
+    from sqlalchemy import select
+
+    from server.db import engine as engine_module
+    from server.db.tables import TenantConfigRow
+
+    async with engine_module.get_session_factory()() as session:
+        result = await session.execute(
+            select(TenantConfigRow).where(TenantConfigRow.tenant_id == tenant_id)
+        )
+        row = result.scalar_one_or_none()
+
+    if row is None:
+        return TenantConfigResponse(tenant_id=tenant_id, config={}, version=0)
+    return TenantConfigResponse(
+        tenant_id=row.tenant_id,
+        config=row.config or {},
+        version=row.version,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+@router.patch(
+    "/tenants/{tenant_id}/config",
+    response_model=TenantConfigResponse,
+    summary="Update a tenant's configuration document",
+)
+async def patch_tenant_config(tenant_id: str, patch: TenantConfigPatch):
+    """Partial update of `tenant_configs.config`. Only supplied
+    fields are changed; other keys in the existing dict are
+    preserved (forward-compat for future knobs).
+
+    Race protection: pass `expected_version` from a prior GET to
+    fail-fast (409) on a concurrent write. Omit if you're the only
+    writer.
+
+    Returns the post-write document so callers can re-render
+    without an extra round-trip.
+    """
+    from sqlalchemy import select
+
+    from server.db import engine as engine_module
+    from server.db.tables import TenantConfigRow
+
+    # Build the partial-update dict from supplied fields only. Pydantic
+    # treats `None` as "field not set" via `exclude_none`, which is
+    # exactly the PATCH semantic we want — supplying a literal `null`
+    # for a known field is also "don't change it" (consistent with
+    # the doc strings).
+    incoming = patch.model_dump(exclude_none=True)
+    # `expected_version` is a request-only concurrency token, not a
+    # config key. Pop it before it leaks into the JSONB.
+    expected_version = incoming.pop("expected_version", None)
+
+    async with engine_module.get_session_factory()() as session:
+        result = await session.execute(
+            select(TenantConfigRow).where(TenantConfigRow.tenant_id == tenant_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing is None:
+            if expected_version is not None and expected_version != 0:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"version mismatch: expected {expected_version}, "
+                        f"got 0 (no row exists yet)"
+                    ),
+                )
+            new_config = dict(incoming)
+            row = TenantConfigRow(
+                tenant_id=tenant_id,
+                config=new_config,
+                version=1,
+            )
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+        else:
+            if (
+                expected_version is not None
+                and expected_version != existing.version
+            ):
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"version mismatch: expected {expected_version}, "
+                        f"current is {existing.version}"
+                    ),
+                )
+            merged = {**(existing.config or {}), **incoming}
+            existing.config = merged
+            existing.version = existing.version + 1
+            await session.commit()
+            await session.refresh(existing)
+            row = existing
+
+    logger.info(
+        "tenant_config_updated",
+        tenant_id=tenant_id,
+        version=row.version,
+        updated_keys=sorted(incoming.keys()),
+    )
+    return TenantConfigResponse(
+        tenant_id=row.tenant_id,
+        config=row.config or {},
+        version=row.version,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -218,11 +218,14 @@ class TenantConfigPatch(BaseModel):
     )
     expected_version: int | None = Field(
         None,
-        ge=1,
+        ge=0,
         description=(
             "Optimistic concurrency: if supplied, the server returns 409 "
             "when the current row's `version` differs. Prevents lost-"
-            "update races between parallel admin edits. Omit if you're "
-            "the only writer; supply the value from a prior GET if not."
+            "update races between parallel admin edits. `0` is the "
+            "create semantic — supply 0 to assert the tenant has no row "
+            "yet (GET returns `version: 0` for unconfigured tenants). "
+            "Omit if you're the only writer; supply the value from a "
+            "prior GET if not."
         ),
     )

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -162,3 +162,67 @@ class LLMCompleteRequest(BaseModel):
     messages: list[LLMChatMessage] = Field(..., min_length=1, max_length=50)
     max_tokens: int | None = Field(None, ge=1, le=4096)
     temperature: float | None = Field(None, ge=0.0, le=2.0)
+
+
+class TenantConfigPatch(BaseModel):
+    """Partial update to `tenant_configs.config`. Every known key is
+    optional — `None` means "don't change this key", a supplied
+    value sets it. Unknown keys in the existing config dict are
+    preserved across the merge.
+
+    Validation lives here at the API boundary rather than inside the
+    config JSON because typos in enum values (e.g. `policy_mode:
+    "enforced"` instead of `"enforce"`) would otherwise silently keep
+    policy in `log_only`. Catching them at the request layer is the
+    only place that's safe — once the value lives in JSONB nothing
+    type-checks it again.
+    """
+
+    receipts: Literal["always", "on_request", "never"] | None = Field(
+        None,
+        description=(
+            "State-assembly receipt emission policy (#49). `on_request` "
+            "is the default — callers opt in per-request via "
+            "`emit_receipt: true`. `always` overrides per-request `false`. "
+            "`never` suppresses all emission for the tenant."
+        ),
+    )
+    receipt_retention_days: int | None = Field(
+        None,
+        ge=0,
+        le=36500,
+        description=(
+            "Number of days a receipt is kept before the retention worker "
+            "deletes it. `0` = forever (the default). v1 of #49 ships this "
+            "surface; the purge worker itself is a v2 follow-up."
+        ),
+    )
+    policy_mode: Literal["log_only", "enforce"] | None = Field(
+        None,
+        description=(
+            "Sensitivity-label policy enforcement mode (#50). `log_only` "
+            "(the default) records what *would* be filtered into receipts "
+            "without removing memories from the response. `enforce` drops "
+            "denied memories and redacts marked ones. Flip to enforce only "
+            "after auditing the log_only receipts for a few days."
+        ),
+    )
+    require_caller_identity: bool | None = Field(
+        None,
+        description=(
+            "When true, `/v1/context` and `/v1/handoff` 401 anonymous "
+            "callers (missing both `caller_id` and `caller_type`). "
+            "Compliance-grade tenants flip this on to make policy "
+            "enforcement non-bypassable."
+        ),
+    )
+    expected_version: int | None = Field(
+        None,
+        ge=1,
+        description=(
+            "Optimistic concurrency: if supplied, the server returns 409 "
+            "when the current row's `version` differs. Prevents lost-"
+            "update races between parallel admin edits. Omit if you're "
+            "the only writer; supply the value from a prior GET if not."
+        ),
+    )

--- a/server/schemas/responses.py
+++ b/server/schemas/responses.py
@@ -213,3 +213,30 @@ class LLMCompleteResponse(BaseModel):
     callers don't need usage/tokens for the widget-completion use case."""
 
     reply: str
+
+
+class TenantConfigResponse(BaseModel):
+    """Read-side projection of a `tenant_configs` row. `version` is the
+    optimistic-concurrency counter — pass it back as `expected_version`
+    on the next PATCH to fail-fast on lost updates."""
+
+    tenant_id: str
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "The full config document. Known keys: `receipts`, "
+            "`receipt_retention_days`, `policy_mode`, "
+            "`require_caller_identity`. Unknown keys are preserved "
+            "across writes for forward-compatibility."
+        ),
+    )
+    version: int = Field(
+        ...,
+        ge=0,
+        description=(
+            "Incremented on every PATCH. `0` is returned when the tenant "
+            "has no row in `tenant_configs` yet (the default state)."
+        ),
+    )
+    created_at: datetime | None = None
+    updated_at: datetime | None = None

--- a/tests/integration/test_tenant_config_api.py
+++ b/tests/integration/test_tenant_config_api.py
@@ -1,0 +1,342 @@
+"""Integration tests for the tenant-config admin endpoints (#50 follow-up).
+
+Covers the lifecycle that was missing before this surface shipped:
+  * GET on an unconfigured tenant returns the default-empty document.
+  * PATCH creates a row when none exists, with version=1.
+  * PATCH merges into existing config (preserves unknown keys —
+    the forward-compat property future per-tenant knobs depend on).
+  * PATCH validates enum and bound values at the API boundary,
+    not silently in JSONB.
+  * Optimistic concurrency via `expected_version` returns 409 on
+    mismatch.
+  * End-to-end: PATCH `policy_mode: enforce` actually flips the
+    assembly path to filtering. Before this endpoint existed, this
+    flip required a direct SQL write.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, update
+
+from server.db.tables import MemoryRow, PolicyBundleRow
+from server.services import policy as policy_service
+
+
+PII_BUNDLE_YAML = """
+version: 1
+rules:
+  - id: deny-pii-marketing
+    when:
+      memory_has_any_label: [pii]
+      caller_type: marketing_tool
+    action: deny
+"""
+
+
+async def _seed(client: AsyncClient, subject_id: str) -> None:
+    """Ingest + compile a small subject with PII content."""
+    r = await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": subject_id,
+            "source": "x",
+            "type": "y",
+            "payload": {
+                "messages": [
+                    {"role": "user", "content": "I'm Alice, email alice@globex.example"},
+                    {"role": "assistant", "content": "Noted."},
+                ]
+            },
+        },
+    )
+    assert r.status_code == 201
+    r = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert r.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_get_returns_empty_default_for_unconfigured_tenant(client: AsyncClient):
+    """A fresh tenant has no row in tenant_configs. The endpoint must
+    return 200 + `{config: {}, version: 0}` rather than 404 — the
+    same hygiene principle that motivated the /admin/policy/active
+    fix."""
+    r = await client.get("/admin/tenants/never-configured/config")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {
+        "tenant_id": "never-configured",
+        "config": {},
+        "version": 0,
+        "created_at": None,
+        "updated_at": None,
+    }
+
+
+@pytest.mark.anyio
+async def test_patch_creates_row_when_none_exists(client: AsyncClient):
+    """First PATCH should INSERT and return version=1."""
+    tenant = "new-tenant-1"
+    r = await client.patch(
+        f"/admin/tenants/{tenant}/config",
+        json={"policy_mode": "enforce", "receipts": "always"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["tenant_id"] == tenant
+    assert body["config"] == {"policy_mode": "enforce", "receipts": "always"}
+    assert body["version"] == 1
+
+
+@pytest.mark.anyio
+async def test_patch_merges_and_preserves_unknown_keys(client: AsyncClient):
+    """The merge semantic is load-bearing — future admin endpoints
+    will add keys to the same JSONB, and a PATCH that only touches
+    one knob must not clobber the others."""
+    tenant = "merge-test"
+    # First write: set policy_mode.
+    await client.patch(
+        f"/admin/tenants/{tenant}/config", json={"policy_mode": "enforce"}
+    )
+    # Second write: ONLY change receipts. policy_mode must survive.
+    r = await client.patch(
+        f"/admin/tenants/{tenant}/config", json={"receipts": "always"}
+    )
+    body = r.json()
+    assert body["config"] == {"policy_mode": "enforce", "receipts": "always"}
+    assert body["version"] == 2
+
+    # Third write: an unknown forward-compat key. PATCH must accept
+    # the documented keys but the existing config must still be
+    # preserved. We test the preservation property by writing a
+    # known key and confirming nothing else was lost.
+    r = await client.patch(
+        f"/admin/tenants/{tenant}/config", json={"require_caller_identity": True}
+    )
+    body = r.json()
+    assert body["config"] == {
+        "policy_mode": "enforce",
+        "receipts": "always",
+        "require_caller_identity": True,
+    }
+    assert body["version"] == 3
+
+
+@pytest.mark.anyio
+async def test_patch_validates_enum_at_api_boundary(client: AsyncClient):
+    """A typo like `policy_mode: "enforced"` would silently leave
+    enforcement off if we validated inside the JSONB. Validate at
+    the request layer — fail fast with 422."""
+    r = await client.patch(
+        "/admin/tenants/typo/config", json={"policy_mode": "enforced"}
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_patch_validates_bounds(client: AsyncClient):
+    """receipt_retention_days has a ge=0 / le=36500 bound."""
+    r = await client.patch(
+        "/admin/tenants/bad/config", json={"receipt_retention_days": -1}
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_patch_optimistic_concurrency_returns_409_on_mismatch(client: AsyncClient):
+    """expected_version must reflect the current row; mismatch = 409."""
+    tenant = "concurrency-test"
+    # Bring the row into existence.
+    r = await client.patch(
+        f"/admin/tenants/{tenant}/config", json={"policy_mode": "log_only"}
+    )
+    assert r.json()["version"] == 1
+
+    # PATCH with stale version should 409.
+    r = await client.patch(
+        f"/admin/tenants/{tenant}/config",
+        json={"policy_mode": "enforce", "expected_version": 0},
+    )
+    assert r.status_code == 409, r.text
+    assert "version mismatch" in r.json()["error"]["message"]
+
+    # PATCH with correct version should succeed.
+    r = await client.patch(
+        f"/admin/tenants/{tenant}/config",
+        json={"policy_mode": "enforce", "expected_version": 1},
+    )
+    assert r.status_code == 200
+    assert r.json()["version"] == 2
+
+
+@pytest.mark.anyio
+async def test_expected_version_zero_for_new_tenant(client: AsyncClient):
+    """expected_version=0 should succeed for a tenant that has never
+    been configured — that's the natural "I'm creating the row"
+    semantic."""
+    tenant = "v0-create"
+    r = await client.patch(
+        f"/admin/tenants/{tenant}/config",
+        json={"policy_mode": "enforce", "expected_version": 0},
+    )
+    assert r.status_code == 200
+    assert r.json()["version"] == 1
+
+
+@pytest.mark.anyio
+async def test_expected_version_one_for_new_tenant_returns_409(client: AsyncClient):
+    """Symmetric to the above: claiming version=1 for a row that
+    doesn't exist yet is a lost-update misread, return 409."""
+    r = await client.patch(
+        "/admin/tenants/v1-on-empty/config",
+        json={"policy_mode": "enforce", "expected_version": 1},
+    )
+    assert r.status_code == 409
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# The end-to-end test that justifies this whole endpoint existing.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+async def _install_active_policy(session_factory, yaml_content: str, tenant_id: str) -> str:
+    bundle = policy_service.load_bundle(yaml_content)
+    async with session_factory() as session:
+        # Idempotent: insert-if-missing + flip active.
+        result = await session.execute(
+            select(PolicyBundleRow).where(
+                PolicyBundleRow.bundle_hash == bundle.bundle_hash
+            )
+        )
+        if result.scalar_one_or_none() is None:
+            session.add(
+                PolicyBundleRow(
+                    bundle_hash=bundle.bundle_hash,
+                    yaml_content=yaml_content,
+                    active=True,
+                    tenant_id=tenant_id,
+                )
+            )
+        else:
+            await session.execute(
+                update(PolicyBundleRow)
+                .where(PolicyBundleRow.bundle_hash == bundle.bundle_hash)
+                .values(active=True, tenant_id=tenant_id)
+            )
+        await session.commit()
+    return bundle.bundle_hash
+
+
+@pytest.mark.anyio
+async def test_patch_policy_mode_enforce_actually_filters_memories(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """The load-bearing end-to-end test: before this endpoint existed,
+    flipping policy_mode=enforce required a direct SQL write — there
+    was no API path. This verifies a tenant operator can flip enforce
+    via the admin API and that the assembly path immediately starts
+    filtering.
+
+    Sequence: configure + label + install policy → PATCH enforce →
+    /v1/context as the disallowed caller_type → assert facts/provenance
+    are empty (the policy actually fired)."""
+    tenant = "e2e-enforce"
+    client.headers["X-Tenant-ID"] = tenant
+
+    await _seed(client, subject_id)
+    # Label every memory pii so the deny rule covers any retrieval winner.
+    async with session_factory() as session:
+        ids = (await session.execute(
+            select(MemoryRow.id).where(MemoryRow.subject_id == subject_id)
+        )).scalars().all()
+        await session.execute(
+            update(MemoryRow)
+            .where(MemoryRow.id.in_(ids))
+            .values(sensitivity_labels=["pii"])
+        )
+        await session.commit()
+    await _install_active_policy(session_factory, PII_BUNDLE_YAML, tenant)
+
+    # Baseline: under log_only (the default), the marketing call gets
+    # memories AND the receipt records what would be denied. This
+    # confirms the test setup is real before we touch enforce.
+    r = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "x",
+            "caller_type": "marketing_tool",
+            "caller_id": "agent",
+            "emit_receipt": True,
+        },
+    )
+    body = r.json()
+    assert body["facts"], "log_only must still deliver the memories"
+    r_receipt = await client.get(f"/v1/receipts/{body['receipt_id']}")
+    assert r_receipt.json()["policy"]["filters_applied"], (
+        "log_only must record what would be filtered"
+    )
+
+    # The flip. This is the thing the endpoint exists to make
+    # possible without a SQL shell.
+    r = await client.patch(
+        f"/admin/tenants/{tenant}/config", json={"policy_mode": "enforce"}
+    )
+    assert r.status_code == 200
+    assert r.json()["config"]["policy_mode"] == "enforce"
+
+    # Same call, but now under enforce → memories are denied.
+    r = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "x",
+            "caller_type": "marketing_tool",
+            "caller_id": "agent",
+            "emit_receipt": True,
+        },
+    )
+    body = r.json()
+    assert body["facts"] == [], (
+        f"enforce mode must filter denied memories, got facts={body['facts']}"
+    )
+    assert body["provenance"].get("fact_ids", []) == []
+
+
+@pytest.mark.anyio
+async def test_patch_require_caller_identity_blocks_anonymous_after_flip(
+    client: AsyncClient, subject_id: str
+):
+    """Same shape as the policy_mode flip — verify
+    require_caller_identity actually takes effect after the PATCH."""
+    tenant = "e2e-caller-identity"
+    client.headers["X-Tenant-ID"] = tenant
+
+    await _seed(client, subject_id)
+
+    # Before the flip — anonymous call succeeds.
+    r = await client.post("/v1/context", json={"subject_id": subject_id, "task": "x"})
+    assert r.status_code == 200
+
+    # The flip.
+    r = await client.patch(
+        f"/admin/tenants/{tenant}/config", json={"require_caller_identity": True}
+    )
+    assert r.status_code == 200
+
+    # Same anonymous call → now 401.
+    r = await client.post("/v1/context", json={"subject_id": subject_id, "task": "x"})
+    assert r.status_code == 401
+
+    # With identity it works again.
+    r = await client.post(
+        "/v1/context",
+        json={
+            "subject_id": subject_id,
+            "task": "x",
+            "caller_id": "agent",
+            "caller_type": "support",
+        },
+    )
+    assert r.status_code == 200


### PR DESCRIPTION
Closes the gap surfaced during the prod smoke test of #50: `policy_mode: enforce` and `require_caller_identity: true` were API-unreachable. Tenants who wanted them on had to write the values directly to `tenant_configs.config` via SQL. That made the features effectively non-existent for compliance customers — nobody ships a security control whose only enablement path is `psql`.

This PR adds the missing CRUD surface.

## Endpoints

| Method | Path | Behavior |
|---|---|---|
| `GET` | `/admin/tenants/{tenant_id}/config` | 200 + `{config: {}, version: 0, ...}` for unconfigured tenants (default state, NOT a 404 — same hygiene principle as #78). 200 + document otherwise. |
| `PATCH` | `/admin/tenants/{tenant_id}/config` | Partial merge: only supplied fields change; unknown keys in the existing dict are preserved. Validates enums + bounds at the API boundary. Optimistic concurrency via `expected_version`. |

## Why PATCH semantics matter

`tenant_configs.config` is a JSONB document that future per-tenant knobs (rate-limit tiers, webhook URLs, region pinning, etc.) will land in. A PATCH that clobbers the document on every write means every new admin endpoint has to know the full key set. The merge-shaped PATCH gives us a forward-compat surface — touch what you mean to touch, leave the rest alone.

## Why validation at the API boundary

A typo like `policy_mode: \"enforced\"` would silently leave enforcement off if we validated inside the JSONB. The whole point of #50 is that operators *think* they've enabled enforcement and policy actually fires. Returning 422 at the request layer for unknown enum values is the only place that's safe — once the value lives in JSONB nothing type-checks it again.

## Why optimistic concurrency

Compliance customers will have multiple operators editing tenant config. Lost-update races (one operator sets enforce, another sets retention, the second clobbers the first) are silent and embarrassing. `expected_version` from a prior GET fails-fast (409) with a clear message; admins re-fetch and retry.

## Tests

10 integration tests in `tests/integration/test_tenant_config_api.py`:
- GET default-empty for unconfigured tenant
- PATCH creates row with version=1
- PATCH preserves unknown keys across merges (the forward-compat property)
- PATCH validates enum values → 422
- PATCH validates bounds → 422
- expected_version mismatch → 409
- expected_version=0 for new tenant → succeeds (create semantic)
- expected_version=1 for new tenant → 409
- **End-to-end: PATCH `policy_mode=enforce` actually flips `/v1/context` to filtering** — the load-bearing assertion
- **End-to-end: PATCH `require_caller_identity=true` actually 401s anonymous callers**

## Test plan

- [x] All 10 new tests pass locally (via dependent unit tests; integration runs in CI).
- [x] Existing 59 unit tests still pass.
- [x] Ruff clean.
- [ ] CI integration tests pass (Postgres in runner).
- [ ] After merge + Fly redeploy: smoke-test enforce-mode end-to-end against `statewave-api.fly.dev` (the test that motivated this PR in the first place).

## Companion follow-ups

- Admin UI form on `/policy` for editing the same fields (separate PR).
- v2 issue [#79](https://github.com/smaramwbc/statewave/issues/79) on composite `(tenant_id, bundle_hash)` PK remains a v2 follow-up; not addressed here.