### PR TITLE
fix(api): enforce one canonical subject_id contract at every ingress (#121)

### DIFF
--- a/server/core/identifiers.py
+++ b/server/core/identifiers.py
@@ -1,0 +1,62 @@
+"""Canonical identifier contracts shared across the API surface.
+
+`subject_id` is an opaque-but-bounded token. Many admin/v1 routes address a
+subject by putting it directly in the URL path
+(`/admin/subjects/{subject_id}`, `/admin/subjects/{subject_id}/memories`,
+`DELETE /v1/subjects/{subject_id}`, …) using FastAPI's default
+single-segment `{subject_id}` converter. A `/` in the id makes that path
+ambiguous, so the route never matches and the subject becomes
+**created-but-unreachable** (issue #121: the episode write succeeded, then
+the admin panel and every path-param endpoint 404'd).
+
+`server.services.memory_packs` already defined exactly this charset for the
+starter-pack path; the bug was that the primary write ingress (episodes,
+batch, compile, …) only length-checked. This module is the single source of
+truth — every request schema and `memory_packs` import from here so the
+contract can never drift apart again.
+
+Pre-existing subjects that already contain `/` remain remediable: the admin
+bulk-delete path matches by `subject_id_prefix` (an unconstrained string),
+so an operator can still purge them — see the issue/PR for the steps.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+# Length cap matches the historical `Field(max_length=256)` on the write
+# schemas (the more permissive of the two prior limits — memory_packs used
+# 128 — so unifying upward is not an additional breaking change).
+SUBJECT_ID_MAX_LEN = 256
+
+# Letters, digits, underscore, dot, dash, colon. Notably excludes `/`,
+# whitespace, and other URL-significant characters (`?`, `#`, `%`, …). The
+# colon is intentionally kept — the tenant convention uses it (`tenant:id`).
+SUBJECT_ID_CHARSET = r"A-Za-z0-9_.\-:"
+SUBJECT_ID_PATTERN = rf"^[{SUBJECT_ID_CHARSET}]{{1,{SUBJECT_ID_MAX_LEN}}}$"
+SUBJECT_ID_RE = re.compile(SUBJECT_ID_PATTERN)
+
+SUBJECT_ID_CHARSET_DESC = (
+    "letters, digits, underscore, dot, dash, or colon — no '/', whitespace, "
+    f"or other URL-significant characters (1–{SUBJECT_ID_MAX_LEN} chars)"
+)
+
+# Reusable pydantic type. Using StringConstraints (not a separate regex on
+# top of a `str` field) means FastAPI returns a 422 with a clear,
+# self-documenting message and the constraint shows up in the OpenAPI schema.
+SubjectId = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=SUBJECT_ID_MAX_LEN,
+        pattern=rf"^[{SUBJECT_ID_CHARSET}]+$",
+    ),
+]
+
+
+def is_valid_subject_id(value: str) -> bool:
+    """True iff `value` satisfies the canonical subject-id contract."""
+    return bool(value) and SUBJECT_ID_RE.match(value) is not None

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -7,9 +7,11 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from server.core.identifiers import SubjectId
+
 
 class CreateEpisodeRequest(BaseModel):
-    subject_id: str = Field(..., min_length=1, max_length=256)
+    subject_id: SubjectId
     source: str = Field(..., min_length=1, max_length=256)
     type: str = Field(..., min_length=1, max_length=128)
     payload: dict[str, Any]
@@ -29,19 +31,19 @@ class BatchCreateEpisodesRequest(BaseModel):
 
 
 class CompileMemoriesRequest(BaseModel):
-    subject_id: str = Field(..., min_length=1, max_length=256)
+    subject_id: SubjectId
     async_mode: bool = Field(default=False, alias="async")
 
 
 class SearchMemoriesRequest(BaseModel):
-    subject_id: str = Field(..., min_length=1, max_length=256)
+    subject_id: SubjectId
     kind: str | None = None
     query: str | None = None
     limit: int = Field(20, ge=1, le=100)
 
 
 class GetContextRequest(BaseModel):
-    subject_id: str = Field(..., min_length=1, max_length=256)
+    subject_id: SubjectId
     task: str = Field(..., min_length=1, max_length=4000)
     max_tokens: int | None = Field(None, ge=1, le=128000)
     session_id: str | None = Field(
@@ -94,7 +96,7 @@ class GetContextRequest(BaseModel):
 
 
 class CreateResolutionRequest(BaseModel):
-    subject_id: str = Field(..., min_length=1, max_length=256)
+    subject_id: SubjectId
     session_id: str = Field(..., min_length=1, max_length=256)
     status: str = Field("open", pattern=r"^(open|resolved|unresolved)$")
     resolution_summary: str | None = Field(None, max_length=2000)
@@ -102,7 +104,7 @@ class CreateResolutionRequest(BaseModel):
 
 
 class HandoffRequest(BaseModel):
-    subject_id: str = Field(..., min_length=1, max_length=256)
+    subject_id: SubjectId
     session_id: str = Field(
         ..., min_length=1, max_length=256, description="Session being handed off"
     )

--- a/server/services/memory_packs.py
+++ b/server/services/memory_packs.py
@@ -25,7 +25,6 @@ subject ids, counts, and pack ids only.
 from __future__ import annotations
 
 import json
-import re
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -35,6 +34,7 @@ import structlog
 from sqlalchemy import delete, func, select
 
 from server.core.config import settings
+from server.core.identifiers import SUBJECT_ID_CHARSET_DESC, SUBJECT_ID_RE
 from server.db import engine as engine_module
 from server.db.tables import EpisodeRow, MemoryRow
 
@@ -57,11 +57,12 @@ _STARTER_PACK_KIND = Literal["support_docs", "demo_agent"]
 
 _PACKS_ROOT = Path(__file__).resolve().parent.parent / "starter_packs"
 
-# Subject-id regex matches what the rest of Statewave already accepts: a
-# loose, URL-safe identifier. We pin a length cap and reject anything that
-# could collide with internal prefixes used by the marketing widget's
-# per-visitor subjects (`demo_web_*`).
-_SUBJECT_ID_RE = re.compile(r"^[A-Za-z0-9_.\-:]{1,128}$")
+# Subject-id contract is now defined once in server.core.identifiers and
+# enforced at every write/query ingress (issue #121) — reuse it here so the
+# pack path can never drift from the rest of the API. On top of the shared
+# charset we additionally reject the reserved prefixes used by the marketing
+# widget's per-visitor subjects (`demo_web_*`).
+_SUBJECT_ID_RE = SUBJECT_ID_RE
 _RESERVED_PREFIXES = ("demo_web_",)
 
 
@@ -94,8 +95,7 @@ def _validate_subject_id(
     """
     if not value or not _SUBJECT_ID_RE.match(value):
         raise StarterPackError(
-            f"{field!r} must be 1-128 characters of letters, digits, "
-            "underscore, dot, dash, or colon.",
+            f"{field!r} must be {SUBJECT_ID_CHARSET_DESC}.",
             status_code=400,
         )
     if not allow_reserved and any(value.startswith(p) for p in _RESERVED_PREFIXES):

--- a/tests/test_admin_memory.py
+++ b/tests/test_admin_memory.py
@@ -247,7 +247,7 @@ def test_validate_subject_id_accepts_valid_ids():
     "bad",
     [
         "",  # empty
-        "x" * 200,  # too long
+        "x" * 257,  # too long (>256 — unified subject-id contract, #121)
         "has spaces",  # invalid char
         "weird/path",  # path separator
         "demo_web_abc",  # reserved prefix used by visitor subjects

--- a/tests/test_issue_121.py
+++ b/tests/test_issue_121.py
@@ -1,0 +1,77 @@
+"""Regression tests for issue #121.
+
+A subject id is used directly as a URL path segment by many admin/v1
+routes. A `/` in the id made FastAPI's single-segment `{subject_id}`
+converter 404, so a subject could be created (the write only length-checked)
+and then be unreachable/undeletable via every path-param endpoint.
+
+Fix: one canonical subject-id contract, enforced at every write/query
+ingress. These tests lock in (a) the contract, (b) that it rejects the
+URL-breaking characters, and (c) that memory_packs and the request schemas
+can never drift to *different* contracts again (the root cause).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from server.core.identifiers import SUBJECT_ID_RE, is_valid_subject_id
+from server.schemas.requests import (
+    CompileMemoriesRequest,
+    CreateEpisodeRequest,
+    GetContextRequest,
+)
+from server.services import memory_packs as mp
+
+_VALID = ["user-1", "tenant-a:agent-7", "support_v2.1", "test:user-42", "x" * 256]
+_INVALID = [
+    "user-1/slash_test",          # the reported bug — path separator
+    "test:user-42/slash_test",    # with the tenant prefix, as in the issue log
+    "a b",                        # whitespace
+    "a?b", "a#b", "a%2Fb",        # other URL-significant characters
+    "",                           # empty
+    "x" * 257,                    # exceeds the 256 cap
+]
+
+
+@pytest.mark.parametrize("sid", _VALID)
+def test_121_valid_subject_ids_accepted(sid):
+    assert CreateEpisodeRequest(subject_id=sid, source="s", type="t", payload={}).subject_id == sid
+    assert CompileMemoriesRequest(subject_id=sid).subject_id == sid
+    assert GetContextRequest(subject_id=sid, task="t").subject_id == sid
+    assert is_valid_subject_id(sid)
+
+
+@pytest.mark.parametrize("sid", _INVALID)
+def test_121_invalid_subject_ids_rejected_at_write_and_query(sid):
+    for model, kwargs in (
+        (CreateEpisodeRequest, dict(source="s", type="t", payload={})),
+        (CompileMemoriesRequest, {}),
+        (GetContextRequest, dict(task="t")),
+    ):
+        with pytest.raises(ValidationError):
+            model(subject_id=sid, **kwargs)
+    assert not is_valid_subject_id(sid)
+
+
+def test_121_single_source_of_truth():
+    """memory_packs must reuse the exact canonical regex — the root cause of
+    #121 was two divergent subject-id contracts in one codebase."""
+    assert mp._SUBJECT_ID_RE is SUBJECT_ID_RE
+
+
+@pytest.mark.asyncio
+async def test_121_http_post_episode_with_slash_returns_422(client):
+    """The slash id is rejected at request validation, before any DB access."""
+    resp = await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": "user-1/slash_test",
+            "source": "support-chat",
+            "type": "conversation",
+            "payload": {"messages": [{"role": "user", "content": "hi"}]},
+        },
+    )
+    assert resp.status_code == 422
+    assert "subject_id" in resp.text


