### PR TITLE
feat(server): /readyz distinguishes DB not-set / unparseable / unreachable (#66)

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -221,10 +221,23 @@ def create_app() -> FastAPI:
         from fastapi.responses import JSONResponse
 
         from server.db.engine import get_engine
-        from server.services.readiness import run_readiness_checks
+        from server.services.readiness import database_url_status, run_readiness_checks
 
-        async with get_engine().connect() as conn:
-            result = await run_readiness_checks(conn)
+        # Classify the DB URL before touching the engine so a first-time
+        # deployer sees "not set" / "couldn't be parsed" / "unreachable"
+        # as distinct, actionable states instead of one generic error (#66).
+        url_state, url_detail = database_url_status()
+        if url_state != "ok":
+            result = await run_readiness_checks(None, db_unavailable_detail=url_detail)
+        else:
+            try:
+                async with get_engine().connect() as conn:
+                    result = await run_readiness_checks(conn)
+            except Exception as exc:
+                result = await run_readiness_checks(
+                    None,
+                    db_unavailable_detail=f"Postgres unreachable: {str(exc)[:200]}",
+                )
 
         body = {
             "status": result.status,

--- a/server/services/readiness.py
+++ b/server/services/readiness.py
@@ -14,8 +14,10 @@ from datetime import datetime, timedelta, timezone
 
 import structlog
 from sqlalchemy import text
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncConnection
 
+from server.core.config import settings
 from server.services.llm import litellm_api_key_configured, llm_requires_api_key
 
 logger = structlog.get_logger()
@@ -120,12 +122,56 @@ async def _check_llm() -> CheckResult:
         )
 
 
-async def run_readiness_checks(conn: AsyncConnection) -> ReadinessResult:
-    """Run all readiness checks and return aggregated result."""
-    db_check, queue_check = await asyncio.gather(
-        _check_db(conn),
-        _check_queue(conn),
-    )
+def database_url_status() -> tuple[str, str | None]:
+    """Classify the configured DB URL *before* a connection is attempted.
+
+    Lets `/readyz` tell a first-time deployer the difference between
+    "you never configured a database" and "the database is down" — the
+    most common early-setup confusion (#66). `get_engine()` builds the
+    engine from `settings.database_url`, so we classify exactly that.
+
+    Returns ``(status, detail)`` where status is ``"ok"`` (detail None),
+    ``"missing"``, or ``"unparseable"``.
+    """
+    url = (settings.database_url or "").strip()
+    if not url:
+        return "missing", "DATABASE_URL is not set"
+    try:
+        make_url(url)
+    except Exception as exc:
+        # SQLAlchemy's parse error is generic and does not echo the URL,
+        # so this is safe to surface (no credential leak).
+        return "unparseable", f"DATABASE_URL is set but couldn't be parsed: {str(exc)[:160]}"
+    return "ok", None
+
+
+async def run_readiness_checks(
+    conn: AsyncConnection | None,
+    *,
+    db_unavailable_detail: str | None = None,
+) -> ReadinessResult:
+    """Run all readiness checks and return aggregated result.
+
+    `conn` is None when the DB connection could not be established at all
+    (URL not set / unparseable / Postgres unreachable). In that case the
+    DB check fails with `db_unavailable_detail`, the queue check is
+    degraded (it needs a connection), and the LLM check still runs since
+    it is independent of the database.
+    """
+    if conn is None:
+        db_check = CheckResult(
+            name="database",
+            status="fail",
+            detail=db_unavailable_detail or "database connection unavailable",
+        )
+        queue_check = CheckResult(
+            name="queue", status="degraded", detail="skipped (no database connection)"
+        )
+    else:
+        db_check, queue_check = await asyncio.gather(
+            _check_db(conn),
+            _check_queue(conn),
+        )
 
     # LLM check is independent of the DB connection
     llm_check = await _check_llm()

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -6,11 +6,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import server.services.readiness as readiness_module
 from server.services.readiness import (
     ReadinessResult,
     _check_db,
     _check_llm,
     _check_queue,
+    database_url_status,
     run_readiness_checks,
 )
 
@@ -122,3 +124,63 @@ async def test_run_readiness_db_fail():
 
     assert result.status == "not_ready"
     assert result.http_status == 503
+
+
+# ── #66: /readyz distinguishes DB not-set / unparseable / unreachable ───────
+
+
+def test_database_url_status_missing(monkeypatch):
+    monkeypatch.setattr(readiness_module.settings, "database_url", "")
+    state, detail = database_url_status()
+    assert state == "missing"
+    assert detail == "DATABASE_URL is not set"
+
+
+def test_database_url_status_unparseable(monkeypatch):
+    monkeypatch.setattr(readiness_module.settings, "database_url", "this is not a url")
+    state, detail = database_url_status()
+    assert state == "unparseable"
+    assert detail.startswith("DATABASE_URL is set but couldn't be parsed:")
+
+
+def test_database_url_status_ok(monkeypatch):
+    monkeypatch.setattr(
+        readiness_module.settings,
+        "database_url",
+        "postgresql+asyncpg://statewave:statewave@localhost:5432/statewave",
+    )
+    state, detail = database_url_status()
+    assert state == "ok"
+    assert detail is None
+
+
+@pytest.mark.asyncio
+async def test_run_readiness_conn_none_classifies_db_and_keeps_llm():
+    """conn=None → DB fails with the supplied detail, queue degraded,
+    LLM still evaluated (it's DB-independent)."""
+    with patch("server.services.readiness.litellm_api_key_configured", return_value=False):
+        result = await run_readiness_checks(
+            None, db_unavailable_detail="DATABASE_URL is not set"
+        )
+
+    by_name = {c.name: c for c in result.checks}
+    assert by_name["database"].status == "fail"
+    assert by_name["database"].detail == "DATABASE_URL is not set"
+    assert by_name["queue"].status == "degraded"
+    assert "llm" in by_name  # LLM check still ran
+    assert result.status == "not_ready"
+    assert result.http_status == 503
+
+
+@pytest.mark.asyncio
+async def test_readyz_http_reports_database_url_not_set(client, monkeypatch):
+    """End-to-end: an unset DB URL yields a clear, actionable 503 — and
+    does so deterministically regardless of whether CI has Postgres up
+    (we short-circuit before any engine/connection)."""
+    monkeypatch.setattr(readiness_module.settings, "database_url", "")
+    resp = await client.get("/readyz")
+    assert resp.status_code == 503
+    body = resp.json()
+    db = next(c for c in body["checks"] if c["name"] == "database")
+    assert db["status"] == "fail"
+    assert db["detail"] == "DATABASE_URL is not set"


### PR DESCRIPTION
## Why

Closes #66. `/readyz` reported one generic database error regardless of cause, so a first-time deployer couldn't tell **"I never configured a DB"** from **"the DB is down"** — the exact early-setup confusion the issue describes.

## Change

- `database_url_status()` classifies `settings.database_url` (what `get_engine()` actually builds from) **before** a connection is attempted:
  - blank → `DATABASE_URL is not set`
  - set but unparseable → `DATABASE_URL is set but couldn't be parsed: …` (SQLAlchemy's parse error is generic and never echoes the URL → no credential leak)
- `run_readiness_checks(conn=None, *, db_unavailable_detail=…)`: DB check fails with the classified detail, queue degraded (needs a conn), **LLM still runs** (DB-independent). Existing `conn`-passing callers/tests unchanged.
- `/readyz` handler classifies first; a failed connect on a valid URL → `Postgres unreachable: …`.

Acceptance criteria (all three states + tests) ✅. Note: `settings.database_url` has a localhost default, so "not set" triggers on an explicitly-blank value; the unparseable/unreachable split covers the rest.

## Tests

`test_readiness.py`: classifier (3 cases), `conn=None` aggregation, and a **deterministic** HTTP `/readyz` test (short-circuits before any engine, so it passes whether or not CI has Postgres up). Full non-integration suite green (**537 passed**), ruff clean.