### PR TITLE
fix(compile): drain async jobs to completion; sync returns has_more (#134)

### DIFF
--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -32,81 +32,135 @@ logger = structlog.stdlib.get_logger()
 router = APIRouter(prefix="/v1/memories", tags=["memories"])
 
 
+async def _compile_one_batch(
+    session: AsyncSession, subject_id: str, tenant_id: str | None, batch_size: int
+) -> tuple[list[MemoryResponse], int, int]:
+    """Compile ONE batch of uncompiled episodes for `subject_id`.
+
+    Returns `(memory_responses, memories_created, remaining_episodes)`.
+    `remaining_episodes` is the count of still-uncompiled episodes AFTER
+    this batch was marked compiled — feeds `has_more` in the response and
+    the drain loop in `_run_compile`.
+
+    Does its own commit so each batch is durable independently — if the
+    process dies mid-drain, no episode is lost or double-counted.
+    """
+    episodes = await repo.list_uncompiled_episodes(
+        session, subject_id, tenant_id=tenant_id, limit=batch_size
+    )
+    if not episodes:
+        return [], 0, 0
+
+    compiler = get_compiler()
+    if hasattr(compiler, "compile_async"):
+        new_rows = await compiler.compile_async(list(episodes))
+    else:
+        loop = asyncio.get_running_loop()
+        new_rows = await loop.run_in_executor(
+            None, functools.partial(compiler.compile, list(episodes))
+        )
+
+    for row in new_rows:
+        row.tenant_id = tenant_id
+        session.add(row)
+    await repo.mark_episodes_compiled(session, [ep.id for ep in episodes])
+
+    superseded_ids = await resolve_conflicts(session, subject_id)
+    if superseded_ids:
+        logger.info("conflicts_resolved", superseded=len(superseded_ids))
+
+    await session.commit()
+    for row in new_rows:
+        await session.refresh(row)
+
+    schedule_embedding_backfill(
+        [row.id for row in new_rows],
+        [row.content for row in new_rows],
+    )
+
+    await webhooks.fire(
+        "memories.compiled",
+        {
+            "subject_id": subject_id,
+            "memories_created": len(new_rows),
+        },
+    )
+
+    remaining = await repo.count_uncompiled_episodes(
+        session, subject_id, tenant_id=tenant_id
+    )
+    return [_to_response(r) for r in new_rows], len(new_rows), remaining
+
+
 async def _run_compile(
     subject_id: str, job_id: str | None = None, tenant_id: str | None = None
 ) -> CompileMemoriesResponse:
-    """Core compilation logic — used by both sync and async paths."""
+    """Async compile path — drains the subject batch by batch (issue #134).
+
+    The async caller asked us not to block them. In return we promise the
+    job actually finishes the work: we loop `_compile_one_batch` until
+    `remaining_episodes == 0`, accumulate `memories_created`, and update
+    the durable job row each iteration so polling clients see progress.
+    Bounded by `settings.compile_max_iterations` so a misbehaving compiler
+    can't burn forever.
+    """
+    from server.core.config import settings
     from server.db.engine import get_session_factory
 
     if job_id:
         await compile_jobs.mark_running_durable(job_id)
 
+    total_created = 0
+    last_batch_responses: list[MemoryResponse] = []
+    last_remaining = 0
     try:
         async with get_session_factory()() as session:
-            episodes = await repo.list_uncompiled_episodes(session, subject_id, tenant_id=tenant_id)
-            if not episodes:
-                result = CompileMemoriesResponse(
-                    subject_id=subject_id, memories_created=0, memories=[]
+            for iteration in range(settings.compile_max_iterations):
+                batch_responses, created, remaining = await _compile_one_batch(
+                    session, subject_id, tenant_id, settings.compile_batch_size
                 )
-                if job_id:
-                    await compile_jobs.mark_completed_durable(job_id, 0, [])
-                return result
+                total_created += created
+                last_batch_responses = batch_responses
+                last_remaining = remaining
 
-            compiler = get_compiler()
-            if hasattr(compiler, "compile_async"):
-                new_rows = await compiler.compile_async(list(episodes))
+                if job_id and (created or iteration == 0):
+                    await compile_jobs.update_progress_durable(job_id, total_created)
+
+                # Drain on `remaining` alone — an empty `batch_responses`
+                # with `remaining > 0` means the compiler produced no rows
+                # this batch (rare but possible: all episodes filtered by
+                # the compiler), and we should keep going. The iteration
+                # cap below guards against a compiler that never advances.
+                if remaining == 0:
+                    break
             else:
-                loop = asyncio.get_running_loop()
-                new_rows = await loop.run_in_executor(
-                    None, functools.partial(compiler.compile, list(episodes))
+                # Loop exhausted without draining — surface, don't silently
+                # hide it. The job completes (we did compile a lot) but the
+                # log entry tells the operator they hit the iteration cap.
+                logger.warning(
+                    "compile_drain_iteration_cap_hit",
+                    subject_id=subject_id,
+                    iterations=settings.compile_max_iterations,
+                    total_created=total_created,
+                    remaining=last_remaining,
                 )
 
-            for row in new_rows:
-                row.tenant_id = tenant_id
-                session.add(row)
-            await repo.mark_episodes_compiled(session, [ep.id for ep in episodes])
+        result = CompileMemoriesResponse(
+            subject_id=subject_id,
+            memories_created=total_created,
+            memories=last_batch_responses,
+            has_more=last_remaining > 0,
+            remaining_episodes=last_remaining,
+        )
 
-            superseded_ids = await resolve_conflicts(session, subject_id)
-            if superseded_ids:
-                logger.info("conflicts_resolved", superseded=len(superseded_ids))
-
-            await session.commit()
-            for row in new_rows:
-                await session.refresh(row)
-
-            # Backfill embeddings in the background. Without this the
-            # async compile path leaves every freshly-compiled memory
-            # with `embedding=NULL`, which silently breaks semantic
-            # retrieval (`search_memories(semantic=True)` returns 0,
-            # `assemble_context` falls back to lexical + heuristic
-            # ranking only). The sync compile route below already
-            # schedules this; the async route used to skip it.
-            schedule_embedding_backfill(
-                [row.id for row in new_rows],
-                [row.content for row in new_rows],
+        if job_id:
+            await compile_jobs.mark_completed_durable(
+                job_id,
+                total_created,
+                [m.model_dump(mode="json") for m in last_batch_responses],
             )
 
-            await webhooks.fire(
-                "memories.compiled",
-                {
-                    "subject_id": subject_id,
-                    "memories_created": len(new_rows),
-                },
-            )
-
-            memory_responses = [_to_response(r) for r in new_rows]
-            result = CompileMemoriesResponse(
-                subject_id=subject_id,
-                memories_created=len(new_rows),
-                memories=memory_responses,
-            )
-
-            if job_id:
-                await compile_jobs.mark_completed_durable(
-                    job_id, len(new_rows), [m.model_dump(mode="json") for m in memory_responses]
-                )
-
-            return result
+        return result
 
     except Exception as exc:
         logger.error("compile_failed", subject_id=subject_id, exc_info=True)
@@ -123,11 +177,19 @@ async def compile_memories(
 ):
     """Compile new memories from unprocessed episodes.
 
-    Pass `"async": true` to return immediately with a job_id for polling.
+    Sync mode processes at most `STATEWAVE_COMPILE_BATCH_SIZE` (default
+    500) uncompiled episodes per call and returns `has_more=True` plus
+    `remaining_episodes` whenever the backlog isn't drained. Clients can
+    loop until `has_more` is False, or pass `"async": true` and let the
+    server drain the whole subject in a durable background job.
     """
+    from server.core.config import settings
+
     with span("compile_memories", {"subject_id": body.subject_id, "async": body.async_mode}):
         if body.async_mode:
-            # Async mode — return job_id immediately, compile in background (durable)
+            # Async mode — return job_id immediately, compile in background (durable).
+            # The background task drains the subject; the client polls
+            # `/v1/memories/compile/{job_id}` for completion.
             job = await compile_jobs.submit_job_durable(body.subject_id, tenant_id=tenant_id)
             asyncio.create_task(_run_compile(body.subject_id, job.id, tenant_id=tenant_id))
             return JSONResponse(
@@ -139,57 +201,19 @@ async def compile_memories(
                 },
             )
 
-        # Sync mode — block until compilation is done (backward compatible)
-        episodes = await repo.list_uncompiled_episodes(
-            session, body.subject_id, tenant_id=tenant_id
+        # Sync mode — bounded per-call: process at most one batch, then
+        # report `has_more` so the caller knows whether to loop. Bounded
+        # latency is the trade-off for not surprising long-standing
+        # sync clients with multi-minute compile calls.
+        memory_responses, created, remaining = await _compile_one_batch(
+            session, body.subject_id, tenant_id, settings.compile_batch_size
         )
-        if not episodes:
-            return CompileMemoriesResponse(
-                subject_id=body.subject_id, memories_created=0, memories=[]
-            )
-
-        compiler = get_compiler()
-        if hasattr(compiler, "compile_async"):
-            new_rows = await compiler.compile_async(list(episodes))
-        else:
-            loop = asyncio.get_running_loop()
-            new_rows = await loop.run_in_executor(
-                None, functools.partial(compiler.compile, list(episodes))
-            )
-
-        for row in new_rows:
-            row.tenant_id = tenant_id
-            session.add(row)
-        await repo.mark_episodes_compiled(session, [ep.id for ep in episodes])
-
-        superseded_ids = await resolve_conflicts(session, body.subject_id)
-        if superseded_ids:
-            logger.info("conflicts_resolved", superseded=len(superseded_ids))
-
-        await session.commit()
-        for row in new_rows:
-            await session.refresh(row)
-
-        # Generate embeddings in background (don't block response). The
-        # shared scheduler also serves the starter-pack import path so
-        # both write paths populate embeddings consistently.
-        schedule_embedding_backfill(
-            [row.id for row in new_rows],
-            [row.content for row in new_rows],
-        )
-
-        await webhooks.fire(
-            "memories.compiled",
-            {
-                "subject_id": body.subject_id,
-                "memories_created": len(new_rows),
-            },
-        )
-
         return CompileMemoriesResponse(
             subject_id=body.subject_id,
-            memories_created=len(new_rows),
-            memories=[_to_response(r) for r in new_rows],
+            memories_created=created,
+            memories=memory_responses,
+            has_more=remaining > 0,
+            remaining_episodes=remaining,
         )
 
 

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -70,6 +70,17 @@ class Settings(BaseSettings):
     # Compile job retention (hours, 0 = no cleanup)
     compile_job_retention_hours: int = 168  # 7 days
 
+    # Compile pagination & drain (issue #134)
+    # Each call to `POST /v1/memories/compile` processes at most
+    # `compile_batch_size` uncompiled episodes — bounded per-call latency
+    # keeps the sync route from timing out on large backlogs. The response
+    # carries `has_more` and `remaining_episodes` so sync clients can loop.
+    # Async mode (`async: true`) drains the subject by looping internally,
+    # up to `compile_max_iterations` batches per job (defensive cap
+    # against a runaway compiler that fails to advance `last_compiled_at`).
+    compile_batch_size: int = 500
+    compile_max_iterations: int = 2000
+
     # ── Memory TTL / expiry policies ────────────────────────────────
     # Per-kind expiry windows. Keys are MemoryKind values
     # ("profile_fact", "episode_summary", "procedure", "artifact_ref");

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -88,7 +88,11 @@ async def list_uncompiled_episodes(
     tenant_id: str | None = None,
     limit: int = 500,
 ) -> Sequence[EpisodeRow]:
-    """Fetch episodes that have never been compiled."""
+    """Fetch episodes that have never been compiled.
+
+    The compile route paginates with `settings.compile_batch_size`; this
+    `limit` default is only the floor for ad-hoc callers (tests, scripts).
+    """
     stmt = (
         select(EpisodeRow)
         .where(EpisodeRow.subject_id == subject_id)
@@ -99,6 +103,28 @@ async def list_uncompiled_episodes(
     stmt = _tenant_filter(stmt, EpisodeRow.tenant_id, tenant_id)
     result = await session.execute(stmt)
     return result.scalars().all()
+
+
+async def count_uncompiled_episodes(
+    session: AsyncSession,
+    subject_id: str,
+    *,
+    tenant_id: str | None = None,
+) -> int:
+    """Count episodes for a subject that have not been compiled yet.
+
+    Powers the `remaining_episodes` / `has_more` drain signal on
+    `CompileMemoriesResponse` (issue #134). Bare `COUNT(*)` — no cap;
+    the count is authoritative and reflects the real backlog.
+    """
+    stmt = (
+        select(func.count())
+        .select_from(EpisodeRow)
+        .where(EpisodeRow.subject_id == subject_id)
+        .where(EpisodeRow.last_compiled_at.is_(None))
+    )
+    stmt = _tenant_filter(stmt, EpisodeRow.tenant_id, tenant_id)
+    return await session.scalar(stmt) or 0
 
 
 async def mark_episodes_compiled(

--- a/server/schemas/responses.py
+++ b/server/schemas/responses.py
@@ -56,6 +56,13 @@ class CompileMemoriesResponse(BaseModel):
     subject_id: str
     memories_created: int
     memories: list[MemoryResponse]
+    # Drain signal (issue #134). `has_more` is True when more uncompiled
+    # episodes remain after this call returned; `remaining_episodes` is
+    # the count of those episodes. Sync callers loop on `has_more`; async
+    # mode (`async: true`) drains internally and always returns
+    # `has_more=False` once the job reaches `completed`.
+    has_more: bool = False
+    remaining_episodes: int = 0
 
 
 class SearchMemoriesResponse(BaseModel):

--- a/server/services/compile_jobs.py
+++ b/server/services/compile_jobs.py
@@ -128,6 +128,21 @@ async def mark_failed_durable(job_id: str, error: str) -> None:
     mark_failed(job_id, error)
 
 
+async def update_progress_durable(job_id: str, memories_created: int) -> None:
+    """Bump the durable `memories_created` count mid-job.
+
+    Used by the async compile drain loop (issue #134) so operators see
+    real progress while a large subject is processed batch by batch.
+    Status stays `running` — only the count is updated.
+    """
+    from server.services.compile_jobs_durable import update_progress as _durable_update
+
+    await _durable_update(job_id, memories_created)
+    job = _jobs.get(job_id)
+    if job:
+        job.memories_created = memories_created
+
+
 # ---------------------------------------------------------------------------
 # In-memory primitives
 #

--- a/server/services/compile_jobs_durable.py
+++ b/server/services/compile_jobs_durable.py
@@ -131,6 +131,23 @@ async def mark_completed(
         await session.commit()
 
 
+async def update_progress(job_id: str, memories_created: int) -> None:
+    """Update the cumulative `memories_created` count on a running job.
+
+    Called once per batch by the async drain loop (issue #134) so that
+    operators polling `/v1/memories/compile/{job_id}` see growing
+    progress while a large subject is being drained, rather than a
+    static `0` until the job completes minutes or hours later.
+    """
+    async with get_session_factory()() as session:
+        await session.execute(
+            update(CompileJobRow)
+            .where(CompileJobRow.id == job_id)
+            .values(memories_created=memories_created)
+        )
+        await session.commit()
+
+
 async def mark_failed(job_id: str, error: str) -> None:
     """Mark job as failed with error message. Raises on DB failure."""
     async with get_session_factory()() as session:

--- a/tests/integration/test_issue_134_drain.py
+++ b/tests/integration/test_issue_134_drain.py
@@ -1,0 +1,119 @@
+"""Integration tests for issue #134 — compile drains the subject.
+
+Exercises the real DB-backed flow with a small `compile_batch_size` so
+the test ingests just enough episodes to force multiple batches without
+slowing the suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from httpx import AsyncClient
+
+
+async def _ingest(client: AsyncClient, subject_id: str, n: int) -> None:
+    for i in range(n):
+        r = await client.post(
+            "/v1/episodes",
+            json={
+                "subject_id": subject_id,
+                "source": "test",
+                "type": "chat.note",
+                "payload": {"text": f"Episode {i}: customer prefers dark mode"},
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+
+
+@pytest.mark.anyio
+async def test_134_sync_compile_reports_has_more_when_batch_size_exceeded(
+    client: AsyncClient, subject_id: str, monkeypatch
+):
+    """With 5 uncompiled episodes and `compile_batch_size=2`, the first
+    sync call must report `has_more=True` and `remaining_episodes>0`."""
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "compile_batch_size", 2)
+    await _ingest(client, subject_id, 5)
+
+    r = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    assert body["has_more"] is True
+    assert body["remaining_episodes"] >= 3
+
+
+@pytest.mark.anyio
+async def test_134_sync_compile_loop_drains_subject(
+    client: AsyncClient, subject_id: str, monkeypatch
+):
+    """A client that loops on `has_more` ends at `has_more=False` and
+    has compiled the whole subject."""
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "compile_batch_size", 2)
+    await _ingest(client, subject_id, 5)
+
+    total_created = 0
+    for _ in range(20):  # generous loop bound — 5 episodes × 2/batch = ≤3 calls
+        r = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        total_created += body["memories_created"]
+        if not body["has_more"]:
+            assert body["remaining_episodes"] == 0
+            break
+    else:
+        pytest.fail("sync compile loop did not drain in 20 iterations")
+
+    # Heuristic compiler emits at least one memory per episode for this
+    # ingest shape (a "preference" sentence). We only assert "non-zero"
+    # because exact count depends on the heuristic — the contract under
+    # test is the drain signal, not the compiler output count.
+    assert total_created > 0
+
+
+@pytest.mark.anyio
+async def test_134_async_compile_drains_subject_in_one_job(
+    client: AsyncClient, subject_id: str, monkeypatch
+):
+    """`async: true` must process the entire backlog inside one job —
+    no caller-side loop required."""
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "compile_batch_size", 2)
+    await _ingest(client, subject_id, 5)
+
+    r = await client.post(
+        "/v1/memories/compile", json={"subject_id": subject_id, "async": True}
+    )
+    assert r.status_code == 202, r.text
+    job_id = r.json()["job_id"]
+
+    # Poll for completion. Each batch is fast; 10s is generous.
+    for _ in range(100):
+        await asyncio.sleep(0.1)
+        status_r = await client.get(f"/v1/memories/compile/{job_id}")
+        assert status_r.status_code == 200, status_r.text
+        body = status_r.json()
+        if body["status"] in ("completed", "failed"):
+            break
+    else:
+        pytest.fail(f"async compile job {job_id} did not finish within 10s")
+
+    assert body["status"] == "completed", body
+    assert body["memories_created"] > 0
+
+    # The whole backlog should be drained — a follow-up sync compile
+    # finds nothing to do.
+    follow_up = await client.post(
+        "/v1/memories/compile", json={"subject_id": subject_id}
+    )
+    assert follow_up.status_code == 200
+    follow_body = follow_up.json()
+    assert follow_body["memories_created"] == 0
+    assert follow_body["has_more"] is False
+    assert follow_body["remaining_episodes"] == 0

--- a/tests/test_issue_134_compile_drain.py
+++ b/tests/test_issue_134_compile_drain.py
@@ -1,0 +1,173 @@
+"""Regression tests for issue #134.
+
+Before the fix, `POST /v1/memories/compile` silently processed at most
+500 uncompiled episodes per call (the `list_uncompiled_episodes`
+default), and the response carried no completion signal. Operators with
+large episode backlogs saw the admin UI's `Memories` count plateau at
+small round numbers (commonly ~500 or ~1000) with no error.
+
+The fix:
+  * `CompileMemoriesResponse` carries `has_more` and `remaining_episodes`.
+  * Sync mode stays bounded per call (latency budget) but signals the
+    backlog so the caller can loop.
+  * Async mode (`async: true`) drains the subject by looping internally,
+    capped by `settings.compile_max_iterations`.
+
+These unit-level tests verify the schema and the drain loop without a
+real database — the integration counterpart in
+`tests/integration/test_issue_134_drain.py` covers the live flow.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from server.schemas.responses import CompileMemoriesResponse
+
+
+def test_134_response_carries_drain_signal_with_safe_defaults():
+    """Existing call sites that omit the new fields still construct
+    a valid response — the defaults state "no more work pending"."""
+    r = CompileMemoriesResponse(subject_id="s", memories_created=0, memories=[])
+    assert r.has_more is False
+    assert r.remaining_episodes == 0
+
+
+def test_134_response_accepts_has_more_and_remaining():
+    r = CompileMemoriesResponse(
+        subject_id="s",
+        memories_created=3,
+        memories=[],
+        has_more=True,
+        remaining_episodes=42,
+    )
+    assert r.has_more is True
+    assert r.remaining_episodes == 42
+
+
+@pytest.mark.anyio
+async def test_134_async_drain_loops_until_remaining_is_zero(monkeypatch):
+    """`_run_compile` keeps calling `_compile_one_batch` until the batch
+    reports `remaining == 0`. Each batch's `memories_created` accumulates
+    into the final response and into the durable job progress."""
+    from server.api import memories as api_memories
+
+    # Three batches: 4 created + 2 remaining, 4 created + 1 remaining,
+    # 1 created + 0 remaining → final total 9, has_more False.
+    scripted = [
+        ([], 4, 2),
+        ([], 4, 1),
+        ([], 1, 0),
+    ]
+
+    call_log = []
+
+    async def fake_batch(_session, _subject_id, _tenant_id, _batch_size):
+        call_log.append("batch")
+        return scripted.pop(0)
+
+    # `_run_compile` opens its own session via `get_session_factory()()`.
+    # We don't care what session arrives at `_compile_one_batch` — only
+    # that the loop drives it to drain.
+    async def fake_factory_call():
+        class _Ctx:
+            async def __aenter__(self_):
+                return object()  # opaque session sentinel
+
+            async def __aexit__(self_, *a):
+                return None
+
+        return _Ctx()
+
+    progress_updates = []
+
+    async def fake_update_progress(job_id, total):
+        progress_updates.append(total)
+
+    async def fake_mark_running(_job_id):
+        pass
+
+    async def fake_mark_completed(_job_id, _total, _mems):
+        pass
+
+    monkeypatch.setattr(api_memories, "_compile_one_batch", fake_batch)
+    monkeypatch.setattr(
+        api_memories.compile_jobs, "update_progress_durable", fake_update_progress
+    )
+    monkeypatch.setattr(
+        api_memories.compile_jobs, "mark_running_durable", fake_mark_running
+    )
+    monkeypatch.setattr(
+        api_memories.compile_jobs, "mark_completed_durable", fake_mark_completed
+    )
+
+    # Patch `get_session_factory` so `_run_compile`'s `async with ... as session`
+    # works without a DB.
+    import server.db.engine as engine_module
+
+    class _FakeFactory:
+        def __call__(self_inner):
+            class _Ctx:
+                async def __aenter__(self_):
+                    return object()
+
+                async def __aexit__(self_, *a):
+                    return None
+
+            return _Ctx()
+
+    monkeypatch.setattr(engine_module, "get_session_factory", lambda: _FakeFactory())
+
+    result = await api_memories._run_compile("subj-x", job_id="job-1", tenant_id=None)
+
+    assert len(call_log) == 3, "loop should run exactly one batch per scripted entry"
+    assert result.memories_created == 9
+    assert result.has_more is False
+    assert result.remaining_episodes == 0
+    # Progress published on first iteration even with zero creates, then on
+    # every subsequent batch that created memories.
+    assert progress_updates == [4, 8, 9]
+
+
+@pytest.mark.anyio
+async def test_134_async_drain_respects_iteration_cap(monkeypatch):
+    """If the compiler keeps reporting work remaining (e.g. fails to
+    advance `last_compiled_at`), `_run_compile` must stop at
+    `settings.compile_max_iterations` instead of looping forever."""
+    from server.api import memories as api_memories
+    from server.core.config import settings
+
+    async def never_drains(_session, _subject_id, _tenant_id, _batch_size):
+        return [], 1, 999  # always 1 created, always 999 remaining
+
+    async def noop(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(api_memories, "_compile_one_batch", never_drains)
+    monkeypatch.setattr(api_memories.compile_jobs, "update_progress_durable", noop)
+    monkeypatch.setattr(api_memories.compile_jobs, "mark_running_durable", noop)
+    monkeypatch.setattr(api_memories.compile_jobs, "mark_completed_durable", noop)
+
+    import server.db.engine as engine_module
+
+    class _FakeFactory:
+        def __call__(self_inner):
+            class _Ctx:
+                async def __aenter__(self_):
+                    return object()
+
+                async def __aexit__(self_, *a):
+                    return None
+
+            return _Ctx()
+
+    monkeypatch.setattr(engine_module, "get_session_factory", lambda: _FakeFactory())
+    monkeypatch.setattr(settings, "compile_max_iterations", 5)
+
+    result = await api_memories._run_compile("subj-stuck", job_id=None, tenant_id=None)
+
+    # 5 iterations × 1 created per iteration → 5 total. has_more=True
+    # because the loop bailed out without draining.
+    assert result.memories_created == 5
+    assert result.has_more is True
+    assert result.remaining_episodes == 999


### PR DESCRIPTION
Fixes #134.

## Summary

`POST /v1/memories/compile` silently processed at most 500 uncompiled episodes per call and returned no completion signal. Operators with thousands of episodes saw the admin UI's `Memories` count plateau at small round numbers and reasonably reported it as a memory cap.

This PR makes the batch contract explicit and makes async mode actually drain the subject.

## Changes

**Schema**
- `CompileMemoriesResponse` gains `has_more: bool` and `remaining_episodes: int` (default `False`/`0` — additive, no breakage for existing call sites).

**Config (env-tunable)**
- `STATEWAVE_COMPILE_BATCH_SIZE` (default `500`) — per-call episode budget.
- `STATEWAVE_COMPILE_MAX_ITERATIONS` (default `2000`) — async drain-loop safety cap.

**Routes**
- Sync mode stays bounded per call (predictable latency) and now reports `has_more` so clients can loop until drained.
- Async mode (`async: true`) loops `_compile_one_batch` internally until `remaining_episodes == 0`, accumulating `memories_created` and publishing in-flight progress to the durable job row. Bounded by `compile_max_iterations` — a misbehaving compiler that never advances `last_compiled_at` produces a logged warning and `has_more=True`, not an infinite loop.

**Helpers**
- `repositories.count_uncompiled_episodes(...)` — cheap `COUNT(*)` for the drain signal.
- `compile_jobs.update_progress_durable(job_id, total)` — bump `memories_created` mid-job without flipping status to completed.

**Tests**
- `tests/test_issue_134_compile_drain.py` — unit tests for schema defaults, drain-loop accumulation, and the iteration-cap guard (mocks the batch helper, no DB).
- `tests/integration/test_issue_134_drain.py` — live coverage of sync `has_more` contract, caller-side drain loop, and async-mode single-job drain. Lowers `compile_batch_size` via monkeypatch so the tests force multiple batches without ingesting hundreds of episodes.

Local: `620 passed, 1 skipped` in unit suite (the one pre-existing local-env DB flake on `test_admin_subjects::test_memory_related_basic` is unrelated — fails on `main` the same way).

## Migration notes

Backward compatible. SDKs that don't yet know about `has_more`/`remaining_episodes` ignore them. Callers that want full-subject compilation should either:
1. Switch to `async: true` — one call, drains the whole subject.
2. Loop sync calls until `has_more == False`.