### PR TITLE
feat(docker): add support for host port overrides in local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,8 +53,10 @@ STATEWAVE_LITELLM_API_KEY=
 # ── Docker Compose — Host Port Overrides ────────────────────
 # For local development: override the default host ports to resolve
 # conflicts with services running on your host machine. Defaults are
-# 5432 (database) and 8080 (admin console).
+# 5432 (database), 8100 (API) and 8080 (admin console). Only the host
+# side changes — in-container service-to-service traffic is unaffected.
 # STATEWAVE_DB_HOST_PORT=5432
+# STATEWAVE_API_HOST_PORT=8100
 # STATEWAVE_ADMIN_HOST_PORT=8080
 
 # ── Server ───────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,13 @@ STATEWAVE_LITELLM_API_KEY=
 # only if you're running the API against a database OUTSIDE compose.
 # STATEWAVE_DATABASE_URL=postgresql+asyncpg://statewave:statewave@localhost:5432/statewave
 
+# ── Docker Compose — Host Port Overrides ────────────────────
+# For local development: override the default host ports to resolve
+# conflicts with services running on your host machine. Defaults are
+# 5432 (database) and 8080 (admin console).
+# STATEWAVE_DB_HOST_PORT=5432
+# STATEWAVE_ADMIN_HOST_PORT=8080
+
 # ── Server ───────────────────────────────────────────────────
 # STATEWAVE_DEBUG=true
 # STATEWAVE_HOST=0.0.0.0

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -52,6 +52,70 @@ curl http://localhost:8100/healthz
 STATEWAVE_VERSION=0.7.0 docker compose up -d
 ```
 
+## Handling port conflicts
+
+Local deployments frequently encounter port conflicts if services like PostgreSQL or other applications already use ports 5432 (database) or 8080 (admin console). Override the host ports using environment variables:
+
+```sh
+# Use custom ports instead of defaults
+STATEWAVE_DB_HOST_PORT=5433 STATEWAVE_ADMIN_HOST_PORT=8081 docker compose up -d
+```
+
+Or set them in a `.env` file next to `docker-compose.yml`:
+
+```sh
+# .env
+STATEWAVE_DB_HOST_PORT=5433
+STATEWAVE_ADMIN_HOST_PORT=8081
+```
+
+Then start as usual:
+
+```sh
+docker compose up -d
+```
+
+### Service port reference
+
+| Service | Container port | Default host port | Override variable |
+|---------|---|---|---|
+| Database (PostgreSQL) | 5432 | 5432 | `STATEWAVE_DB_HOST_PORT` |
+| Admin console | 8080 | 8080 | `STATEWAVE_ADMIN_HOST_PORT` |
+| API | 8100 | 8100 | *(not configurable — reserved for internal use)* |
+
+### Troubleshooting port conflicts
+
+**Error: `bind: address already in use`**
+
+1. **Identify the conflicting process:**
+   ```sh
+   # On macOS/Linux
+   lsof -i :5432  # Check database port
+   lsof -i :8080  # Check admin port
+   ```
+
+2. **Choose one of:**
+   - **Kill the other process** (if it's not needed)
+   - **Change the Statewave port** (recommended for local dev) — set `DB_HOST_PORT` and/or `ADMIN_HOST_PORT`
+   - **Change the other service's port** (if you control it)
+
+3. **Start Statewave with the new ports:**
+   ```sh
+   STATEWAVE_DB_HOST_PORT=5433 STATEWAVE_ADMIN_HOST_PORT=8081 docker compose up -d
+   ```
+
+4. **Update your connection strings** if scripting against Statewave:
+   ```python
+   # Example: connect to database on custom port 5433
+   from sqlalchemy import create_engine
+   engine = create_engine("postgresql://statewave:statewave@localhost:5433/statewave")
+   ```
+
+### Environment variable precedence
+
+- Command-line variables override `.env` file variables: `STATEWAVE_DB_HOST_PORT=5433 docker compose up -d` takes precedence over `STATEWAVE_DB_HOST_PORT=5434` in `.env`
+- If neither is set, defaults are used (5432 for DB, 8080 for admin)
+
 ## Tags
 
 | Tag | Meaning |

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -54,7 +54,7 @@ STATEWAVE_VERSION=0.7.0 docker compose up -d
 
 ## Handling port conflicts
 
-Local deployments frequently encounter port conflicts if services like PostgreSQL or other applications already use ports 5432 (database) or 8080 (admin console). Override the host ports using environment variables:
+Local deployments frequently encounter port conflicts if services like PostgreSQL or other applications already use ports 5432 (database), 8100 (API) or 8080 (admin console). Override the host ports using environment variables. Only the host-side port changes — traffic between the containers (e.g. admin → API) stays on the internal compose network and is unaffected:
 
 ```sh
 # Use custom ports instead of defaults
