### PR TITLE
fix(api): apply the canonical id contract to session_id (#124)

### DIFF
--- a/server/core/identifiers.py
+++ b/server/core/identifiers.py
@@ -60,3 +60,29 @@ SubjectId = Annotated[
 def is_valid_subject_id(value: str) -> bool:
     """True iff `value` satisfies the canonical subject-id contract."""
     return bool(value) and SUBJECT_ID_RE.match(value) is not None
+
+
+# ── Session ids ────────────────────────────────────────────────────────────
+# A session_id has the *exact same* problem as a subject_id: it is used as a
+# URL path segment (e.g. GET /admin/subjects/{subject_id}/sessions/
+# {session_id}/timeline), so a `/` makes the route unmatchable and the
+# session unreachable — the #121 failure mode (tracked as #124). Same charset,
+# same cap. Kept as its own name so error messages say "session_id" and the
+# two can diverge later without churn.
+SESSION_ID_MAX_LEN = SUBJECT_ID_MAX_LEN
+SESSION_ID_RE = SUBJECT_ID_RE
+SESSION_ID_CHARSET_DESC = SUBJECT_ID_CHARSET_DESC
+
+SessionId = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=SESSION_ID_MAX_LEN,
+        pattern=rf"^[{SUBJECT_ID_CHARSET}]+$",
+    ),
+]
+
+
+def is_valid_session_id(value: str) -> bool:
+    """True iff `value` satisfies the canonical session-id contract."""
+    return bool(value) and SESSION_ID_RE.match(value) is not None

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from server.core.identifiers import SubjectId
+from server.core.identifiers import SessionId, SubjectId
 
 
 class CreateEpisodeRequest(BaseModel):
@@ -17,7 +17,7 @@ class CreateEpisodeRequest(BaseModel):
     payload: dict[str, Any]
     metadata: dict[str, Any] = Field(default_factory=dict)
     provenance: dict[str, Any] = Field(default_factory=dict)
-    session_id: str | None = Field(None, max_length=256)
+    session_id: SessionId | None = None
     # When the source event actually happened. Optional — when absent, the
     # database server-defaults to now() (= ingest time), which is the right
     # answer for live-chat ingest. Connectors that backfill historical data
@@ -46,9 +46,8 @@ class GetContextRequest(BaseModel):
     subject_id: SubjectId
     task: str = Field(..., min_length=1, max_length=4000)
     max_tokens: int | None = Field(None, ge=1, le=128000)
