### PR TITLE
release: v0.8.0 — governance & audit layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Everything is organised around **subjects** — a user, account, agent, repo, or
 
 Statewave is **not** a chatbot framework, a vector database, a RAG pipeline, or a hosted service. It is infrastructure you run alongside your application.
 
-> **Status:** v0.7.2 — actively developed. Per-kind memory TTL with hourly tombstone sweep, Helm chart for ops, cross-machine query embedding cache (L1 + L2), on top of the full support-agent intelligence stack from v0.7.1: session-aware context, resolution tracking, handoff packs, health scoring, SLA tracking, proactive alerts. See [current limitations](#current-limitations) below.
+> **Status:** v0.8.0 — actively developed. **Governance & audit layer shipped:** every context assembly can emit an immutable [state-assembly receipt](https://github.com/smaramwbc/statewave-docs/blob/main/receipts.md) (content-hash integrity, full provenance, queryable + chainable by ULID), per-memory [sensitivity labels](https://github.com/smaramwbc/statewave-docs/blob/main/sensitivity-labels.md) feed a declarative YAML policy engine that filters by caller identity, and per-tenant config flips enforce mode on without a SQL shell. Builds on the v0.7.x foundation: per-kind memory TTL, Helm chart, cross-machine query embedding cache, and the full support-agent intelligence stack (session-aware context, resolution tracking, handoff packs, health, SLA, proactive alerts). See [current limitations](#current-limitations) below.
 
 ## 🎯 Try it
 
@@ -89,6 +89,11 @@ Statewave is **not** a chatbot framework, a vector database, a RAG pipeline, or 
 - **SLA tracking** — first-response time, resolution time, breach detection
 - **Proactive health alerts** — webhooks on health state transitions (degradation + recovery)
 - **Repeat-issue detection** — surfaces prior resolutions when patterns recur
+- **State-assembly receipts** — every `/v1/context` and `/v1/handoff` call can emit an immutable, ULID-addressable audit record of which memories + episodes influenced the bundle, with a SHA-256 hash of the bytes delivered to the agent and tenant-scoped retrieval via `GET /v1/receipts`
+- **Per-memory sensitivity labels** — operator-supplied capability tags (`pii`, `financial`, `secret`, …) carried as a `TEXT[]` column with a GIN index; set via `PATCH /v1/memories/{id}/labels`
+- **Declarative policy engine** — YAML/JSON policy bundles with six predicates (label match, caller_type, caller_id), two actions (`deny`, `redact`), and first-match-wins evaluation; bundles are content-hashed and immutable, addressable by `bundle_hash`; per-tenant policy_mode toggles between `log_only` (record decisions to receipts, no filtering) and `enforce` (drop denied memories before ranking)
+- **Caller identity** — `caller_id` and `caller_type` on context/handoff requests feed the policy evaluator; tenant config `require_caller_identity: true` 401s anonymous calls
+- **Per-tenant config** — `GET / PATCH /admin/tenants/{id}/config` for receipts emission, retention, policy_mode, caller-identity gating; PATCH-shape merge with optimistic concurrency via `expected_version`
 
 ## Quick start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "statewave"
-version = "0.7.2"
+version = "0.8.0"
 description = "Open-source memory runtime for AI agents — durable, structured context with provenance."
 readme = "README.md"
 license = {text = "AGPL-3.0-only OR LicenseRef-Statewave-Commercial"}


### PR DESCRIPTION
SemVer minor bump capturing the work merged across this release cycle:

- #49 — state-assembly receipts (immutable audit artifact, content-hash integrity, ULID-addressable, queryable per subject)
- #50 — sensitivity labels + declarative policy engine (six predicates, two actions, log_only vs enforce mode, content-hashed bundles)
- #77 — multi-replica cache staleness hotfix
- #78 + admin#61 — console hygiene
- #80 + admin#62 — tenant-config write endpoint (makes enforce mode + require_caller_identity reachable via API, not raw SQL)
- #79 + admin#63 — composite (tenant_id, bundle_hash) uniqueness (two tenants can install the same YAML independently)

## What changed

- \`pyproject.toml\` version 0.7.2 → 0.8.0
- \`README.md\` status line rewritten around the governance/audit pivot — receipts, labels, policy, tenant config
- \`README.md\` capabilities list extended with five new bullets covering the new surface

## Companion PRs (open simultaneously)

- statewave-py 0.8.0 (CHANGELOG + version)
- statewave-ts 0.8.0 (CHANGELOG + version)
- statewave-docs (roadmap + CHANGELOG + product + why + architecture)
- statewave-web (HomePage + ProductPage)

All bump to the same 0.8.0 version so the cross-repo consistency gate stays happy. Merge order: server first → SDKs → docs → web.

## Test plan

- [x] All 58 policy/receipts unit tests pass locally.
- [ ] CI green.