@@ -81,7 +81,7 @@ docker compose up -d
 |---------|---|---|---|
 | Database (PostgreSQL) | 5432 | 5432 | `STATEWAVE_DB_HOST_PORT` |
 | Admin console | 8080 | 8080 | `STATEWAVE_ADMIN_HOST_PORT` |
-| API | 8100 | 8100 | *(not configurable — reserved for internal use)* |
+| API | 8100 | 8100 | `STATEWAVE_API_HOST_PORT` |
 
 ### Troubleshooting port conflicts
 
@@ -91,12 +91,13 @@ docker compose up -d
    ```sh
    # On macOS/Linux
    lsof -i :5432  # Check database port
+   lsof -i :8100  # Check API port
    lsof -i :8080  # Check admin port
    ```
 
 2. **Choose one of:**
    - **Kill the other process** (if it's not needed)
-   - **Change the Statewave port** (recommended for local dev) — set `DB_HOST_PORT` and/or `ADMIN_HOST_PORT`
+   - **Change the Statewave port** (recommended for local dev) — set `STATEWAVE_DB_HOST_PORT`, `STATEWAVE_API_HOST_PORT` and/or `STATEWAVE_ADMIN_HOST_PORT`
    - **Change the other service's port** (if you control it)
 
 3. **Start Statewave with the new ports:**
@@ -104,17 +105,20 @@ docker compose up -d
    STATEWAVE_DB_HOST_PORT=5433 STATEWAVE_ADMIN_HOST_PORT=8081 docker compose up -d
    ```
 
-4. **Update your connection strings** if scripting against Statewave:
-   ```python
-   # Example: connect to database on custom port 5433
-   from sqlalchemy import create_engine
-   engine = create_engine("postgresql://statewave:statewave@localhost:5433/statewave")
+4. **Update anything that targets the remapped host ports.** In-cluster
+   addresses are unchanged — only host-side clients need the new port:
+   ```sh
+   # API remapped to host port 8101 instead of 8100
+   curl http://localhost:8101/healthz
+
+   # A client connecting directly to the DB on a custom host port (5433):
+   export STATEWAVE_DATABASE_URL=postgresql+asyncpg://statewave:statewave@localhost:5433/statewave
    ```
 
 ### Environment variable precedence
 
 - Command-line variables override `.env` file variables: `STATEWAVE_DB_HOST_PORT=5433 docker compose up -d` takes precedence over `STATEWAVE_DB_HOST_PORT=5434` in `.env`
-- If neither is set, defaults are used (5432 for DB, 8080 for admin)
+- If neither is set, defaults are used (5432 for DB, 8100 for API, 8080 for admin)
 
 ## Tags
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: statewave
       POSTGRES_DB: statewave
     ports:
-      - "5432:5432"
+      - "${STATEWAVE_DB_HOST_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -61,7 +61,7 @@ services:
     # start just the core stack with `docker compose up -d api db`.
     image: statewavedev/statewave-admin:${STATEWAVE_ADMIN_VERSION:-latest}
     ports:
-      - "8080:8080"
+      - "${STATEWAVE_ADMIN_HOST_PORT:-8080}:8080"
     environment:
       # Talks to the api over the compose network — both containers see each
       # other by service name. The browser hits the admin's own server, which

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     image: statewavedev/statewave:${STATEWAVE_VERSION:-latest}
     build: .
     ports:
-      - "8100:8100"
+      - "${STATEWAVE_API_HOST_PORT:-8100}:8100"
     # Load STATEWAVE_LITELLM_*, STATEWAVE_API_KEY, etc. from the host's .env.
     # `.dockerignore` keeps .env OUT of the image — env_file injects values
     # at runtime so the docker-compose `environment:` block below remains


### PR DESCRIPTION
## Description

Fixes port conflict issues in local Docker Compose deployments by adding environment variable support for host port overrides. Users can now resolve 5432/8080 conflicts without manually editing `docker-compose.yml`.

## Related Issue

Closes #117 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🔧 Maintenance (refactoring, dependencies, CI, etc.)
- [ ] 🧪 Test improvement

## Changes Made

### Configuration
- `STATEWAVE_DB_HOST_PORT` — override database host port (default: 5432)
- `STATEWAVE_ADMIN_HOST_PORT` — override admin console host port (default: 8080)

Both are optional; existing deployments continue to work unchanged.

### Implementation
- **docker-compose.yml**: Updated `db` and `admin` services to use environment variable port mappings with sensible defaults
- **DOCKER.md**: Added comprehensive "Handling port conflicts" section including:
  - Quick start examples for command-line and `.env` file usage
  - Service port reference table
  - Troubleshooting guide with `lsof` commands
  - Environment variable precedence rules
  - Python example for connecting to custom database ports
- **.env.example**: Added commented examples and documentation for the new variables

## Testing

- [ ] Unit tests pass locally
- [ ] Integration tests pass locally
- [X] Manual testing completed
- [ ] New tests added for new functionality

### Test Commands Run

```bash
# e.g., pytest tests/ or npm test
```

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass
- [x] I have checked for breaking changes
