### PR TITLE
docs(readme): point top jump-link to Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _If Statewave is useful to you, a ⭐ on the repo helps others discover it._
 
 The interactive comparison demo is embedded directly in the website at **[statewave.ai](https://statewave.ai)** — open the chat widget to see two identical AI agents answer the same question, one stateless and one backed by Statewave.
 
-## [🚀 Skip to Quickstart →](#quickstart)
+## [🚀 Skip to Getting Started →](#documentation)
 
 ## The problem
 


### PR DESCRIPTION
Follow-up to #133. The H2 heading-link added right after **🎯 Try it** previously jumped to the **Quickstart** section. Per offline feedback the right landing target is the **Documentation** table (its first row is literally "Getting started"), so visitors get the full doc index instead of just the inline code snippet.

```diff
- ## [🚀 Skip to Quickstart →](#quickstart)
+ ## [🚀 Skip to Getting Started →](#documentation)
```

Label updated to "Skip to Getting Started" so the visible text matches the row visitors land next to. Anchor `#documentation` resolves to the `## Documentation` heading at the existing table.

Docs-only single-line change.