### PR TITLE
feat(templates): add memory templates for common patterns

### DIFF
--- a/docs/memory-templates.md
+++ b/docs/memory-templates.md
@@ -1,0 +1,128 @@
+# Memory templates
+
+Memory templates are declarative, versioned scaffolds for the kinds of
+information a team ingests over and over — a support handoff, a project
+decision, an incident summary. A template fixes the *shape* of that
+pattern once; callers then supply values and Statewave produces a
+consistent, provenance-tagged episode.
+
+Templates exist to make adoption easy without adding magic:
+
+- **Pure data.** A template is a YAML file. No code runs inside it.
+- **Deterministic.** Applying a template is plain string substitution —
+  the same values always produce the same bytes.
+- **Provenance is explicit.** Every episode a template produces records
+  the template id and version, both in its `payload` and in
+  `metadata.template`.
+- **Composes, doesn't replace.** A template produces an ordinary
+  episode. It flows through the normal ingest → compile → context
+  pipeline; the compiler is not involved in templating and is not
+  changed by it.
+
+## Bundled templates
+
+Five templates ship in `server/templates/`:
+
+| Template id | Episode type | Purpose |
+|---|---|---|
+| `customer-support-handoff` | `support.handoff_note` | Escalation note when a conversation changes hands |
+| `user-preference` | `profile.preference` | A durable preference an agent should respect |
+| `project-decision` | `project.decision` | A lightweight ADR-style decision record |
+| `incident-summary` | `incident.summary` | Post-incident summary for repeat-issue detection |
+| `account-onboarding` | `account.onboarding` | Starting context for a new account or tenant |
+
+## Template file format
+
+A template is a YAML mapping with these keys:
+
+| Key | Required | Description |
+|---|---|---|
+| `id` | yes | Stable identifier, `^[a-z0-9][a-z0-9-]*$`. Unique across all templates. |
+| `version` | yes | Integer ≥ 1. Bump it whenever the field set or content scaffold changes. |
+| `title` | yes | Human-readable name. |
+| `description` | no | What the template is for. |
+| `episode_type` | yes | The `type` stamped on every episode this template produces. |
+| `fields` | yes | List of field definitions (at least one). |
+| `content_template` | yes | The content scaffold; `{field_name}` placeholders are substituted on apply. |
+
+Each entry in `fields`:
+
+| Key | Required | Description |
+|---|---|---|
+| `name` | yes | Field name, `^[a-zA-Z0-9_]+$`. Referenced as `{name}` in `content_template`. |
+| `type` | no | `string` (short, default) or `text` (multi-line). Advisory metadata for callers and UIs — both render as plain strings. |
+| `required` | no | Whether `apply` rejects a request that omits this field. Defaults to `false`. |
+| `description` | no | What the field holds. |
+
+Every `{placeholder}` in `content_template` must name a declared field;
+a template that violates this — or has duplicate field names, or a
+duplicate `id` — fails the server at startup rather than silently.
+
+## API
+
+### `GET /v1/memory-templates`
+
+Lists every template with its full field schema. Templates are
+inspectable by design — callers can render their own forms from this.
+
+### `GET /v1/memory-templates/{template_id}`
+
+Returns one template. `404` if there is no such template.
+
+### `POST /v1/memory-templates/{template_id}/apply`
+
+Validates caller-supplied values against the template and ingests the
+resulting episode.
+
+```json
+{
+  "subject_id": "customer:globex",
+  "session_id": "ticket-8842",
+  "values": {
+    "customer": "Globex Corp",
+    "issue": "Duplicate charge on the May invoice",
+    "next_owner": "Tier 2 billing"
+  }
+}
+```
+
+Validation is strict — an unknown field, a missing required field, or a
+non-string value is rejected with `422`. `404` if the template does not
+exist. On success the response is `201` with the created episode.
+
+The episode's `payload`:
+
+```json
+{
+  "template_id": "customer-support-handoff",
+  "template_version": 1,
+  "fields": { "customer": "Globex Corp", "issue": "...", "next_owner": "..." },
+  "content": "Customer support handoff — Globex Corp.\n\nActive issue: ..."
+}
+```
+
+`fields` records exactly what the caller supplied — an omitted optional
+field is absent here, and renders as an empty string inside `content`.
+`metadata.template` carries `{ "id": ..., "version": ... }` so the
+episode's provenance is exact.
+
+## Adding or extending a template
+
+Adding a template is dropping a new `*.yaml` file into
+`server/templates/`. It is picked up at the next server start.
+
+Extending an existing template — new field, changed scaffold — should
+**bump `version`**. The id stays stable so historical episodes remain
+attributable; the version distinguishes which scaffold produced them.
+
+Two deliberate extension points exist:
+
+- **Field `type`.** Today `string` and `text` are advisory metadata.
+  A later release can use the type to drive richer validation (dates,
+  enums, numbers) without changing the file format or existing
+  templates.
+- **Template scope.** Templates currently form a single global,
+  bundled set. Per-tenant or operator-supplied template catalogues
+  would layer on top of the same `MemoryTemplate` schema and the same
+  `apply` semantics — the bundled set is the primitive they compose
+  with.

