### PR TITLE
docs: correct /readyz wording, mark LLM key optional in DOCKER.md

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -31,8 +31,10 @@ services:
     ports: ["8100:8100"]
     environment:
       STATEWAVE_DATABASE_URL: postgresql+asyncpg://statewave:statewave@db:5432/statewave
-      # LLM provider — pick one and set the matching key.
-      STATEWAVE_LITELLM_API_KEY: sk-...
+      # Optional. With no key, Statewave runs in demo mode (local regex
+      # compiler, no external calls). Set a key for real LLM extraction
+      # and semantic search — see the Getting Started guide linked below.
+      # STATEWAVE_LITELLM_API_KEY: sk-...
     depends_on:
       db:
         condition: service_healthy
@@ -43,8 +45,12 @@ volumes:
 
 ```sh
 docker compose up -d
-curl http://localhost:8100/healthz
+curl http://localhost:8100/healthz   # → {"status":"ok"}
+curl http://localhost:8100/readyz    # → {"status":"ready", ...}
 ```
+
+New to Statewave? The [Getting Started guide](https://github.com/smaramwbc/statewave-docs/blob/main/getting-started.md)
+walks through clone → run → store and retrieve your first memory in about 5 minutes.
 
 ## Pin a version
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ STATEWAVE_LITELLM_EMBEDDING_MODEL=text-embedding-3-small
 | `GET /healthz` or `GET /health` | Liveness check |
 | `GET /readyz` or `GET /ready` | Readiness check |
 
-Check `GET /readyz` to confirm your LLM key was picked up — if `llm` shows `"not configured (skip)"`, the key isn't being read (re-check `.env` sits next to `docker-compose.yml` and re-run `docker compose up -d`).
+Check `GET /readyz` to confirm your LLM key was picked up — if the `llm` check shows `"detail":"STATEWAVE_LITELLM_API_KEY is not set"`, the key isn't being read (re-check that `.env` sits next to `docker-compose.yml` and re-run `docker compose up -d`).
 
 See the full [getting started guide](https://github.com/smaramwbc/statewave-docs/blob/main/getting-started.md) for step-by-step setup including environment configuration.
 


### PR DESCRIPTION
Part of a cross-repo pass to make first-run onboarding beginner-proof.

- **README.md** — the `/readyz` LLM check reports `"detail":"STATEWAVE_LITELLM_API_KEY is not set"` (see `server/services/readiness.py`); the README pointed at a stale `"not configured (skip)"` string. Corrected.
- **DOCKER.md** — the Docker Hub compose snippet hard-set `STATEWAVE_LITELLM_API_KEY: sk-...`, implying a key is required. It is now commented/optional (demo mode runs without one), with an added `/readyz` check and a link to the Getting Started guide.

No runtime code touched.
