### PR TITLE
docs(readme): add Skip to Quickstart heading-link after Try it

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ _If Statewave is useful to you, a ⭐ on the repo helps others discover it._
 
 The interactive comparison demo is embedded directly in the website at **[statewave.ai](https://statewave.ai)** — open the chat widget to see two identical AI agents answer the same question, one stateless and one backed by Statewave.
 
+## [🚀 Skip to Quickstart →](#quickstart)
+
 ## The problem
 
 Most AI applications have no memory. Every conversation starts from scratch. Context is lost between sessions, decisions aren't remembered, and user history disappears the moment a session ends. Bolting on a vector database or dumping chat logs into a prompt doesn't solve this — it creates fragile, unstructured context that degrades as it scales.


### PR DESCRIPTION
## What

Adds an H2 heading-link directly after the **🎯 Try it** section that jumps to **Quickstart** (previously buried far down the README).

```markdown
## [🚀 Skip to Quickstart →](#quickstart)
```

Rendered as a title at the same level as *Try it*, styled as a blue link (GitHub heading-link color), so visitors can reach the ingest → compile → use loop without scrolling.

## Why

The Quickstart code snippet sat low in the README; new visitors had no quick path to it from the top.

## Scope

Docs only — single line added to `README.md`, no code changes.