--- a/server/api/templates.py
+++ b/server/api/templates.py
@@ -1,0 +1,106 @@
+"""Memory template routes.
+
+Templates are read-only declarative patterns (see
+`server.services.templates`). `apply` validates caller-supplied field
+values against a template and ingests an ordinary episode — the
+templated episode then flows through the normal compile/context
+pipeline, with `template_id` / `template_version` recorded for
+provenance.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.core.dependencies import get_tenant_id
+from server.db import repositories as repo
+from server.db.engine import get_session
+from server.db.tables import EpisodeRow
+from server.schemas.requests import ApplyTemplateRequest
+from server.schemas.responses import EpisodeResponse
+from server.services import templates, webhooks
+
+router = APIRouter(prefix="/v1/memory-templates", tags=["memory-templates"])
+
+
+@router.get(
+    "",
+    response_model=templates.MemoryTemplateList,
+    summary="List memory templates",
+)
+async def list_memory_templates() -> templates.MemoryTemplateList:
+    """List every bundled memory template, with its full field schema."""
+    return templates.MemoryTemplateList(templates=templates.list_templates())
+
+
+@router.get(
+    "/{template_id}",
+    response_model=templates.MemoryTemplate,
+    summary="Get a memory template",
+)
+async def get_memory_template(template_id: str) -> templates.MemoryTemplate:
+    """Fetch one memory template by id — fields, types, and the content scaffold."""
+    template = templates.get_template(template_id)
+    if template is None:
+        raise HTTPException(status_code=404, detail=f"unknown memory template: {template_id}")
+    return template
+
+
+@router.post(
+    "/{template_id}/apply",
+    response_model=EpisodeResponse,
+    status_code=201,
+    summary="Apply a memory template",
+)
+async def apply_memory_template(
+    template_id: str,
+    body: ApplyTemplateRequest,
+    session: AsyncSession = Depends(get_session),
+    tenant_id: str | None = Depends(get_tenant_id),
+) -> EpisodeResponse:
+    """Validate field values against a template and ingest the resulting episode.
+
+    The episode's `payload` carries the template id/version, the supplied
+    field values, and the deterministically-rendered `content`;
+    `metadata.template` records the id/version for provenance. The
+    episode is otherwise identical to one created via `POST /v1/episodes`
+    and compiles the same way.
+    """
+    template = templates.get_template(template_id)
+    if template is None:
+        raise HTTPException(status_code=404, detail=f"unknown memory template: {template_id}")
+
+    try:
+        payload = templates.render(template, body.values)
+    except templates.TemplateError as exc:
+        # Caller-supplied values failed the template's field schema.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    row = EpisodeRow(
+        subject_id=body.subject_id,
+        tenant_id=tenant_id,
+        session_id=body.session_id,
+        source="memory-template",
+        type=template.episode_type,
+        payload=payload,
+        metadata_={"template": {"id": template.id, "version": template.version}},
+        provenance={},
+    )
+    await repo.insert_episode(session, row)
+    await session.commit()
+    await session.refresh(row)
+    await webhooks.fire("episode.created", {"id": str(row.id), "subject_id": row.subject_id})
+
+    return EpisodeResponse(
+        id=row.id,
+        subject_id=row.subject_id,
+        source=row.source,
+        type=row.type,
+        payload=row.payload,
+        metadata=row.metadata_,
+        provenance=row.provenance,
+        session_id=row.session_id,
+        occurred_at=row.occurred_at,
+        created_at=row.created_at,
+    )

--- a/server/app.py
+++ b/server/app.py
@@ -207,6 +207,10 @@ def create_app() -> FastAPI:
 
     app.include_router(receipts_router)
 
+    from server.api.templates import router as templates_router
+
+    app.include_router(templates_router)
+
     # -- Ops endpoints -------------------------------------------------------
     @app.get("/healthz", tags=["ops"], summary="Liveness check")
     @app.get("/health", tags=["ops"], summary="Liveness check (alias)", include_in_schema=False)

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -30,6 +30,18 @@ class BatchCreateEpisodesRequest(BaseModel):
     episodes: list[CreateEpisodeRequest] = Field(..., min_length=1, max_length=100)
 
 
+class ApplyTemplateRequest(BaseModel):
+    """Body for POST /v1/memory-templates/{template_id}/apply.
+
+    `values` maps template field names to their (string) values; it is
+    validated against the template's field schema server-side.
+    """
+
+    subject_id: SubjectId
+    values: dict[str, Any] = Field(default_factory=dict)
+    session_id: SessionId | None = None
+
+
 class CompileMemoriesRequest(BaseModel):
     subject_id: SubjectId
     async_mode: bool = Field(default=False, alias="async")

--- a/server/services/templates.py
+++ b/server/services/templates.py
@@ -1,0 +1,196 @@
+"""Memory templates — declarative scaffolds for common episode patterns.
+
+A *memory template* is a named, versioned, inspectable definition of a
+recurring information pattern: a customer-support handoff, a project
+decision, an incident summary, and so on. Applying a template validates
+caller-supplied field values against the template's schema and ingests a
+normal episode whose payload carries both the structured field values
+and a deterministically-rendered content string.
+
+Design constraints (deliberately un-magical):
+
+- **Pure data.** Templates are YAML files. No code runs inside a
+  template; nothing is inferred or guessed.
+- **Deterministic.** Rendering is plain string substitution — the same
+  values always produce the same bytes.
+- **Provenance is explicit.** Every episode an `apply` produces records
+  ``template_id`` / ``template_version`` in its payload, and
+  ``metadata.template`` carries the same pair. You can always see
+  exactly which template, at which version, produced a memory.
+- **Composes, doesn't replace.** A template produces an ordinary
+  episode. The compiler is untouched; templated episodes flow through
+  the existing ingest → compile → context pipeline like any other.
+
+Bundled templates live in ``server/templates/*.yaml``. Adding one is
+dropping a new YAML file there — see ``docs/memory-templates.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+
+# Directory holding the bundled template YAML files.
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+
+# Placeholder tokens in a content_template: {field_name}.
+_PLACEHOLDER_RE = re.compile(r"{([a-zA-Z0-9_]+)}")
+
+
+class TemplateError(ValueError):
+    """Raised when a template file is malformed, or when caller-supplied
+    values do not satisfy a template's field schema."""
+
+
+class TemplateField(BaseModel):
+    """One field a template expects.
+
+    ``type`` is advisory metadata for callers and UIs — ``string`` hints
+    a short single-line value, ``text`` a longer multi-line one. Both are
+    carried and rendered as plain strings; the distinction is a
+    documented extension point, not behaviour.
+    """
+
+    name: str = Field(..., pattern=r"^[a-zA-Z0-9_]+$")
+    type: Literal["string", "text"] = "string"
+    required: bool = False
+    description: str = ""
+
+
+class MemoryTemplate(BaseModel):
+    """A declarative pattern for a common kind of episode."""
+
+    id: str = Field(..., pattern=r"^[a-z0-9][a-z0-9-]*$")
+    version: int = Field(..., ge=1)
+    title: str = Field(..., min_length=1)
+    description: str = ""
+    # The episode `type` stamped on every episode this template produces.
+    episode_type: str = Field(..., min_length=1, max_length=128)
+    fields: list[TemplateField] = Field(..., min_length=1)
+    # Content scaffold; {field_name} placeholders are substituted at apply.
+    content_template: str = Field(..., min_length=1)
+
+    def field_names(self) -> set[str]:
+        return {f.name for f in self.fields}
+
+
+class MemoryTemplateList(BaseModel):
+    """Wrapper for the list endpoint."""
+
+    templates: list[MemoryTemplate]
+
+
+def _validate_template(template: MemoryTemplate, source: str) -> None:
+    """Check a loaded template is internally consistent.
+
+    Field names must be unique, and every ``{placeholder}`` in
+    ``content_template`` must correspond to a declared field — so a
+    template author's typo fails at startup, not at apply time.
+    """
+    names = [f.name for f in template.fields]
+    duplicates = {n for n in names if names.count(n) > 1}
+    if duplicates:
+        raise TemplateError(
+            f"template {source}: duplicate field name(s): {', '.join(sorted(duplicates))}"
+        )
+    referenced = set(_PLACEHOLDER_RE.findall(template.content_template))
+    undeclared = referenced - template.field_names()
+    if undeclared:
+        raise TemplateError(
+            f"template {source}: content_template references undeclared "
+            f"field(s): {', '.join(sorted(undeclared))}"
+        )
+
+
+def load_templates(directory: Path = TEMPLATES_DIR) -> dict[str, MemoryTemplate]:
+    """Load and validate every ``*.yaml`` template in ``directory``.
+
+    Raises ``TemplateError`` on a malformed file, an internally
+    inconsistent template, or a duplicate template id — so a bad bundled
+    template fails the server at startup rather than silently.
+    """
+    registry: dict[str, MemoryTemplate] = {}
+    for path in sorted(directory.glob("*.yaml")):
+        try:
+            raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise TemplateError(f"template {path.name}: invalid YAML: {exc}") from exc
+        if not isinstance(raw, dict):
+            raise TemplateError(f"template {path.name}: file must be a YAML mapping")
+        try:
+            template = MemoryTemplate.model_validate(raw)
+        except ValidationError as exc:
+            raise TemplateError(f"template {path.name}: {exc}") from exc
+        _validate_template(template, path.name)
+        if template.id in registry:
+            raise TemplateError(
+                f"template {path.name}: duplicate template id {template.id!r}"
+            )
+        registry[template.id] = template
+    return registry
+
+
+# Loaded once at import time — a malformed bundled template fails fast.
+_REGISTRY: dict[str, MemoryTemplate] = load_templates()
+
+
+def list_templates() -> list[MemoryTemplate]:
+    """Every registered template, ordered by id."""
+    return [_REGISTRY[tid] for tid in sorted(_REGISTRY)]
+
+
+def get_template(template_id: str) -> MemoryTemplate | None:
+    """Look up a single template by id, or None if there is no such template."""
+    return _REGISTRY.get(template_id)
+
+
+def render(template: MemoryTemplate, values: dict[str, Any]) -> dict[str, Any]:
+    """Validate ``values`` against ``template`` and build the episode payload.
+
+    Validation is strict: an unknown field, a missing required field, or
+    a non-string value all raise ``TemplateError``. Rendering is
+    deterministic — every ``{field}`` placeholder is replaced with the
+    supplied value, or with an empty string when an optional field is
+    omitted.
+
+    The returned payload records the template id/version, the
+    caller-supplied fields verbatim, and the rendered ``content``.
+    """
+    declared = template.field_names()
+    unknown = set(values) - declared
+    if unknown:
+        raise TemplateError(
+            f"template {template.id}: unknown field(s): {', '.join(sorted(unknown))}"
+        )
+
+    supplied: dict[str, str] = {}
+    for name, value in values.items():
+        if not isinstance(value, str):
+            raise TemplateError(
+                f"template {template.id}: field {name!r} must be a string, "
+                f"got {type(value).__name__}"
+            )
+        supplied[name] = value
+
+    missing = sorted(
+        f.name for f in template.fields if f.required and f.name not in supplied
+    )
+    if missing:
+        raise TemplateError(
+            f"template {template.id}: missing required field(s): {', '.join(missing)}"
+        )
+
+    content = template.content_template
+    for field in template.fields:
+        content = content.replace("{" + field.name + "}", supplied.get(field.name, ""))
+
+    return {
+        "template_id": template.id,
+        "template_version": template.version,
+        "fields": supplied,
+        "content": content.strip(),
+    }

--- a/server/templates/account-onboarding.yaml
+++ b/server/templates/account-onboarding.yaml
@@ -1,0 +1,31 @@
+id: account-onboarding
+version: 1
+title: Account / tenant onboarding context
+description: >-
+  The starting context for a new account or tenant — who they are, what
+  they bought, their goals, and key contacts. Grounds an agent's first
+  interactions with a fresh customer.
+episode_type: account.onboarding
+fields:
+  - name: account
+    type: string
+    required: true
+    description: The account or tenant name.
+  - name: plan
+    type: string
+    required: false
+    description: The plan or tier they are on.
+  - name: goals
+    type: text
+    required: true
+    description: What the customer is trying to achieve with the product.
+  - name: key_contacts
+    type: text
+    required: false
+    description: Primary contacts and their roles.
+content_template: |-
+  Account onboarding — {account} ({plan}).
+
+  Goals: {goals}
+
+  Key contacts: {key_contacts}

--- a/server/templates/customer-support-handoff.yaml
+++ b/server/templates/customer-support-handoff.yaml
@@ -1,0 +1,33 @@
+id: customer-support-handoff
+version: 1
+title: Customer support handoff
+description: >-
+  A structured escalation note for when a support conversation moves to
+  another agent, team, or shift. Captures who the customer is, the active
+  issue, what has already been tried, and who is taking over.
+episode_type: support.handoff_note
+fields:
+  - name: customer
+    type: string
+    required: true
+    description: The customer or account being handed off.
+  - name: issue
+    type: text
+    required: true
+    description: The active issue, in the customer's own terms.
+  - name: steps_taken
+    type: text
+    required: false
+    description: Troubleshooting already attempted, and its outcome.
+  - name: next_owner
+    type: string
+    required: false
+    description: The agent or team picking the conversation up.
+content_template: |-
+  Customer support handoff — {customer}.
+
+  Active issue: {issue}
+
+  Steps already taken: {steps_taken}
+
+  Handed to: {next_owner}

--- a/server/templates/incident-summary.yaml
+++ b/server/templates/incident-summary.yaml
@@ -1,0 +1,39 @@
+id: incident-summary
+version: 1
+title: Troubleshooting / incident summary
+description: >-
+  A post-incident summary — what broke, the user-visible impact, how it
+  was resolved, and the follow-up. Useful for repeat-issue detection and
+  for grounding handoffs.
+episode_type: incident.summary
+fields:
+  - name: title
+    type: string
+    required: true
+    description: A short name for the incident.
+  - name: symptoms
+    type: text
+    required: true
+    description: What was observed — the user-visible impact.
+  - name: root_cause
+    type: text
+    required: false
+    description: The underlying cause, once known.
+  - name: resolution
+    type: text
+    required: false
+    description: How the incident was resolved or mitigated.
+  - name: follow_up
+    type: text
+    required: false
+    description: Outstanding follow-up actions.
+content_template: |-
+  Incident — {title}.
+
+  Symptoms: {symptoms}
+
+  Root cause: {root_cause}
+
+  Resolution: {resolution}
+
+  Follow-up: {follow_up}

--- a/server/templates/project-decision.yaml
+++ b/server/templates/project-decision.yaml
@@ -1,0 +1,33 @@
+id: project-decision
+version: 1
+title: Project decision log entry
+description: >-
+  A decision taken on a project — the choice, the options weighed, and the
+  reasoning behind it. A lightweight ADR-style record for agent and team
+  memory.
+episode_type: project.decision
+fields:
+  - name: decision
+    type: text
+    required: true
+    description: The decision that was made.
+  - name: context
+    type: text
+    required: true
+    description: The situation or problem that prompted the decision.
+  - name: alternatives
+    type: text
+    required: false
+    description: Other options considered, and why they were not chosen.
+  - name: decided_by
+    type: string
+    required: false
+    description: Who made or owns the decision.
+content_template: |-
+  Project decision: {decision}
+
+  Context: {context}
+
+  Alternatives considered: {alternatives}
+
+  Decided by: {decided_by}

--- a/server/templates/user-preference.yaml
+++ b/server/templates/user-preference.yaml
@@ -1,0 +1,24 @@
+id: user-preference
+version: 1
+title: User preference
+description: >-
+  A single durable preference a user has expressed — a channel, a format,
+  a working style — that an agent should respect in future interactions.
+episode_type: profile.preference
+fields:
+  - name: subject
+    type: string
+    required: true
+    description: What the preference is about (notifications, language, tone, ...).
+  - name: preference
+    type: text
+    required: true
+    description: The preference itself, stated plainly.
+  - name: rationale
+    type: text
+    required: false
+    description: Why the user holds this preference, if they said.
+content_template: |-
+  User preference — {subject}: {preference}
+
+  Rationale: {rationale}

--- a/tests/test_memory_templates.py
+++ b/tests/test_memory_templates.py
@@ -1,0 +1,244 @@
+"""Tests for memory templates — loader, render, and the API surface."""
+
+from __future__ import annotations
+
+import pytest
+
+from server.services import templates
+
+# The five templates bundled in server/templates/.
+BUNDLED_IDS = {
+    "account-onboarding",
+    "customer-support-handoff",
+    "incident-summary",
+    "project-decision",
+    "user-preference",
+}
+
+
+def _write(directory, name: str, body: str) -> None:
+    (directory / name).write_text(body, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Bundled registry
+# ---------------------------------------------------------------------------
+
+def test_bundled_templates_load():
+    """Every bundled template loads, validates, and has the expected shape."""
+    loaded = {t.id for t in templates.list_templates()}
+    assert loaded == BUNDLED_IDS
+    for template in templates.list_templates():
+        assert template.version >= 1
+        assert template.title
+        assert template.episode_type
+        assert template.fields
+        assert template.content_template
+
+
+def test_get_template_known_and_unknown():
+    assert templates.get_template("user-preference") is not None
+    assert templates.get_template("does-not-exist") is None
+
+
+def test_bundled_templates_are_internally_consistent():
+    """Every {placeholder} in a bundled template is a declared field."""
+    import re
+
+    for template in templates.list_templates():
+        referenced = set(re.findall(r"{([a-zA-Z0-9_]+)}", template.content_template))
+        assert referenced <= template.field_names(), template.id
+
+
+# ---------------------------------------------------------------------------
+# load_templates — validation
+# ---------------------------------------------------------------------------
+
+_VALID = """\
+id: temp-test
+version: 1
+title: Temp test
+episode_type: temp.test
+fields:
+  - name: a
+    required: true
+content_template: "value is {a}"
+"""
+
+
+def test_load_templates_from_directory(tmp_path):
+    _write(tmp_path, "temp-test.yaml", _VALID)
+    registry = templates.load_templates(tmp_path)
+    assert set(registry) == {"temp-test"}
+
+
+def test_load_rejects_undeclared_placeholder(tmp_path):
+    _write(
+        tmp_path,
+        "bad.yaml",
+        "id: bad-x\nversion: 1\ntitle: Bad\nepisode_type: bad.t\n"
+        "fields:\n  - name: a\ncontent_template: \"{a} and {b}\"\n",
+    )
+    with pytest.raises(templates.TemplateError, match="undeclared field"):
+        templates.load_templates(tmp_path)
+
+
+def test_load_rejects_duplicate_field_names(tmp_path):
+    _write(
+        tmp_path,
+        "bad.yaml",
+        "id: bad-y\nversion: 1\ntitle: Bad\nepisode_type: bad.t\n"
+        "fields:\n  - name: a\n  - name: a\ncontent_template: \"{a}\"\n",
+    )
+    with pytest.raises(templates.TemplateError, match="duplicate field name"):
+        templates.load_templates(tmp_path)
+
+
+def test_load_rejects_duplicate_template_ids(tmp_path):
+    _write(tmp_path, "one.yaml", _VALID)
+    _write(tmp_path, "two.yaml", _VALID)  # same id: temp-test
+    with pytest.raises(templates.TemplateError, match="duplicate template id"):
+        templates.load_templates(tmp_path)
+
+
+def test_load_rejects_non_mapping_file(tmp_path):
+    _write(tmp_path, "bad.yaml", "- just\n- a list\n")
+    with pytest.raises(templates.TemplateError, match="must be a YAML mapping"):
+        templates.load_templates(tmp_path)
+
+
+def test_load_rejects_missing_required_key(tmp_path):
+    # No content_template — pydantic validation fails.
+    _write(
+        tmp_path,
+        "bad.yaml",
+        "id: bad-z\nversion: 1\ntitle: Bad\nepisode_type: bad.t\nfields:\n  - name: a\n",
+    )
+    with pytest.raises(templates.TemplateError):
+        templates.load_templates(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# render
+# ---------------------------------------------------------------------------
+
+def test_render_happy_path():
+    template = templates.get_template("customer-support-handoff")
+    payload = templates.render(
+        template,
+        {"customer": "Globex", "issue": "duplicate charge", "next_owner": "Tier 2"},
+    )
+    assert payload["template_id"] == "customer-support-handoff"
+    assert payload["template_version"] == 1
+    assert payload["fields"] == {
+        "customer": "Globex",
+        "issue": "duplicate charge",
+        "next_owner": "Tier 2",
+    }
+    assert "Globex" in payload["content"]
+    assert "duplicate charge" in payload["content"]
+    assert "Tier 2" in payload["content"]
+
+
+def test_render_is_deterministic():
+    template = templates.get_template("user-preference")
+    values = {"subject": "notifications", "preference": "email only"}
+    assert templates.render(template, values) == templates.render(template, values)
+
+
+def test_render_omitted_optional_is_empty_in_content_and_absent_from_fields():
+    template = templates.get_template("user-preference")
+    payload = templates.render(
+        template, {"subject": "tone", "preference": "concise"}
+    )
+    # rationale is optional and was not supplied.
+    assert "rationale" not in payload["fields"]
+    # The {rationale} placeholder rendered to an empty string — no leftover
+    # placeholder token, and the content ends at the bare label.
+    assert "{rationale}" not in payload["content"]
+    assert payload["content"].endswith("Rationale:")
+
+
+def test_render_rejects_missing_required():
+    template = templates.get_template("customer-support-handoff")
+    with pytest.raises(templates.TemplateError, match="missing required field"):
+        templates.render(template, {"customer": "Globex"})  # issue is required
+
+
+def test_render_rejects_unknown_field():
+    template = templates.get_template("user-preference")
+    with pytest.raises(templates.TemplateError, match="unknown field"):
+        templates.render(
+            template, {"subject": "x", "preference": "y", "bogus": "z"}
+        )
+
+
+def test_render_rejects_non_string_value():
+    template = templates.get_template("user-preference")
+    with pytest.raises(templates.TemplateError, match="must be a string"):
+        templates.render(template, {"subject": "x", "preference": 42})
+
+
+# ---------------------------------------------------------------------------
+# API
+# ---------------------------------------------------------------------------
+
+async def test_list_endpoint(client):
+    resp = await client.get("/v1/memory-templates")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert {t["id"] for t in body["templates"]} == BUNDLED_IDS
+    # The full field schema is exposed — templates are inspectable.
+    handoff = next(t for t in body["templates"] if t["id"] == "customer-support-handoff")
+    assert any(f["name"] == "issue" and f["required"] for f in handoff["fields"])
+
+
+async def test_get_endpoint(client):
+    resp = await client.get("/v1/memory-templates/incident-summary")
+    assert resp.status_code == 200
+    assert resp.json()["episode_type"] == "incident.summary"
+
+
+async def test_get_endpoint_unknown_is_404(client):
+    resp = await client.get("/v1/memory-templates/nope")
+    assert resp.status_code == 404
+
+
+async def test_apply_unknown_template_is_404(client):
+    resp = await client.post(
+        "/v1/memory-templates/nope/apply",
+        json={"subject_id": "u1", "values": {}},
+    )
+    assert resp.status_code == 404
+
+
+async def test_apply_missing_required_field_is_422(client):
+    resp = await client.post(
+        "/v1/memory-templates/customer-support-handoff/apply",
+        json={"subject_id": "u1", "values": {"customer": "Globex"}},
+    )
+    assert resp.status_code == 422
+    assert "issue" in resp.json()["error"]["message"]
+
+
+async def test_apply_creates_episode_with_provenance(client):
+    resp = await client.post(
+        "/v1/memory-templates/customer-support-handoff/apply",
+        json={
+            "subject_id": "template-test-subject",
+            "values": {"customer": "Globex", "issue": "duplicate charge"},
+        },
+    )
+    assert resp.status_code == 201
+    episode = resp.json()
+    assert episode["source"] == "memory-template"
+    assert episode["type"] == "support.handoff_note"
+    assert episode["payload"]["template_id"] == "customer-support-handoff"
+    assert episode["payload"]["template_version"] == 1
+    assert episode["payload"]["fields"]["customer"] == "Globex"
+    assert "Globex" in episode["payload"]["content"]
+    # Provenance: metadata records the template id + version.
+    assert episode["metadata"]["template"] == {
+        "id": "customer-support-handoff",
+        "version": 1,
+    }


### PR DESCRIPTION
## Memory templates for common patterns

Part of **v0.8 Adoption** — *"Memory templates for common patterns"*.

### What this adds

Memory templates are declarative, versioned scaffolds for the kinds of information a team ingests repeatedly. A template fixes the *shape* of a pattern once; callers then supply values and Statewave produces a consistent, provenance-tagged episode.

Five templates ship in `server/templates/`:

| Template id | Episode type | Purpose |
|---|---|---|
| `customer-support-handoff` | `support.handoff_note` | Escalation note when a conversation changes hands |
| `user-preference` | `profile.preference` | A durable preference an agent should respect |
| `project-decision` | `project.decision` | A lightweight ADR-style decision record |
| `incident-summary` | `incident.summary` | Post-incident summary for repeat-issue detection |
| `account-onboarding` | `account.onboarding` | Starting context for a new account / tenant |

### Design — deliberately un-magical

- **Pure data.** A template is a YAML file. No code runs inside it.
- **Deterministic.** Applying a template is plain string substitution — the same values always produce the same bytes.
- **Provenance is explicit.** Every episode an `apply` produces records `template_id` / `template_version` in its `payload` *and* in `metadata.template`.
- **Composes, doesn't replace.** A template produces an ordinary episode that flows through the existing ingest → compile → context pipeline. **The compiler is not touched.**

### Changes

- `server/templates/*.yaml` — the 5 bundled templates.
- `server/services/templates.py` — `MemoryTemplate` / `TemplateField` models; a startup loader+validator; a deterministic `render()`. The loader rejects malformed YAML, non-mapping files, `content_template` placeholders that name an undeclared field, duplicate field names, and duplicate template ids — a bad bundled template fails the server at startup, not silently.
- `server/api/templates.py` — `GET /v1/memory-templates` (list, full field schema — templates are inspectable), `GET /v1/memory-templates/{id}`, `POST /v1/memory-templates/{id}/apply`.
- `server/schemas/requests.py` — `ApplyTemplateRequest`.
- `server/app.py` — registers the router.
- `docs/memory-templates.md` — file format, API, provenance, and the two documented extension points (field `type`-driven validation; per-tenant template scope).

### Template / extension format

A template declares `id`, `version`, `title`, `description`, `episode_type`, a list of `fields` (`name`, `type` = `string`|`text`, `required`, `description`), and a `content_template` with `{field_name}` placeholders. **Adding a template is dropping a new `*.yaml` into `server/templates/`** — picked up at the next start. Extending a template should bump `version` (id stays stable so historical episodes remain attributable). Full reference: `docs/memory-templates.md`.

### Migration notes

**No database migration.** Templates carry their provenance in the episode's existing `payload` and `metadata` columns — no schema change, no new table.

### Tests — `tests/test_memory_templates.py` (21 cases)

- **Loader / registry** — all 5 bundled templates load; bundled templates are internally consistent; `get_template` known/unknown; loader rejects undeclared placeholders, duplicate field names, duplicate template ids, non-mapping files, and missing required keys (via `tmp_path`).
- **render** — happy path produces the documented payload; deterministic (same input → identical output); omitted optional field is absent from `fields` and empty in `content`; rejects missing-required, unknown-field, and non-string values.
- **API** — `list` exposes the full schema; `get`; `get` unknown → 404; `apply` unknown template → 404; `apply` missing required field → 422; `apply` success → 201 with the episode carrying `payload.template_id/version`, `payload.fields`, rendered `payload.content`, and `metadata.template` provenance.

### Validation

```
ruff check server/ tests/                      # All checks passed!
pytest tests/test_memory_templates.py -v       # 21 passed
```

> The CI unit suite also surfaces one **pre-existing, unrelated** failure — `tests/test_admin_subjects.py::test_memory_related_basic` — which fails identically on a clean `main` checkout and touches no file in this PR. (Confirmed in `statewave#150`.)

### Remaining follow-ups

- Sibling PR in `statewave-docs` documents the three endpoints in `api/v1-contract.md`.
- A one-line mention in `README.md` / `docs/capabilities.md` is deferred — both files currently have concurrent uncommitted edits from an onboarding-docs pass; adding a line now would either contaminate this PR or be clobbered. `docs/memory-templates.md` is the canonical feature doc in the meantime.
- SDK convenience wrappers (`applyTemplate` / `apply_template`) are a natural follow-up if templates see uptake; this PR keeps the surface to the HTTP API.