### PR DESCRIPTION
## Verdict: valid bug (not user error)

Closes #121. A `subject_id` is used directly as a URL path segment by many admin/v1 routes (`/admin/subjects/{subject_id}`, `.../memories`, `DELETE /v1/subjects/{subject_id}`, …) via FastAPI's single-segment `{subject_id}` converter. A `/` in the id makes `GET /admin/subjects/test:user-42/slash_test` match `{subject_id}=test:user-42` with a dangling `/slash_test` → 404. The episode write **succeeded** (it only length-checked), so the subject was **created but unreachable and undeletable** via every path-param endpoint. The admin-panel error is a downstream symptom.

## Root cause

Two divergent subject_id contracts in one codebase: `memory_packs` already required `^[A-Za-z0-9_.\-:]$`, but the primary write/query schemas only checked length — so `/` (and whitespace, `%`, `?`, `#`, …) sailed through.

## Fix (best long-term: make the existing contract consistent)

- New single source of truth — `server/core/identifiers.py`: `SubjectId` pydantic type + `SUBJECT_ID_RE`.
- Applied to **every** v1 write/query schema: episode, batch, compile, search, context, resolution, handoff. Invalid ids now fail fast with a clear **422** instead of creating unaddressable data.
- `memory_packs` reuses the **exact same compiled regex** — the two contracts can never drift apart again (that drift *was* the bug).
- Length unified to **256** (the write path's existing cap, the more permissive of the two — no extra breakage; memory_packs widens 128→256, non-breaking).

## Scope notes

- **Breaking change:** clients sending path-hostile subject_ids now get 422 at create time. Those subjects were already unreachable, so no usable behavior is lost.
- **Pre-existing `/` rows remain remediable:** `POST /admin/subjects/bulk-delete` matches by `subject_id_prefix` (an unconstrained string), so operators can still purge them. Deliberately left unconstrained for exactly this.
- `session_id` has the same latent path-segment issue on a few routes — out of scope here (issue is subject_id); flagging as a follow-up.

## Tests

`tests/test_issue_121.py`: the contract, every URL-breaking character, the HTTP 422 path, and a single-source-of-truth assertion. Full non-integration suite green (**522 passed**), ruff clean.