### PR TITLE
fix(context): flag when no stored context is relevant to the task (#116)

### DIFF
--- a/server/services/context.py
+++ b/server/services/context.py
@@ -69,6 +69,28 @@ _LEXICAL_BONUS_MAX = 4.0  # Additive bonus when query terms appear verbatim in
 # floor. Capped at 4.0 so it can't override a clearly dominant kind signal —
 # only break ties between similarly-ranked candidates.
 
+# Task-relevance gate (issue #116). The ranker always returns *something*
+# (kind priority + recency keep memories ranked even when nothing matches the
+# task), so an off-topic task — "What is the airline ticket price?" against a
+# weather subject — silently renders unrelated facts as if they were relevant.
+# We don't drop those facts (recall is still useful and the benchmark relies
+# on it), but when NOTHING clears a real task-relevance signal we prepend an
+# explicit caveat so the caller knows the context isn't task-specific.
+#
+# A candidate counts as task-relevant if EITHER:
+#   - semantic cosine similarity ≥ _SEMANTIC_RELEVANCE_FLOOR, or
+#   - it shares ≥1 meaningful (non-stopword) token with the task.
+# semantic_scores[id] = (1 - cosine_distance) * _SEMANTIC_MAX, so the cosine
+# similarity is semantic_scores[id] / _SEMANTIC_MAX. 0.25 is deliberately
+# conservative: unrelated sentence-embedding pairs typically sit ≤0.15 while
+# topically-related ones clear ~0.35+, so this only fires for clearly
+# off-topic tasks and never on the (always on-topic) benchmark queries.
+_SEMANTIC_RELEVANCE_FLOOR = 0.25
+_NO_TASK_CONTEXT_NOTE = (
+    "_No stored context is directly associated with this task. "
+    "The items below are this subject's general memory, not task-specific._"
+)
+
 # Support-agent-specific scoring signals
 _OPEN_ISSUE_BOOST = 4.0  # Bonus for episodes in sessions with open/unresolved issues
 _ACTION_STEP_BOOST = 2.0  # Bonus for agent/assistant/tool episodes (what was tried)
@@ -319,6 +341,11 @@ async def assemble_context(
     # -- Score all candidates ------------------------------------------------
     task_tokens = _tokenize_for_relevance(task)
 
+    # Issue #116: track whether ANY candidate is genuinely task-relevant
+    # (semantic similarity above the floor, or a literal token overlap).
+    # Drives the no-task-context caveat below without altering ranking.
+    task_relevant = False
+
     scored: list[_ScoredItem] = []
     all_memory_rows = list(fact_rows) + list(procedure_rows) + list(summary_rows)
 
@@ -376,6 +403,18 @@ async def assemble_context(
             else:
                 relevance = _relevance_score(row.content, task_tokens)
                 lexical_bonus = 0.0
+
+            # Issue #116: does THIS memory actually relate to the task?
+            # Use the stopword-aware meaningful-overlap predicate (same one
+            # the lexical bonus uses) — raw word overlap would treat a shared
+            # "the"/"is" as relevance and never fire the caveat.
+            if not task_relevant and task_tokens:
+                if use_semantic and row.id in semantic_scores:
+                    cosine_sim = semantic_scores[row.id] / _SEMANTIC_MAX
+                    if cosine_sim >= _SEMANTIC_RELEVANCE_FLOOR or lexical_bonus > 0.0:
+                        task_relevant = True
+                elif _lexical_overlap_bonus(row.content, task_tokens) > 0.0:
+                    task_relevant = True
 
             breadcrumb_bonus = _breadcrumb_overlap_bonus(
                 memory_breadcrumbs.get(row.id, []),
@@ -464,10 +503,19 @@ async def assemble_context(
                 continue  # already represented by a summary
             ep_text = _short_episode_text(row.payload, row.source, row.type)
             content_text = extract_payload_text(row.payload)
+            ep_relevance = _relevance_score(content_text, task_tokens)
+            # Issue #116: a meaningful (non-stopword) token overlap with an
+            # episode also counts as the task being on-topic for this subject.
+            if (
+                not task_relevant
+                and task_tokens
+                and _lexical_overlap_bonus(content_text, task_tokens) > 0.0
+            ):
+                task_relevant = True
             score = (
                 _EPISODE_PRIORITY
                 + _recency_score(row.created_at, ep_ts_range)
-                + _relevance_score(content_text, task_tokens)
+                + ep_relevance
             )
             # Boost episodes belonging to the active session
             if session_id and getattr(row, "session_id", None) == session_id:
@@ -511,6 +559,13 @@ async def assemble_context(
     # -- Assemble within budget ---------------------------------------------
     task_header = f"## Task\n{task}\n"
     budget_used = len(enc.encode(task_header))
+
+    # Issue #116: if nothing cleared a real task-relevance signal, we still
+    # return the subject's memory (recall preserved) but prepend an explicit
+    # caveat. Reserve its tokens up front so the budget stays honored.
+    show_no_task_context = bool(task.strip()) and not task_relevant
+    if show_no_task_context:
+        budget_used += len(enc.encode(_NO_TASK_CONTEXT_NOTE + "\n"))
 
     included_facts: list[MemoryResponse] = []
     included_summaries: list[MemoryResponse] = []
@@ -558,6 +613,9 @@ async def assemble_context(
     # This mirrors how a human would brief someone: who is this person,
     # what do they need, what happened recently, raw detail if room.
     parts: list[str] = [task_header]
+    if show_no_task_context:
+        parts.append(_NO_TASK_CONTEXT_NOTE)
+        parts.append("")
     if section_lines["facts"]:
         parts.append("## About this user")
         parts.extend(section_lines["facts"])

--- a/tests/test_issue_116.py
+++ b/tests/test_issue_116.py
@@ -1,0 +1,125 @@
+"""Regression test for issue #116.
+
+/v1/context must flag when nothing stored is relevant to the task instead
+of silently presenting unrelated memory as "About this user".
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.services.context import _NO_TASK_CONTEXT_NOTE, assemble_context
+
+
+def _fact(content: str) -> SimpleNamespace:
+    now = datetime(2026, 5, 16, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        subject_id="alice_bob_conversation",
+        kind="profile_fact",
+        content=content,
+        summary=content[:80],
+        confidence=0.9,
+        valid_from=now,
+        valid_to=None,
+        source_episode_ids=[],
+        metadata_={},
+        status="active",
+        sensitivity_labels=[],
+        created_at=now,
+        updated_at=now,
+    )
+
+
+_WEATHER_FACTS = [
+    _fact("Bob checked the weather on the morning of 2026-05-16."),
+    _fact("The temperature was around 60 degrees Fahrenheit and windy on 2026-05-16."),
+    _fact("Alice brought her jacket on 2026-05-16 because it was cold outside."),
+]
+
+
+@contextmanager
+def _mock_repos(facts):
+    async def _search_memories(session, subject_id, *, tenant_id=None, kind=None, limit=None):
+        return list(facts) if kind == "profile_fact" else []
+
+    with (
+        patch(
+            "server.services.context.repo.search_memories",
+            new=AsyncMock(side_effect=_search_memories),
+        ),
+        patch(
+            "server.services.context.repo.list_episodes_by_subject",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "server.services.context.repo.search_memories_by_embedding",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("server.services.context.get_embedding_provider", return_value=None),
+        patch(
+            "server.services.context.repo.get_resolved_session_ids",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch(
+            "server.services.context.repo.get_open_session_ids",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch(
+            "server.services.context.repo.list_resolutions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "server.services.context.policy_service.resolve_active_bundle",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_116_offtopic_task_gets_caveat_but_keeps_facts():
+    """An unrelated task surfaces the caveat — and still returns the facts."""
+    with _mock_repos(_WEATHER_FACTS):
+        result = await assemble_context(
+            AsyncMock(), "alice_bob_conversation",
+            "What is the airline ticket price?", max_tokens=4000,
+        )
+    assert _NO_TASK_CONTEXT_NOTE in result.assembled_context
+    # Recall preserved: the weather facts are still in the bundle.
+    assert "60 degrees Fahrenheit" in result.assembled_context
+    assert len(result.facts) == len(_WEATHER_FACTS)
+
+
+@pytest.mark.asyncio
+async def test_116_relevant_task_has_no_caveat():
+    """A task that overlaps stored content must NOT trigger the caveat."""
+    with _mock_repos(_WEATHER_FACTS):
+        result = await assemble_context(
+            AsyncMock(), "alice_bob_conversation",
+            "What was the weather like that morning?", max_tokens=4000,
+        )
+    assert _NO_TASK_CONTEXT_NOTE not in result.assembled_context
+    assert "60 degrees Fahrenheit" in result.assembled_context
+
+
+@pytest.mark.asyncio
+async def test_116_empty_task_never_caveats():
+    """No task → relevance is undefined; never emit the caveat."""
+    with _mock_repos(_WEATHER_FACTS):
+        result = await assemble_context(
+            AsyncMock(), "alice_bob_conversation", "", max_tokens=4000,
+        )
+    assert _NO_TASK_CONTEXT_NOTE not in result.assembled_context


### PR DESCRIPTION
## Problem

Closes #116. `POST /v1/context` with an off-topic task (`"What is the airline ticket price?"`) against a weather subject silently renders the unrelated weather memories under `## About this user` as if they were task-specific.

## Root cause

The ranker always returns *something*: `score = kind_priority + recency + relevance + …` has no relevance floor, so kind/recency keep memories ranked even when relevance is zero. Nothing signals "none of this relates to your task".

## Fix

Track whether **any** candidate is genuinely task-relevant:
- semantic cosine similarity ≥ a conservative `0.25` floor, **or**
- a stopword-aware meaningful token overlap (reusing the same predicate as the lexical bonus — a shared `"the"`/`"is"` does not count).

When nothing clears it, prepend an explicit caveat:

> _No stored context is directly associated with this task. The items below are this subject's general memory, not task-specific._

**Recall is preserved** — the facts are still returned (the benchmark depends on it) and ranking is untouched. The `0.25` floor is deliberately conservative so the always-on-topic benchmark queries never trip it. Caveat tokens are reserved up front so the budget stays honored.

## Tests

`tests/test_issue_116.py`: off-topic task gets the caveat **and** still returns the facts; relevant task does not; empty task never caveats. Full non-integration suite green (507 passed), incl. benchmark-sensitive `test_support_ranking.py`.