### PR TITLE
fix(llm): don't flag missing API key for local Ollama models (#62 follow-up)

### DIFF
--- a/server/services/llm.py
+++ b/server/services/llm.py
@@ -78,6 +78,19 @@ def litellm_api_key_configured() -> bool:
     return bool(key and str(key).strip())
 
 
+def llm_requires_api_key() -> bool:
+    """False for providers that authenticate locally / need no API key.
+
+    A LiteLLM ``ollama/*`` (or ``ollama_chat/*``) model talks to a local
+    Ollama server with no credentials, so an unset
+    STATEWAVE_LITELLM_API_KEY is the *expected* configuration there — not a
+    misconfiguration. Without this, the missing-key warning and the
+    ``/readyz`` "key is not set" message both fire spuriously for every
+    local-Ollama operator (credit: @LPHuynh, #122).
+    """
+    return not settings.litellm_model.startswith("ollama")
+
+
 def warn_if_llm_compiler_missing_api_key() -> None:
     """Log a one-shot startup warning when LLM compiler is selected without credentials.
 
@@ -89,6 +102,9 @@ def warn_if_llm_compiler_missing_api_key() -> None:
     if settings.compiler_type != "llm":
         return
     if litellm_api_key_configured():
+        return
+    if not llm_requires_api_key():
+        # Local Ollama model — no key needed, nothing to warn about.
         return
     logger.warning(
         "llm_compiler_missing_api_key",

--- a/server/services/readiness.py
+++ b/server/services/readiness.py
@@ -16,7 +16,7 @@ import structlog
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncConnection
 
-from server.services.llm import litellm_api_key_configured
+from server.services.llm import litellm_api_key_configured, llm_requires_api_key
 
 logger = structlog.get_logger()
 
@@ -90,10 +90,12 @@ async def _check_llm() -> CheckResult:
     Routes through the central LLM adapter — see server.services.llm.
     No direct litellm import here; the adapter owns the SDK choice.
     """
-    if not litellm_api_key_configured():
+    if llm_requires_api_key() and not litellm_api_key_configured():
         return CheckResult(
             name="llm", status="ok", detail="STATEWAVE_LITELLM_API_KEY is not set"
         )
+    # Local Ollama (no key required) falls through to the real probe below —
+    # if the local Ollama server is down, that *should* surface here.
 
     import time
 

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -6,7 +6,11 @@ import logging
 
 from server.core.config import Settings
 import server.services.llm as llm_module
-from server.services.llm import litellm_api_key_configured, warn_if_llm_compiler_missing_api_key
+from server.services.llm import (
+    litellm_api_key_configured,
+    llm_requires_api_key,
+    warn_if_llm_compiler_missing_api_key,
+)
 
 
 def test_litellm_api_key_configured_rejects_empty_string(monkeypatch):
@@ -64,3 +68,41 @@ def test_warn_if_llm_compiler_missing_api_key_silent_when_key_set(monkeypatch, c
         warn_if_llm_compiler_missing_api_key()
 
     assert not any("llm_compiler_missing_api_key" in r.getMessage() for r in caplog.records)
+
+
+# ── Ollama exemption (#122 follow-up; credit @LPHuynh) ──────────────────────
+
+
+def test_llm_requires_api_key_false_for_ollama(monkeypatch):
+    for model in ("ollama/llama3", "ollama_chat/llama3"):
+        monkeypatch.setattr(
+            llm_module, "settings", Settings(_env_file=None, litellm_model=model)
+        )
+        assert llm_requires_api_key() is False
+
+
+def test_llm_requires_api_key_true_for_hosted_default(monkeypatch):
+    monkeypatch.setattr(
+        llm_module, "settings", Settings(_env_file=None, litellm_model="gpt-4o-mini")
+    )
+    assert llm_requires_api_key() is True
+
+
+def test_warn_silent_for_ollama_model_without_key(monkeypatch, caplog):
+    """LLM compiler + local Ollama + no key is a *valid* config — no warning."""
+    monkeypatch.setattr(
+        llm_module,
+        "settings",
+        Settings(
+            _env_file=None,
+            compiler_type="llm",
+            litellm_api_key=None,
+            litellm_model="ollama/llama3",
+        ),
+    )
+    with caplog.at_level(logging.WARNING):
+        warn_if_llm_compiler_missing_api_key()
+
+    assert not any(
+        "llm_compiler_missing_api_key" in r.getMessage() for r in caplog.records
+    )

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -86,6 +86,22 @@ async def test_check_llm_empty_api_key_treated_as_not_set():
 
 
 @pytest.mark.asyncio
+async def test_check_llm_ollama_without_key_probes_instead_of_skipping():
+    """Ollama needs no key — don't short-circuit with 'key not set'; actually
+    probe the local server (#122 follow-up, credit @LPHuynh)."""
+    with (
+        patch("server.services.readiness.litellm_api_key_configured", return_value=False),
+        patch("server.services.readiness.llm_requires_api_key", return_value=False),
+        patch("server.services.llm.aping", new=AsyncMock(return_value=None)) as aping,
+    ):
+        result = await _check_llm()
+
+    aping.assert_awaited_once()
+    assert result.status == "ok"
+    assert result.detail != "STATEWAVE_LITELLM_API_KEY is not set"
+
+
+@pytest.mark.asyncio
 async def test_run_readiness_all_ok():
     conn = _mock_conn_with_scalar(0)
 


### PR DESCRIPTION
## Why

Follow-up to #107 (which resolved #62). #107's missing-key startup warning and `/readyz` clarity don't account for **local Ollama**: a LiteLLM `ollama/*` / `ollama_chat/*` model needs **no API key**, so an unset `STATEWAVE_LITELLM_API_KEY` there is the *expected, working* config — not a misconfiguration. As merged, every local-Ollama operator running `STATEWAVE_COMPILER_TYPE=llm` would get a spurious "demo mode / key not set" warning at startup and a misleading `/readyz` detail.

## Change

- New `llm_requires_api_key()` — `False` for `ollama*` models.
- `warn_if_llm_compiler_missing_api_key()`: skip when no key is required.
- `/readyz` `_check_llm`: only short-circuit with "key is not set" when a key is actually required; Ollama-without-key falls through to the real provider probe, so a down local Ollama server correctly surfaces.
- Default `gpt-4o-mini` (and every other hosted provider) is unaffected — `llm_requires_api_key()` returns `True`, behaviour identical to #107. #107's existing readiness tests stay green.

## Credit

The Ollama case was raised by **@LPHuynh** in #122 (closed as superseded by #107 for the core fix). This lands their insight properly on top of #107.

## Tests

`test_llm_config.py` + `test_readiness.py`: `llm_requires_api_key` truth table, warn-silent for ollama-no-key, and `/readyz` probes instead of skipping for ollama. Full non-integration suite green (**532 passed**), ruff clean.