### PR TITLE
chore: align workspace version to v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Statewave is the open-source memory runtime that gives AI agents reproducible, p
 
 <!-- QUICKSTART GIF: docs/img/quickstart.gif landing in follow-up PR (issue #4) -->
 
-> **v0.8.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
+> **v0.9.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
 
 ## 🎯 Try it
 
@@ -269,7 +269,7 @@ pytest tests/ -v
 
 ## Current limitations
 
-Statewave is in active development (v0.8.0). Honest status:
+Statewave is in active development (v0.9.0). Honest status:
 
 - **Rate limiting is per-IP** — distributed (Postgres-backed), but keyed by IP only, not per-tenant or per-API-key yet
 - **Multi-tenant is app-layer** — query-scoped data isolation (v0.5) + per-tenant config / policy bundles / receipts (v0.8) layered on top, but no Postgres RLS yet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "statewave"
-version = "0.8.0"
+version = "0.9.0"
 description = "Open-source memory runtime for AI agents — durable, structured context with provenance."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## What

Aligns the single cross-repo workspace version to **v0.9.0**.

`v0.9.0` is the TypeScript SDK's independent pre-1.0 breaking release (camelCase rename, statewave-ts#103). The **server, API contract, and Python SDK have no functional changes** since v0.8.0 — this PR only realigns version strings so the release-time `check-versions.py` gate passes. No release tag is pushed by this PR, so nothing is republished.

- Python SDK CHANGELOG entry explicitly states "version-alignment only, no API changes".
- Docs status blurb reframed honestly (no fabricated v0.9.0 feature story; the product surface is still the v0.8.0 governance & audit layer).

## Why this is a band-aid

The lockstep "one version across all repos" model is what forced this. Independent per-package releases will keep re-triggering the same drift. The proper fix — decouple per-package versions, coordinate on the API contract instead — is tracked as a follow-up issue.