-    session_id: str | None = Field(
+    session_id: SessionId | None = Field(
         None,
-        max_length=256,
         description="Current session ID — episodes in this session receive a relevance boost",
     )
     emit_receipt: bool | None = Field(
@@ -97,7 +96,7 @@ class GetContextRequest(BaseModel):
 
 class CreateResolutionRequest(BaseModel):
     subject_id: SubjectId
-    session_id: str = Field(..., min_length=1, max_length=256)
+    session_id: SessionId
     status: str = Field("open", pattern=r"^(open|resolved|unresolved)$")
     resolution_summary: str | None = Field(None, max_length=2000)
     metadata: dict[str, Any] = Field(default_factory=dict)
@@ -105,9 +104,7 @@ class CreateResolutionRequest(BaseModel):
 
 class HandoffRequest(BaseModel):
     subject_id: SubjectId
-    session_id: str = Field(
-        ..., min_length=1, max_length=256, description="Session being handed off"
-    )
+    session_id: SessionId = Field(..., description="Session being handed off")
     reason: str = Field("escalation", max_length=256, description="Why the handoff is happening")
     max_tokens: int | None = Field(None, ge=1, le=16000)
     emit_receipt: bool | None = Field(

--- a/tests/test_issue_124.py
+++ b/tests/test_issue_124.py
@@ -1,0 +1,84 @@
+"""Regression tests for issue #124.
+
+`session_id` is used as a URL path segment (e.g.
+`GET /admin/subjects/{subject_id}/sessions/{session_id}/timeline`), so a
+`/` made the route unmatchable and the session unreachable — the same
+class of bug as #121/#123, just for session_id. Fix: the canonical
+`SessionId` contract enforced at every session_id write/query ingress,
+optional-friendly (None still allowed where the field is optional).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from server.core.identifiers import SESSION_ID_RE, SUBJECT_ID_RE, is_valid_session_id
+from server.schemas.requests import (
+    CreateEpisodeRequest,
+    CreateResolutionRequest,
+    GetContextRequest,
+    HandoffRequest,
+)
+
+_VALID = ["sess-1", "tenant-a:sess.7", "abc_123", "x" * 256]
+_INVALID = ["sess/1", "a b", "a?b", "a#b", "a%2Fb", "", "x" * 257]
+
+
+def test_124_session_id_shares_the_subject_id_contract():
+    assert SESSION_ID_RE is SUBJECT_ID_RE
+
+
+@pytest.mark.parametrize("sid", _VALID)
+def test_124_valid_session_ids_accepted(sid):
+    assert CreateEpisodeRequest(
+        subject_id="s", source="x", type="t", payload={}, session_id=sid
+    ).session_id == sid
+    assert CreateResolutionRequest(subject_id="s", session_id=sid).session_id == sid
+    assert HandoffRequest(subject_id="s", session_id=sid).session_id == sid
+    assert is_valid_session_id(sid)
+
+
+@pytest.mark.parametrize("sid", _INVALID)
+def test_124_invalid_session_ids_rejected_everywhere(sid):
+    # Optional field (CreateEpisodeRequest / GetContextRequest): a bad
+    # *value* is still rejected — only None is exempt.
+    with pytest.raises(ValidationError):
+        CreateEpisodeRequest(
+            subject_id="s", source="x", type="t", payload={}, session_id=sid
+        )
+    with pytest.raises(ValidationError):
+        GetContextRequest(subject_id="s", task="t", session_id=sid)
+    # Required field (CreateResolutionRequest / HandoffRequest).
+    with pytest.raises(ValidationError):
+        CreateResolutionRequest(subject_id="s", session_id=sid)
+    with pytest.raises(ValidationError):
+        HandoffRequest(subject_id="s", session_id=sid)
+    assert not is_valid_session_id(sid)
+
+
+def test_124_session_id_stays_optional_when_omitted_or_none():
+    """The optional fields must still accept absence / explicit None."""
+    assert CreateEpisodeRequest(
+        subject_id="s", source="x", type="t", payload={}
+    ).session_id is None
+    assert CreateEpisodeRequest(
+        subject_id="s", source="x", type="t", payload={}, session_id=None
+    ).session_id is None
+    assert GetContextRequest(subject_id="s", task="t").session_id is None
+
+
+@pytest.mark.asyncio
+async def test_124_http_post_episode_with_slash_session_returns_422(client):
+    resp = await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": "user-1",
+            "source": "support-chat",
+            "type": "conversation",
+            "payload": {"messages": [{"role": "user", "content": "hi"}]},
+            "session_id": "sess/1",
+        },
+    )
+    assert resp.status_code == 422
+    assert "session_id" in resp.text


### PR DESCRIPTION
## Why

Closes #124 — the deferred follow-up to #121/#123. `session_id` has the **same latent path-segment defect** as `subject_id` did: it's a URL path segment (`GET /admin/subjects/{subject_id}/sessions/{session_id}/timeline`), but was accepted at write time with only a length check. A `session_id` containing `/` could be created and then be **unreachable** on every `{session_id}` route — the #121 failure mode.

## Change

- New canonical `SessionId` type in `server/core/identifiers.py` — same charset/cap as `SubjectId` (session ids are URL path segments too), its own name so errors say `session_id` and the two can diverge later.
- Applied to every `session_id` write/query field: `CreateEpisodeRequest`, `GetContextRequest`, `CreateResolutionRequest`, `HandoffRequest`.
- **Optional-friendly:** `None`/omitted still accepted where the field is optional; only a non-conforming *value* is rejected (clear 422).
- Read-path `{session_id}` converters left unconstrained — same rationale as #123 (legacy bad rows stay remediable).

## Tests

`tests/test_issue_124.py`: contract sharing, valid/invalid values across all four schemas, optional-stays-optional, HTTP 422 path. Full non-integration suite green (**546 passed**), ruff clean.