### PR TITLE
chore(support): point enterprise inquiries to licensing@statewave.ai

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -63,4 +63,4 @@ Not sure? Open an issue in the main [statewave](https://github.com/smaramwbc/sta
 
 ## 🏢 Enterprise Support
 
-For enterprise support inquiries, please contact us at [enterprise@statewave.ai](mailto:enterprise@statewave.ai).
+For enterprise support inquiries, please contact us at [licensing@statewave.ai](mailto:licensing@statewave.ai).


### PR DESCRIPTION
Replaces the unmonitored `enterprise@statewave.ai` alias with the canonical `licensing@statewave.ai` address used across the workspace.

Completes the workspace-wide migration started with the 5 sibling-repo PRs that already landed.