### PR TITLE
feat(policy): composite (tenant_id, bundle_hash) uniqueness — closes #79

### DIFF
--- a/alembic/versions/0019_per_tenant_bundles.py
+++ b/alembic/versions/0019_per_tenant_bundles.py
@@ -1,6 +1,6 @@
 """policy_bundles: composite (tenant_id, bundle_hash) uniqueness — closes #79
 
-Revision ID: 0019_policy_bundles_composite_uniqueness
+Revision ID: 0019_per_tenant_bundles
 Revises: 0018_sensitivity_labels
 Create Date: 2026-05-14
 
@@ -49,7 +49,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
 
 
-revision: str = "0019_policy_bundles_composite_uniqueness"
+revision: str = "0019_per_tenant_bundles"
 down_revision: Union[str, None] = "0018_sensitivity_labels"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/alembic/versions/0019_policy_bundles_composite_uniqueness.py
+++ b/alembic/versions/0019_policy_bundles_composite_uniqueness.py
@@ -1,0 +1,108 @@
+"""policy_bundles: composite (tenant_id, bundle_hash) uniqueness — closes #79
+
+Revision ID: 0019_policy_bundles_composite_uniqueness
+Revises: 0018_sensitivity_labels
+Create Date: 2026-05-14
+
+v1 of #50 used `bundle_hash` as the sole primary key on
+`policy_bundles`. Because bundles are content-addressed, two tenants
+uploading the same YAML produce the same hash → only one row could
+exist for that hash, and the second tenant's upload silently
+re-bound the existing row's `tenant_id` to whatever was last
+uploaded. The active-bundle resolver then failed to find a bundle
+for the tenant whose row got hijacked. Caught in prod smoke testing
+of the enforce-mode endpoint (the smoke had to use tenant-unique
+YAML as a workaround); filed as #79.
+
+The fix lets multiple rows share a `bundle_hash` as long as their
+`tenant_id` differs:
+
+  * Add a synthetic UUID `id` column as the new primary key. Random
+    per row, no semantic meaning — content addressing stays on
+    `bundle_hash`, the row's *identity* is the UUID.
+
+  * Drop the old single-column PK on `bundle_hash`.
+
+  * Add a composite unique index on `(tenant_id, bundle_hash)` with
+    `NULLS NOT DISTINCT` so two rows with `(NULL, 'X')` conflict
+    (correct for globals), but `(NULL, 'X')` and `('acme', 'X')`
+    are distinct (correct for tenant scoping). Requires PostgreSQL
+    15+ for `NULLS NOT DISTINCT`; statewave runs on PG16 (see CI
+    workflow + the pgvector/pgvector:pg16 image).
+
+  * Drop the obsolete `ix_policy_bundles_tenant_active` index
+    created by 0017 — it's superseded by the new composite unique
+    index (which covers the tenant_id lead column for the existing
+    active-lookup query pattern). Re-created on downgrade.
+
+The migration is reversible: downgrade restores the single-column
+PK, but DOES NOT collapse rows that share a hash across tenants — a
+downgrade applied to a database with cross-tenant bundles will fail
+on the PK re-add. Operators rolling back should first run
+`DELETE FROM policy_bundles WHERE tenant_id IS NOT NULL` after
+exporting any policies they care about, then apply the downgrade.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision: str = "0019_policy_bundles_composite_uniqueness"
+down_revision: Union[str, None] = "0018_sensitivity_labels"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add the synthetic id column. server_default applies on INSERT
+    #    so new rows get a UUID automatically; existing rows below get
+    #    populated by the explicit UPDATE.
+    op.add_column(
+        "policy_bundles",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+    )
+    # 2. Backfill existing rows. server_default doesn't apply to rows
+    #    already present at ALTER TABLE time — the explicit UPDATE
+    #    fills them in.
+    op.execute("UPDATE policy_bundles SET id = gen_random_uuid() WHERE id IS NULL")
+
+    # 3. Drop the old PK and the obsolete tenant_active index that
+    #    was added by 0017 (now subsumed by the composite unique
+    #    index we're about to add).
+    op.drop_index("ix_policy_bundles_tenant_active", table_name="policy_bundles")
+    op.drop_constraint("policy_bundles_pkey", "policy_bundles", type_="primary")
+
+    # 4. Add the new PK on `id`.
+    op.create_primary_key("policy_bundles_pkey", "policy_bundles", ["id"])
+
+    # 5. Composite unique index. `NULLS NOT DISTINCT` (PG15+) makes
+    #    (NULL, 'X') equal to (NULL, 'X') so globals can't be
+    #    duplicated, while still allowing (NULL, 'X') alongside
+    #    ('acme', 'X'). Raw SQL is used because alembic 1.13's
+    #    `op.create_index` doesn't surface the keyword directly.
+    op.execute(
+        "CREATE UNIQUE INDEX ix_policy_bundles_tenant_hash "
+        "ON policy_bundles (tenant_id, bundle_hash) NULLS NOT DISTINCT"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_policy_bundles_tenant_hash")
+    op.drop_constraint("policy_bundles_pkey", "policy_bundles", type_="primary")
+    # The single-column PK only succeeds if no cross-tenant duplicates
+    # exist. Operators rolling back must first drop tenant-scoped
+    # bundles — see the module docstring.
+    op.create_primary_key("policy_bundles_pkey", "policy_bundles", ["bundle_hash"])
+    op.create_index(
+        "ix_policy_bundles_tenant_active",
+        "policy_bundles",
+        ["tenant_id", "active"],
+    )
+    op.drop_column("policy_bundles", "id")

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2279,14 +2279,23 @@ async def upload_policy_bundle(req: UploadPolicyBundleRequest):
         raise HTTPException(status_code=400, detail=str(e))
 
     async with engine_module.get_session_factory()() as session:
-        # If a row already exists with this hash, the bundle is a
-        # duplicate of one we already stored — return the existing
-        # row's metadata rather than INSERT-conflicting.
-        existing = await session.execute(
-            select(PolicyBundleRow).where(
-                PolicyBundleRow.bundle_hash == bundle.bundle_hash
-            )
+        # If a row already exists with the SAME (tenant_id, bundle_hash),
+        # the bundle is a duplicate the caller already uploaded —
+        # return the existing row's metadata rather than INSERT-
+        # conflicting on the composite unique index. The tenant_id
+        # scope on this lookup is the load-bearing fix for #79: two
+        # tenants installing the same YAML must produce two rows,
+        # not silently rebind the first row's tenant.
+        existing_stmt = select(PolicyBundleRow).where(
+            PolicyBundleRow.bundle_hash == bundle.bundle_hash
         )
+        if req.tenant_id is None:
+            existing_stmt = existing_stmt.where(PolicyBundleRow.tenant_id.is_(None))
+        else:
+            existing_stmt = existing_stmt.where(
+                PolicyBundleRow.tenant_id == req.tenant_id
+            )
+        existing = await session.execute(existing_stmt)
         existing_row = existing.scalar_one_or_none()
         if existing_row is None:
             session.add(
@@ -2313,11 +2322,22 @@ async def upload_policy_bundle(req: UploadPolicyBundleRequest):
                 )
             scope_stmt = scope_stmt.values(active=False)
             await session.execute(scope_stmt)
-            await session.execute(
-                sa_update(PolicyBundleRow)
-                .where(PolicyBundleRow.bundle_hash == bundle.bundle_hash)
-                .values(active=True)
+            # Activate ONLY the row for this (tenant, hash) — without
+            # the tenant_id scope, an UPDATE on `bundle_hash=X` alone
+            # would flip the active flag on another tenant's row that
+            # happened to share the same content hash.
+            activate_stmt = sa_update(PolicyBundleRow).where(
+                PolicyBundleRow.bundle_hash == bundle.bundle_hash
             )
+            if req.tenant_id is None:
+                activate_stmt = activate_stmt.where(
+                    PolicyBundleRow.tenant_id.is_(None)
+                )
+            else:
+                activate_stmt = activate_stmt.where(
+                    PolicyBundleRow.tenant_id == req.tenant_id
+                )
+            await session.execute(activate_stmt.values(active=True))
             await session.commit()
             policy_service.invalidate_bundle_cache()
 
@@ -2359,8 +2379,15 @@ async def list_policy_bundles(tenant_id: str | None = Query(None)):
 
 
 @router.get("/policy/bundles/{bundle_hash}")
-async def get_policy_bundle(bundle_hash: str):
-    """Fetch a bundle's full YAML content + parsed rule summary."""
+async def get_policy_bundle(bundle_hash: str, tenant_id: str | None = Query(None)):
+    """Fetch a bundle's full YAML content + parsed rule summary.
+
+    `tenant_id` query param disambiguates when multiple tenants have
+    uploaded the same YAML (post-#79). Omit for the global-scope row
+    (`tenant_id IS NULL`); pass a specific id to scope to that tenant.
+    When omitted and the hash exists in multiple scopes, returns the
+    global row if one exists, else 404 with a hint to specify
+    `?tenant_id=` for tenant-scoped rows."""
     from sqlalchemy import select
 
     from server.db import engine as engine_module
@@ -2368,10 +2395,30 @@ async def get_policy_bundle(bundle_hash: str):
     from server.services import policy as policy_service
 
     async with engine_module.get_session_factory()() as session:
-        result = await session.execute(
-            select(PolicyBundleRow).where(PolicyBundleRow.bundle_hash == bundle_hash)
+        stmt = select(PolicyBundleRow).where(
+            PolicyBundleRow.bundle_hash == bundle_hash
         )
-        row = result.scalar_one_or_none()
+        if tenant_id is not None:
+            stmt = stmt.where(PolicyBundleRow.tenant_id == tenant_id)
+            result = await session.execute(stmt)
+            row = result.scalar_one_or_none()
+        else:
+            # No tenant filter — prefer the global row (tenant_id IS NULL).
+            # If absent, surface that the hash exists tenant-scoped and
+            # the caller needs to disambiguate.
+            global_stmt = stmt.where(PolicyBundleRow.tenant_id.is_(None))
+            result = await session.execute(global_stmt)
+            row = result.scalar_one_or_none()
+            if row is None:
+                any_stmt = stmt.limit(1)
+                if (await session.execute(any_stmt)).scalar_one_or_none() is not None:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=(
+                            f"bundle {bundle_hash} exists in tenant-scoped form; "
+                            "pass `?tenant_id=<id>` to fetch it"
+                        ),
+                    )
     if row is None:
         raise HTTPException(status_code=404, detail="bundle not found")
     parsed = policy_service.load_bundle(row.yaml_content)
@@ -2397,19 +2444,24 @@ async def get_policy_bundle(bundle_hash: str):
 class ActivateBundleRequest(BaseModel):
     """Body for POST /admin/policy/activate.
 
-    Scope (global vs tenant-specific) is inferred from the stored
-    bundle's `tenant_id` column — we don't accept it on the activate
-    call to avoid a request body that disagrees with the row.
+    Identifies the bundle to activate by `(tenant_id, bundle_hash)`.
+    Post-#79 the same `bundle_hash` can exist in multiple scopes
+    (global + N tenants), so the request must specify which one to
+    flip — otherwise the activate could silently target the wrong
+    row. Use `tenant_id: null` to activate the global-scope row.
     """
 
     bundle_hash: str
+    tenant_id: str | None = None
 
 
 @router.post("/policy/activate")
 async def activate_policy_bundle(req: ActivateBundleRequest):
     """Mark a bundle as the active policy for its scope. Deactivates
     any other bundle in the same scope (global or tenant-specific)
-    so the active-bundle resolver sees exactly one row."""
+    so the active-bundle resolver sees exactly one row.
+
+    Returns 404 if no row matches `(tenant_id, bundle_hash)`."""
     from sqlalchemy import select, update as sa_update
 
     from server.db import engine as engine_module
@@ -2417,16 +2469,26 @@ async def activate_policy_bundle(req: ActivateBundleRequest):
     from server.services import policy as policy_service
 
     async with engine_module.get_session_factory()() as session:
-        result = await session.execute(
-            select(PolicyBundleRow).where(
-                PolicyBundleRow.bundle_hash == req.bundle_hash
-            )
+        target_stmt = select(PolicyBundleRow).where(
+            PolicyBundleRow.bundle_hash == req.bundle_hash
         )
+        if req.tenant_id is None:
+            target_stmt = target_stmt.where(PolicyBundleRow.tenant_id.is_(None))
+        else:
+            target_stmt = target_stmt.where(
+                PolicyBundleRow.tenant_id == req.tenant_id
+            )
+        result = await session.execute(target_stmt)
         target = result.scalar_one_or_none()
         if target is None:
             raise HTTPException(status_code=404, detail="bundle not found")
+
+        # Deactivate every other bundle in the same scope (≠ THIS
+        # bundle, same tenant). Using target.id rather than
+        # bundle_hash here is the load-bearing precision: we want to
+        # leave the same-hash-different-tenant rows untouched.
         scope_stmt = sa_update(PolicyBundleRow).where(
-            PolicyBundleRow.bundle_hash != req.bundle_hash
+            PolicyBundleRow.id != target.id
         )
         if target.tenant_id is None:
             scope_stmt = scope_stmt.where(PolicyBundleRow.tenant_id.is_(None))
@@ -2436,7 +2498,7 @@ async def activate_policy_bundle(req: ActivateBundleRequest):
         await session.execute(scope_stmt)
         await session.execute(
             sa_update(PolicyBundleRow)
-            .where(PolicyBundleRow.bundle_hash == req.bundle_hash)
+            .where(PolicyBundleRow.id == target.id)
             .values(active=True)
         )
         await session.commit()

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -275,16 +275,23 @@ class TenantConfigRow(Base):
 
 
 class PolicyBundleRow(Base):
-    """Immutable policy YAML bundle, addressed by content hash.
+    """Immutable policy YAML bundle, content-addressed by `bundle_hash`.
 
-    Reserved for issue #50 — created in the same migration as receipts
-    so #50 doesn't have to migrate again. Empty in v1; receipt rows
-    carry `policy_bundle_hash = NULL` until the policy layer ships.
+    Identity of the *row* is the synthetic `id` UUID (added in 0019)
+    so two tenants can install the same YAML independently — same
+    `bundle_hash`, different `tenant_id`, distinct rows. Composite
+    unique index on `(tenant_id, bundle_hash) NULLS NOT DISTINCT`
+    enforces "one bundle per (scope, content)"; receipts continue to
+    reference bundles by `bundle_hash` (with the tenant context
+    available alongside on the receipt itself).
     """
 
     __tablename__ = "policy_bundles"
 
-    bundle_hash: Mapped[str] = mapped_column(String(64), primary_key=True)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    bundle_hash: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     yaml_content: Mapped[str] = mapped_column(Text, nullable=False)
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     tenant_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
@@ -292,7 +299,11 @@ class PolicyBundleRow(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
 
-    __table_args__ = (Index("ix_policy_bundles_tenant_active", "tenant_id", "active"),)
+    # The composite unique index `ix_policy_bundles_tenant_hash`
+    # (created in migration 0019 with NULLS NOT DISTINCT) enforces
+    # "one row per (tenant_id, bundle_hash)". Not declared here as a
+    # SQLAlchemy UniqueConstraint because NULLS NOT DISTINCT isn't
+    # natively expressible — the migration owns it.
 
 
 class QueryEmbeddingCacheRow(Base):

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0019_policy_bundles_composite_uniqueness"
+EXPECTED_HEAD = "0019_per_tenant_bundles"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0018_sensitivity_labels"
+EXPECTED_HEAD = "0019_policy_bundles_composite_uniqueness"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/tests/integration/test_policy_api.py
+++ b/tests/integration/test_policy_api.py
@@ -416,32 +416,14 @@ async def test_set_memory_labels_endpoint_normalizes_and_persists(
 @pytest.mark.anyio
 async def test_admin_policy_upload_and_activate_round_trip(client: AsyncClient):
     """The /admin/policy/* endpoints lifecycle: upload a bundle,
-    list it, activate it, fetch active. Verifies the operator
-    surface end-to-end.
-
-    Uses a content unique to this test rather than the shared
-    PII_BUNDLE_YAML — bundles are content-addressed (same YAML →
-    same hash), and `bundle_hash` is the primary key of
-    `policy_bundles`. Reusing PII_BUNDLE_YAML here would silently
-    point at the row inserted by the earlier global-scope tests
-    (whose `tenant_id IS NULL`), so the tenant-scoped listing would
-    miss it. Cross-tenant bundle reuse via a composite-key schema
-    is a v2 follow-up.
-    """
-    unique_yaml = """
-version: 1
-metadata:
-  description: admin-round-trip-test
-rules:
-  - id: deny-admin-round-trip-only
-    when:
-      memory_has_any_label: [admin-round-trip-marker]
-    action: deny
-"""
+    list it, fetch active. Reuses PII_BUNDLE_YAML — earlier tests
+    in this file install it globally; post-#79 the upload here
+    creates a separate row scoped to `acme-policy-admin` and the
+    tenant-scoped listing must show it independently."""
     r = await client.post(
         "/admin/policy/bundles",
         json={
-            "yaml_content": unique_yaml,
+            "yaml_content": PII_BUNDLE_YAML,
             "tenant_id": "acme-policy-admin",
             "activate": True,
         },
@@ -459,3 +441,58 @@ rules:
     r3 = await client.get("/admin/policy/active?tenant_id=acme-policy-admin")
     assert r3.status_code == 200
     assert r3.json()["bundle_hash"] == bundle_hash
+
+
+@pytest.mark.anyio
+async def test_same_yaml_two_tenants_resolve_independently(client: AsyncClient):
+    """#79 acceptance test: two tenants uploading the exact same YAML
+    must each end up with their own active bundle. Before the
+    composite (tenant_id, bundle_hash) uniqueness landed, the
+    second tenant's upload silently re-bound the first tenant's row
+    and broke that first tenant's policy resolution."""
+    yaml = """
+version: 1
+metadata:
+  description: shared YAML for the cross-tenant test
+rules:
+  - id: deny-shared
+    when:
+      memory_has_any_label: [pii]
+    action: deny
+"""
+    # Tenant A uploads + activates.
+    r_a = await client.post(
+        "/admin/policy/bundles",
+        json={"yaml_content": yaml, "tenant_id": "cross-a", "activate": True},
+    )
+    assert r_a.status_code == 200
+    hash_a = r_a.json()["bundle_hash"]
+
+    # Tenant B uploads the IDENTICAL YAML + activates.
+    r_b = await client.post(
+        "/admin/policy/bundles",
+        json={"yaml_content": yaml, "tenant_id": "cross-b", "activate": True},
+    )
+    assert r_b.status_code == 200
+    hash_b = r_b.json()["bundle_hash"]
+
+    # Same content → same hash. Different rows (separate tenant_id).
+    assert hash_a == hash_b
+
+    # Both tenants must see the bundle as active on their own
+    # listing and active-resolve. Pre-#79 one of these returned 404.
+    r_a_active = await client.get("/admin/policy/active?tenant_id=cross-a")
+    assert r_a_active.status_code == 200
+    assert r_a_active.json()["bundle_hash"] == hash_a
+
+    r_b_active = await client.get("/admin/policy/active?tenant_id=cross-b")
+    assert r_b_active.status_code == 200
+    assert r_b_active.json()["bundle_hash"] == hash_b
+
+    # And the per-tenant listing each shows the one row, not both.
+    r_a_list = await client.get("/admin/policy/bundles?tenant_id=cross-a")
+    a_rows = [b for b in r_a_list.json()["bundles"] if b["tenant_id"] == "cross-a"]
+    assert len(a_rows) == 1 and a_rows[0]["active"]
+    r_b_list = await client.get("/admin/policy/bundles?tenant_id=cross-b")
+    b_rows = [b for b in r_b_list.json()["bundles"] if b["tenant_id"] == "cross-b"]
+    assert len(b_rows) == 1 and b_rows[0]["active"]

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 18
+    assert len(revs) == 19
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 8
+    assert result.pending_count == 9
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 18
+    assert result.pending_count == 19
 
 
 def test_resolve_pending_unknown_revision():


### PR DESCRIPTION
Closes #79.

Before this PR, \`policy_bundles\` had a single-column PK on \`bundle_hash\`. Because bundles are content-addressed (same YAML → same hash), two tenants installing the same YAML produced only one row. The second upload's "insert if missing" check found the existing row, silently re-bound its \`tenant_id\`, and the first tenant's policy resolution broke. Caught during the enforce-mode prod smoke for #50 (had to use tenant-unique YAML as a workaround); filed as #79.

## Schema (migration 0019)

- Add synthetic \`id\` UUID column as the new PK. Random per row, no semantic meaning — content addressing stays on \`bundle_hash\`, row identity moves to the UUID so multiple rows can share a hash.
- Drop the old PK on \`bundle_hash\` alone.
- Composite unique index on \`(tenant_id, bundle_hash) NULLS NOT DISTINCT\` (PG15+; statewave runs PG16). This makes \`(NULL, 'X') = (NULL, 'X')\` (globals can't be duplicated) but \`(NULL, 'X') ≠ ('acme', 'X')\` (cross-tenant install is allowed).
- Drop the now-redundant \`ix_policy_bundles_tenant_active\` index — the new composite unique covers the \`tenant_id\` lead column for the active-lookup query.

Reverse-compatible if no cross-tenant duplicates exist; downgrade documented in the migration docstring.

## Endpoint changes

- \`POST /admin/policy/bundles\`: existing-row check now uses \`(tenant_id, bundle_hash)\`; activate's UPDATE scopes the same way so a cross-tenant row with the same hash isn't touched.
- \`GET /admin/policy/bundles/{bundle_hash}\`: now accepts \`?tenant_id=\` for disambiguation. Without it, the lookup prefers the global row; if the hash exists only in tenant-scoped form, returns 404 with a helpful detail message telling the caller to pass \`?tenant_id=\`.
- \`POST /admin/policy/activate\`: request body now includes \`tenant_id\`. Activates exactly the row matching \`(tenant_id, bundle_hash)\`, deactivates only other rows in the SAME tenant scope.

## Tests

- **New: \`test_same_yaml_two_tenants_resolve_independently\`** — the load-bearing acceptance test. Two tenants upload the IDENTICAL YAML, hashes match, but each tenant's \`/admin/policy/active\` returns their own bundle and their \`/admin/policy/bundles\` listing shows exactly one row.
- \`test_admin_policy_upload_and_activate_round_trip\` reverted to use \`PII_BUNDLE_YAML\` (the v2 workaround comment was removed since the workaround is no longer needed).
- \`EXPECTED_HEAD\` bumped + migration counts updated.

## Companion admin PR

\`fetchPolicyBundle()\` and the Policy page need the \`?tenant_id=\` query param threaded through. Ships next.