### PR TITLE
fix(compiler): anchor relative dates to the episode's real timestamp (#115)

### DIFF
--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -79,11 +79,11 @@ Rules:
 - Return ONLY the JSON array, no markdown fences or extra text.
 
 Temporal grounding:
-- If a message is prefixed with a bracketed timestamp like `[1:14 pm on 25 May, 2023]`, that timestamp marks WHEN the speaker said this — and by extension, when any event they describe in present/past tense happened.
-- For ANY memory you extract about a dated event, action, or state change (e.g. "ran a race", "attended a conference", "joined a group", "started a project", "moved cities", "got married"), the memory `content` MUST include the date.
-- Convert relative phrases against the message timestamp: "yesterday" -> the message timestamp minus 1 day; "last Saturday" -> the most recent Saturday before the message timestamp; "two days ago" -> message timestamp minus 2 days; "last year" -> the year before the message timestamp's year. Render the resolved date as ISO-like prose ("on 2023-05-24" or "on 24 May 2023") in the memory `content`.
-- If a message is itself stated as a present-tense event ("I'm running a charity race today"), use the message's own timestamp date.
-- If no timestamp is available and no absolute date is mentioned in the text, omit the date rather than guess.
+- Every episode block is prefixed with a header line `--- Episode N | recorded YYYY-MM-DD (Weekday) ---`. That `recorded` date is the authoritative reference timestamp for everything in that episode unless a specific message carries its own more precise timestamp.
+- If a message is prefixed with a bracketed timestamp like `[1:14 pm on 25 May, 2023]`, prefer that over the episode header for that message: it marks WHEN the speaker said this — and by extension, when any event they describe in present/past tense happened.
+- For ANY memory you extract about a dated event, action, or state change (e.g. "ran a race", "attended a conference", "joined a group", "started a project", "moved cities", "got married"), the memory `content` MUST include the resolved absolute date.
+- Resolve every relative phrase against the applicable reference date (a message's bracketed timestamp if present, otherwise the episode's `recorded` date): "today" / "this morning" / present tense -> the reference date itself; "yesterday" -> reference date minus 1 day; "last Saturday" -> the most recent Saturday before the reference date; "two days ago" -> reference date minus 2 days; "last year" -> the year before the reference date's year; "this weekend" / "the weekend" -> the Saturday–Sunday of the reference date's week. Render the resolved date as ISO-like prose ("on 2026-05-16" or "on 16 May 2026") in the memory `content`.
+- NEVER invent, guess, or default a date. Do not emit any date that cannot be derived from either an explicit date in the text or the applicable reference date. Only if there is genuinely no reference date AND no absolute date in the text, omit the date rather than guess.
 - This applies to BOTH profile_fact and episode_summary memories — a summary of a dated session should also lead with or include the session date.
 
 Granularity — extract DETAILS, not just headlines:
@@ -201,10 +201,20 @@ class LLMCompiler:
     ) -> list[MemoryRow]:
         """Process a batch of episodes in a single LLM call."""
         async with semaphore:
-            # Format the prompt with all episodes in this batch
+            # Format the prompt with all episodes in this batch. Each block
+            # is annotated with the episode's resolved reference timestamp
+            # (`episode_valid_from` — the same anchor used for the memory's
+            # `valid_from`), so the model resolves "today"/relative phrases
+            # against the real episode date instead of inventing one. Without
+            # this the model has no reference point and falls back to a
+            # plausible-looking default (commonly the LoCoMo sample's
+            # "25 May 2023") — see issue #115.
             episode_blocks = []
             for i, (ep, text) in enumerate(batch):
-                episode_blocks.append(f"--- Episode {i} ---\n{text}")
+                ref_label = episode_valid_from(ep).strftime("%Y-%m-%d (%A)")
+                episode_blocks.append(
+                    f"--- Episode {i} | recorded {ref_label} ---\n{text}"
+                )
             combined_text = "\n\n".join(episode_blocks)
 
             try:

