### PR TITLE
feat(webhooks): add event-type allowlist for webhook delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ All settings use the `STATEWAVE_` env prefix. Copy `.env.example` to `.env` to g
 | `STATEWAVE_RATE_LIMIT_STRATEGY` | `distributed` | `distributed` (Postgres) or `memory` (in-process) |
 | `STATEWAVE_WEBHOOK_URL` | — | Webhook callback URL (empty = disabled) |
 | `STATEWAVE_WEBHOOK_TIMEOUT` | `5.0` | Webhook HTTP timeout in seconds |
+| `STATEWAVE_WEBHOOK_EVENTS` | — | Comma-separated event-type allowlist (empty = deliver every event) |
 | `STATEWAVE_TENANT_HEADER` | `X-Tenant-ID` | Header for multi-tenant isolation |
 | `STATEWAVE_REQUIRE_TENANT` | `false` | Reject requests without tenant header |
 | `STATEWAVE_DEFAULT_MAX_CONTEXT_TOKENS` | `4000` | Default token budget for context assembly |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -27,7 +27,7 @@ The lead [README](../README.md#capabilities) lists the top 8 capabilities most r
 - **Authentication** — optional API key via `X-API-Key` header.
 - **Rate limiting** — per-IP fixed-window, distributed (Postgres-backed) or in-memory.
 - **Multi-tenant** — optional `X-Tenant-ID` header with real query-scoped data isolation across all reads and writes.
-- **Webhooks** — persistent HTTP callbacks with retries and dead-letter on episode, compile, and delete events.
+- **Webhooks** — persistent HTTP callbacks with retries and dead-letter on episode, compile, and delete events; an optional event-type allowlist (`STATEWAVE_WEBHOOK_EVENTS`) restricts delivery to specific event types.
 - **OpenTelemetry tracing** — optional spans on key operations (requires `[otel]` extra).
 - **Structured logging** — `structlog` with JSON output in production, console in development.
 - **Structured errors** — consistent JSON error format with request-ID correlation.

--- a/server/app.py
+++ b/server/app.py
@@ -86,7 +86,11 @@ async def lifespan(app: FastAPI):
     # Configure webhooks
     from server.services import webhooks
 
-    webhooks.configure(url=settings.webhook_url, timeout=settings.webhook_timeout)
+    webhooks.configure(
+        url=settings.webhook_url,
+        timeout=settings.webhook_timeout,
+        events=settings.webhook_event_filter,
+    )
     await webhooks.start_worker()
 
     # Start background cleanup (snapshots + compile job retention + rate limit + memory TTL)

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -7,6 +7,8 @@ import json
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
+from server.core.webhook_events import parse_webhook_event_filter
+
 
 class Settings(BaseSettings):
     """Central configuration — populated from env vars or .env file."""
@@ -147,6 +149,32 @@ class Settings(BaseSettings):
     # Webhooks (empty = disabled)
     webhook_url: str | None = None
     webhook_timeout: float = 5.0
+    # Event-type allowlist for webhook delivery, comma-separated. Empty =
+    # deliver every event (the backward-compatible default). Example:
+    #   STATEWAVE_WEBHOOK_EVENTS=memories.compiled,subject.deleted
+    # Kept as the raw string so the env var is plain comma-separated;
+    # read the parsed, validated list via the `webhook_event_filter`
+    # property.
+    webhook_events: str = ""
+
+    @field_validator("webhook_events")
+    @classmethod
+    def _validate_webhook_events(cls, value: str) -> str:
+        """Validate the event-type allowlist at construction.
+
+        An unknown event type fails fast at startup instead of silently
+        dropping every webhook weeks later. The raw string is returned
+        unchanged; `parse_webhook_event_filter` does the checking."""
+        parse_webhook_event_filter(value)
+        return value
+
+    @property
+    def webhook_event_filter(self) -> list[str]:
+        """Parsed + validated webhook event-type allowlist.
+
+        An empty list means no filter is configured — every event is
+        delivered. See `parse_webhook_event_filter`."""
+        return parse_webhook_event_filter(self.webhook_events)
 
     # Multi-tenant (empty = single-tenant mode)
     tenant_header: str = "X-Tenant-ID"

--- a/server/core/webhook_events.py
+++ b/server/core/webhook_events.py
@@ -1,0 +1,68 @@
+"""Canonical webhook event-type vocabulary.
+
+Dependency-free on purpose: both the config layer (``server.core.config``)
+and the delivery service (``server.services.webhooks``) import it, and the
+delivery service pulls in the database layer — so the vocabulary has to
+live somewhere neither side's import graph routes back through.
+
+Every string in ``KNOWN_WEBHOOK_EVENTS`` is an event passed to
+``webhooks.fire()`` somewhere in the server. Adding a new event type
+means adding it here too, otherwise ``STATEWAVE_WEBHOOK_EVENTS`` will
+reject any filter that names it.
+"""
+
+from __future__ import annotations
+
+#: Every event type the server emits via ``webhooks.fire()``.
+#:
+#: Keep this in sync with the ``webhooks.fire(...)`` call sites. The
+#: ``test_webhook_events`` suite asserts the set is non-empty and the
+#: config validator checks operator-supplied filters against it.
+KNOWN_WEBHOOK_EVENTS: frozenset[str] = frozenset(
+    {
+        "episode.created",
+        "episodes.batch_created",
+        "memories.compiled",
+        "subject.deleted",
+        "subject.health_degraded",
+        "subject.health_improved",
+    }
+)
+
+
+def parse_webhook_event_filter(value: object) -> list[str]:
+    """Normalise and validate a webhook event-type allowlist.
+
+    Accepts any of:
+
+    - ``None`` or ``""`` — no filter; every event is delivered.
+    - a comma-separated string — the operator-facing env-var form,
+      e.g. ``STATEWAVE_WEBHOOK_EVENTS=memories.compiled,subject.deleted``.
+    - a list / tuple / set of event types — the programmatic form used
+      by tests and embedders.
+
+    Unknown event types are rejected eagerly so a typo surfaces at
+    startup, not as silently-dropped webhooks weeks later. The result is
+    sorted and de-duplicated; an empty list means "no filter".
+    """
+    if value is None or value == "":
+        return []
+    if isinstance(value, str):
+        items = [part.strip() for part in value.split(",")]
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        items = [str(part).strip() for part in value]
+    else:
+        raise ValueError(
+            "STATEWAVE_WEBHOOK_EVENTS must be a comma-separated string or a "
+            f"list of event types, got {type(value).__name__}"
+        )
+
+    cleaned = sorted({item for item in items if item})
+    unknown = [item for item in cleaned if item not in KNOWN_WEBHOOK_EVENTS]
+    if unknown:
+        raise ValueError(
+            "STATEWAVE_WEBHOOK_EVENTS names unknown event type(s): "
+            f"{', '.join(unknown)}. Known event types: "
+            f"{', '.join(sorted(KNOWN_WEBHOOK_EVENTS))}."
+        )
+    return cleaned

--- a/server/services/webhooks.py
+++ b/server/services/webhooks.py
@@ -38,13 +38,36 @@ _webhook_url: str | None = None
 _timeout: float = 5.0
 _worker_task: asyncio.Task | None = None
 _poll_interval: float = 5.0  # seconds between queue checks
+# Event-type allowlist. An empty set means "no filter — deliver every
+# event" (the backward-compatible default). When non-empty, only events
+# whose type is in the set are enqueued.
+_event_filter: frozenset[str] = frozenset()
 
 
-def configure(url: str | None, timeout: float = 5.0) -> None:
-    """Set the global webhook URL. Called at app startup."""
-    global _webhook_url, _timeout
+def configure(
+    url: str | None,
+    timeout: float = 5.0,
+    events: list[str] | None = None,
+) -> None:
+    """Set the global webhook URL, timeout, and event filter.
+
+    Called at app startup with values from `Settings`. `events` is the
+    event-type allowlist (`STATEWAVE_WEBHOOK_EVENTS`): an empty or None
+    value disables filtering so every event is delivered.
+    """
+    global _webhook_url, _timeout, _event_filter
     _webhook_url = url
     _timeout = timeout
+    _event_filter = frozenset(events) if events else frozenset()
+
+
+def event_filter() -> frozenset[str]:
+    """Return the active event-type allowlist.
+
+    An empty set means no filter is configured — every event type is
+    delivered. Exposed for tests and operator introspection.
+    """
+    return _event_filter
 
 
 async def start_worker() -> None:
@@ -75,10 +98,20 @@ async def fire(
 ) -> uuid.UUID | None:
     """Enqueue a webhook event for delivery.
 
-    If no webhook URL is configured, returns None (no-op).
-    The event is persisted immediately and delivered asynchronously.
+    If no webhook URL is configured, returns None (no-op). If an event
+    filter is configured and `event` is not in the allowlist, the event
+    is dropped before it reaches the delivery queue and None is
+    returned. Otherwise the event is persisted immediately and delivered
+    asynchronously.
     """
     if not _webhook_url:
+        return None
+
+    # Event-type allowlist (STATEWAVE_WEBHOOK_EVENTS). An empty filter
+    # means "deliver everything"; a filtered-out event is never enqueued,
+    # so it costs nothing in storage or delivery attempts.
+    if _event_filter and event not in _event_filter:
+        logger.debug("webhook_event_filtered", event_type=event)
         return None
 
     event_id = uuid.uuid4()

--- a/tests/test_webhook_events.py
+++ b/tests/test_webhook_events.py
@@ -1,0 +1,105 @@
+"""Tests for the webhook event-type filter (STATEWAVE_WEBHOOK_EVENTS).
+
+Covers the `parse_webhook_event_filter` parser/validator and its
+integration into `Settings`. The delivery-path behaviour (which events
+actually reach the queue) is in `test_webhooks.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from server.core.config import Settings
+from server.core.webhook_events import (
+    KNOWN_WEBHOOK_EVENTS,
+    parse_webhook_event_filter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+def test_known_events_non_empty():
+    """The vocabulary must list the event types the server emits."""
+    assert KNOWN_WEBHOOK_EVENTS
+    assert "memories.compiled" in KNOWN_WEBHOOK_EVENTS
+    assert "subject.deleted" in KNOWN_WEBHOOK_EVENTS
+    assert "subject.health_degraded" in KNOWN_WEBHOOK_EVENTS
+
+
+# ---------------------------------------------------------------------------
+# parse_webhook_event_filter
+# ---------------------------------------------------------------------------
+
+def test_parse_none_and_empty_mean_no_filter():
+    assert parse_webhook_event_filter(None) == []
+    assert parse_webhook_event_filter("") == []
+
+
+def test_parse_single_event_string():
+    assert parse_webhook_event_filter("memories.compiled") == ["memories.compiled"]
+
+
+def test_parse_comma_separated_string():
+    assert parse_webhook_event_filter("memories.compiled,subject.deleted") == [
+        "memories.compiled",
+        "subject.deleted",
+    ]
+
+
+def test_parse_strips_whitespace_and_blank_entries():
+    assert parse_webhook_event_filter(" memories.compiled ,, subject.deleted ") == [
+        "memories.compiled",
+        "subject.deleted",
+    ]
+
+
+def test_parse_accepts_list_input_and_sorts():
+    assert parse_webhook_event_filter(["subject.deleted", "memories.compiled"]) == [
+        "memories.compiled",
+        "subject.deleted",
+    ]
+
+
+def test_parse_deduplicates():
+    assert parse_webhook_event_filter("memories.compiled,memories.compiled") == [
+        "memories.compiled",
+    ]
+
+
+def test_parse_rejects_unknown_event():
+    with pytest.raises(ValueError, match="unknown event type"):
+        parse_webhook_event_filter("bogus.event")
+
+
+def test_parse_rejects_unknown_mixed_with_known():
+    """One bad entry rejects the whole filter — there is no partial apply."""
+    with pytest.raises(ValueError, match="bogus.event"):
+        parse_webhook_event_filter("memories.compiled,bogus.event")
+
+
+def test_parse_rejects_wrong_type():
+    with pytest.raises(ValueError, match="comma-separated string or a"):
+        parse_webhook_event_filter(123)
+
+
+# ---------------------------------------------------------------------------
+# Settings integration
+# ---------------------------------------------------------------------------
+
+def test_settings_default_is_no_filter():
+    """No STATEWAVE_WEBHOOK_EVENTS set → empty filter → deliver everything."""
+    assert Settings(webhook_events="").webhook_event_filter == []
+
+
+def test_settings_parses_comma_separated():
+    settings = Settings(webhook_events="memories.compiled,subject.deleted")
+    assert settings.webhook_event_filter == ["memories.compiled", "subject.deleted"]
+
+
+def test_settings_rejects_unknown_event_at_construction():
+    """An unknown event type fails fast — the server refuses to start."""
+    with pytest.raises(ValidationError, match="unknown event type"):
+        Settings(webhook_events="not.a.real.event")

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -71,3 +71,105 @@ def test_backoff_increases_exponentially():
     assert 15 <= b1 <= 45
     assert 60 <= b2 <= 180
     assert 240 <= b3 <= 720
+
+
+# ── Event-type filter (STATEWAVE_WEBHOOK_EVENTS) ───────────────────────────
+
+# Every event type the server emits — kept in lockstep with
+# server.core.webhook_events.KNOWN_WEBHOOK_EVENTS.
+ALL_EVENT_TYPES = [
+    "episode.created",
+    "episodes.batch_created",
+    "memories.compiled",
+    "subject.deleted",
+    "subject.health_degraded",
+    "subject.health_improved",
+]
+
+
+async def test_fire_no_filter_delivers_all_event_types():
+    """With no filter configured, every event type is enqueued."""
+    webhooks.configure("http://example.com/hook")  # events defaults to None
+    assert webhooks.event_filter() == frozenset()
+
+    for event in ALL_EVENT_TYPES:
+        session = MagicMock()
+        result = await webhooks.fire(event, {"x": 1}, db=session)
+        assert result is not None, f"{event} should be enqueued"
+        session.add.assert_called_once()
+
+
+async def test_fire_single_event_filter():
+    """A one-event filter enqueues that type and drops every other."""
+    webhooks.configure("http://example.com/hook", events=["memories.compiled"])
+
+    allowed = MagicMock()
+    assert await webhooks.fire("memories.compiled", {}, db=allowed) is not None
+    allowed.add.assert_called_once()
+
+    for blocked in ("episode.created", "subject.deleted", "subject.health_degraded"):
+        session = MagicMock()
+        assert await webhooks.fire(blocked, {}, db=session) is None
+        session.add.assert_not_called()
+
+
+async def test_fire_multiple_event_filter():
+    """A multi-event filter enqueues exactly the listed types."""
+    allowed_events = ["memories.compiled", "subject.deleted"]
+    webhooks.configure("http://example.com/hook", events=allowed_events)
+
+    for event in allowed_events:
+        session = MagicMock()
+        assert await webhooks.fire(event, {}, db=session) is not None
+        session.add.assert_called_once()
+
+    for blocked in ("episode.created", "episodes.batch_created", "subject.health_improved"):
+        session = MagicMock()
+        assert await webhooks.fire(blocked, {}, db=session) is None
+        session.add.assert_not_called()
+
+
+async def test_fire_filtered_event_is_not_persisted():
+    """A filtered-out event never touches the delivery queue."""
+    webhooks.configure("http://example.com/hook", events=["memories.compiled"])
+    session = MagicMock()
+    result = await webhooks.fire("subject.deleted", {"subject_id": "u1"}, db=session)
+    assert result is None
+    session.add.assert_not_called()
+    session.commit.assert_not_called()
+
+
+async def test_filter_decision_is_event_type_only():
+    """Tenant isolation: the filter keys on event type alone, never on
+    payload contents. Payload data — including any tenant/subject id —
+    can neither smuggle a blocked event through nor block an allowed one,
+    so the filter introduces no cross-tenant coupling."""
+    webhooks.configure("http://example.com/hook", events=["memories.compiled"])
+
+    # An allowed event is enqueued whichever tenant/subject the payload names.
+    for tenant in ("acme", "globex", None):
+        session = MagicMock()
+        payload = {"subject_id": "s1", "tenant_id": tenant}
+        assert await webhooks.fire("memories.compiled", payload, db=session) is not None
+        session.add.assert_called_once()
+
+    # A blocked event stays blocked whatever the payload contains.
+    for tenant in ("acme", "globex", None):
+        session = MagicMock()
+        payload = {"subject_id": "s1", "tenant_id": tenant}
+        assert await webhooks.fire("subject.deleted", payload, db=session) is None
+        session.add.assert_not_called()
+
+
+async def test_fire_noop_without_url_even_with_filter():
+    """No URL short-circuits before the filter — nothing is enqueued."""
+    webhooks.configure(None, events=["memories.compiled"])
+    assert await webhooks.fire("memories.compiled", {}, db=MagicMock()) is None
+
+
+def test_event_filter_accessor_reflects_configuration():
+    webhooks.configure("http://example.com/hook", events=["subject.deleted"])
+    assert webhooks.event_filter() == frozenset({"subject.deleted"})
+    # Reconfiguring without events clears the filter.
+    webhooks.configure("http://example.com/hook")
+    assert webhooks.event_filter() == frozenset()


### PR DESCRIPTION
## Webhook event filters

Part of **v0.8 Adoption** — *"Webhook event filters: allow subscribers to subscribe to specific event types"*.

### Design

Webhook delivery in Statewave is a **single global URL** (`STATEWAVE_WEBHOOK_URL`) fed by a persisted delivery queue — there is no multi-subscriber registration model. The smallest coherent "event filter" for that architecture is an **event-type allowlist on the one webhook**: `STATEWAVE_WEBHOOK_EVENTS`.

- **No filter set** (the default) → every event the server emits is delivered, exactly as before. Fully backward-compatible.
- **Filter set** → only the listed event types are enqueued; everything else is dropped at `fire()` time, before it ever reaches the delivery queue (zero storage / zero delivery attempts for filtered-out events).

The six event types the server emits: `episode.created`, `episodes.batch_created`, `memories.compiled`, `subject.deleted`, `subject.health_degraded`, `subject.health_improved`.

### Changes

- **`server/core/webhook_events.py`** (new) — the `KNOWN_WEBHOOK_EVENTS` vocabulary and `parse_webhook_event_filter()`. A deliberately dependency-free leaf module: both the config layer and the delivery service import it, and the delivery service pulls in the DB layer, so the vocabulary must live where neither import graph cycles back through.
- **`server/core/config.py`** — `STATEWAVE_WEBHOOK_EVENTS` (comma-separated string). A `@field_validator` rejects unknown event types **at `Settings` construction**, so a typo fails the server at startup instead of silently dropping every webhook weeks later. The parsed, validated list is exposed via the `webhook_event_filter` property.
- **`server/services/webhooks.py`** — `configure()` gains an `events` allowlist; `fire()` drops a non-allowlisted event up front. New `event_filter()` accessor for tests / operator introspection.
- **`server/app.py`** — passes `settings.webhook_event_filter` into `configure()` at startup.

### Backward compatibility

Fully backward-compatible. `configure()`'s new `events` parameter defaults to `None`; an unset / empty `STATEWAVE_WEBHOOK_EVENTS` produces an empty filter, which means "deliver everything" — identical to current behaviour. Every existing `configure()` and `fire()` call site is unaffected.

### Migration notes

**No database migration.** The filter is operator configuration, not stored state — it lives in `Settings`, not a table. (A future multi-subscriber model — per-URL subscriptions each with their own filters — would add a `webhook_subscriptions` table; the global allowlist composes cleanly underneath that and is the right primitive to ship first.)

### Tests

- **`tests/test_webhook_events.py`** (new, 13 cases) — `parse_webhook_event_filter` (none/empty → no filter, single, comma-separated, whitespace/blank stripping, list input, dedup, unknown rejected, unknown-mixed-with-known rejected, wrong-type rejected) and `Settings` integration (default = no filter, comma-separated parsed, **unknown event type rejected at construction**).
- **`tests/test_webhooks.py`** (+7 cases) — **no filter → all six event types delivered**; **single event-type filter**; **multiple event-type filters**; filtered event is not persisted (no `session.add`/`commit`); **filter decision keys on event type only, never on payload contents** — so payload data (incl. any tenant/subject id) can neither smuggle a blocked event through nor block an allowed one, i.e. the filter introduces no cross-tenant coupling; no-op without a URL.

### Validation

```
ruff check server/ tests/                                  # All checks passed!
pytest tests/test_webhooks.py tests/test_webhook_events.py  # 24 passed
pytest tests/test_*.py                                      # 640 passed, 1 pre-existing failure
```

> The one unit-suite failure — `tests/test_admin_subjects.py::test_memory_related_basic` (`TypeError: Not a boolean value: UUID(...)`) — is **pre-existing and unrelated**: it fails identically on a clean `main` checkout, touches no file in this PR, and references nothing in the webhook/config path. It looks like a local SQLite type-affinity quirk; CI runs unit tests against real Postgres.

### Docs

- `README.md` — `STATEWAVE_WEBHOOK_EVENTS` added to the configuration-reference table.
- `docs/capabilities.md` — webhook capability line notes the optional allowlist.

### Remaining follow-ups

- Sibling PR in `statewave-docs` updates `api/v1-contract.md` (Webhooks section + Configuration reference) to document `STATEWAVE_WEBHOOK_EVENTS`.