--- a/tests/test_issue_115.py
+++ b/tests/test_issue_115.py
@@ -1,0 +1,87 @@
+"""Regression test for issue #115.
+
+The LLM compiler must give the model the episode's real reference date so
+relative phrases ("today", "this morning") resolve to the actual date
+instead of a hallucinated one (the LoCoMo sample's "25 May 2023").
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.db.tables import EpisodeRow
+from server.services.compilers.llm import _SYSTEM_PROMPT, LLMCompiler
+
+
+# ---------------------------------------------------------------------------
+# #115 — episode reference date reaches the LLM prompt
+# ---------------------------------------------------------------------------
+
+
+def _make_compiler() -> LLMCompiler:
+    compiler = LLMCompiler.__new__(LLMCompiler)
+    compiler._model = "gpt-4o-mini"
+    return compiler
+
+
+def _episode(**kw) -> EpisodeRow:
+    defaults = dict(
+        id=uuid.uuid4(),
+        subject_id="alice_bob_conversation",
+        source="test",
+        type="chat",
+        payload={"messages": [{"role": "user", "content": "Bob checked the weather this morning."}]},
+        metadata_={},
+        provenance={},
+        created_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+    )
+    defaults.update(kw)
+    return EpisodeRow(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_115_prompt_carries_episode_reference_date():
+    """The episode's resolved timestamp must be in the text sent to the LLM."""
+    compiler = _make_compiler()
+    ep = _episode()
+
+    captured = AsyncMock(return_value=[])
+    with patch.object(compiler, "_call_llm_async", captured):
+        await compiler.compile_async([ep])
+
+    assert captured.await_count == 1
+    prompt_text = captured.await_args.args[0]
+    # 2026-05-16 is a Saturday — header is "recorded YYYY-MM-DD (Weekday)".
+    assert "Episode 0 | recorded 2026-05-16 (Saturday)" in prompt_text
+    # The bare, dateless header must no longer be emitted.
+    assert "--- Episode 0 ---" not in prompt_text
+
+
+@pytest.mark.asyncio
+async def test_115_message_timestamp_overrides_episode_date():
+    """payload.messages[0].timestamp wins over created_at (episode_valid_from)."""
+    compiler = _make_compiler()
+    ep = _episode(
+        payload={
+            "messages": [
+                {"role": "user", "content": "Hi", "timestamp": "2024-03-02T09:00:00+00:00"}
+            ]
+        },
+    )
+    captured = AsyncMock(return_value=[])
+    with patch.object(compiler, "_call_llm_async", captured):
+        await compiler.compile_async([ep])
+
+    assert "recorded 2024-03-02" in captured.await_args.args[0]
+
+
+def test_115_system_prompt_forbids_inventing_dates():
+    assert "NEVER invent, guess, or default a date" in _SYSTEM_PROMPT
+    assert "recorded YYYY-MM-DD (Weekday)" in _SYSTEM_PROMPT
+    # The old unconditional "omit the date" escape hatch is gone — it now
+    # only applies when there is genuinely no reference date at all.
+    assert "If no timestamp is available and no absolute date" not in _SYSTEM_PROMPT


### PR DESCRIPTION
## Problem

Closes #115. A conversation recorded `2026-05-16` where speakers say "today"/"this morning" compiled to memories dated **25 May 2023**.

## Root cause

`_SYSTEM_PROMPT` instructs the model to resolve relative phrases "against the message timestamp", but `_process_batch` fed each episode to the LLM as a bare `--- Episode N ---` header plus text — **the timestamp was never in the prompt**. With no reference point the model fell back to a plausible default; `25 May 2023` is the LoCoMo sample date bleeding through from training.

## Fix

- Annotate each episode block with its resolved reference date — `--- Episode N | recorded YYYY-MM-DD (Weekday) ---` — from `episode_valid_from()`, the **same anchor already used for the memory's `valid_from`**. The in-content date and `valid_from` now share one source of truth.
- Tighten the temporal-grounding rules: resolve every relative phrase (incl. "today"/"this weekend") against that date; a per-message bracketed timestamp still wins; **never invent or default a date**.

## On `valid_to` (also raised in #115)

Intentionally unchanged. A null `valid_to` on a forever-valid `profile_fact` is the TTL/decay model working as designed, not a lost temporal period — the real defect was the wrong content date. Overloading `valid_to` with event-extent semantics would be a bitemporal schema redesign affecting decay/cleanup and the benchmark; out of scope for this bug.

## Tests

`tests/test_issue_115.py`: reference date reaches the prompt; per-message timestamp precedence; prompt forbids invented dates. Full non-integration suite green (507 passed).