### PR TITLE
docs: align v0.8 shipped state

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Three runnable examples in [statewave-examples](https://github.com/smaramwbc/sta
 - **[Long-running coding agent](https://github.com/smaramwbc/statewave-examples/tree/main/coding-agent-python)** — multi-session project memory: tech stack, preferences, architecture decisions persist between conversations. *(Python · TypeScript)*
 - **[Stateless vs memory-powered agent (live LLM)](https://github.com/smaramwbc/statewave-examples/tree/main/support-agent-llm)** — full loop with a real LLM (any LiteLLM provider) running side by side with and without Statewave so you can A/B the difference yourself. *(Python)*
 
-Plus four more — minimal quickstart, docs-grounded support, eval suite (55 assertions across 23 tests), and a benchmark — in the [examples repo](https://github.com/smaramwbc/statewave-examples).
+Plus the minimal quickstart, docs-grounded support, eval suite (55 assertions across 23 tests), a benchmark, and **drop-in framework integrations** — [LangChain](https://github.com/smaramwbc/statewave-examples/tree/main/langchain-quickstart), [CrewAI](https://github.com/smaramwbc/statewave-examples/tree/main/crewai-quickstart), and [AutoGen](https://github.com/smaramwbc/statewave-examples/tree/main/autogen-quickstart) — in the [examples repo](https://github.com/smaramwbc/statewave-examples).
 
 ## Run the server
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -13,6 +13,7 @@ The lead [README](../README.md#capabilities) lists the top 8 capabilities most r
 - **Memory conflict resolution** — auto-supersede older overlapping memories.
 - **Provenance** — every memory traces back to its source episodes; bundles carry the chain.
 - **Subject management** — list subjects with episode/memory counts, inspect timelines, hard-delete all data per subject.
+- **Memory templates** — declarative, versioned YAML scaffolds for recurring information patterns (support handoff, decision log, incident summary, …). `GET /v1/memory-templates` lists the bundled set with full field schemas; `POST /v1/memory-templates/{id}/apply` validates field values and ingests a normal episode with `template_id` / `template_version` provenance. See [`memory-templates.md`](memory-templates.md).
 
 ## Governance & audit
 


### PR DESCRIPTION
## Surface v0.8 Adoption shipments in this repo's user-facing docs

Sibling consistency PR after the v0.8 Adoption block landed across the workspace this week. Brings the server repo's docs in line with what's in `main`.

### What was stale or missing

- `docs/capabilities.md` did not list **Memory templates** — the feature lives in `main` (`statewave#152`) with its own dedicated doc (`docs/memory-templates.md`), but the capability inventory had no pointer at it. Anyone reading the inventory to see what Statewave can do would miss the feature.
- `README.md` "Use cases" tail read *"Plus four more — minimal quickstart, docs-grounded support, eval suite, and a benchmark"*. The three framework-integration quickstarts (LangChain, CrewAI, AutoGen) that shipped today in `statewave-examples#12` weren't acknowledged.

### What was updated

| File | Change |
|---|---|
| `docs/capabilities.md` | One new bullet for Memory templates under `## Core runtime`. Templates are an ingestion pattern, not a governance feature — so they fit alongside *Episode ingestion* and *Pluggable compilers*, not under *Governance & audit*. Links to `docs/memory-templates.md`. |
| `README.md` | Rewrote the "Use cases" tail to mention the framework integrations explicitly, linking each. |

### What was intentionally left unchanged

- `README.md` `## Capabilities` section — the curated 8-bullet list reads to first-time visitors; the full inventory it links to (`docs/capabilities.md`) is where Memory templates land. Keeping the README short was an explicit goal of the audit.
- `README.md` webhook event-filter mention — `STATEWAVE_WEBHOOK_EVENTS` is already in the configuration-reference table further down (the audit confirmed it).
- Webhook capability bullet on `docs/capabilities.md` line 30 — already mentions the event-type allowlist (added in `statewave#150`); no further edit needed.

### Validation

```
git diff --stat
→ README.md (+1 -1), docs/capabilities.md (+1)

grep -rni "planned\|coming soon\|memory template" README.md docs/capabilities.md
→ all live references; no "planned/coming soon" hits
```

This repo doesn't lint markdown in CI; the changes are well-formed and reviewed in the diff.

### Related

- Sibling PR in `statewave-docs#44` updates the wider docs corpus (deployment runbooks, why-statewave gap table, CHANGELOG v0.8.1 entry, product.md API surface).
- One more sibling PR in `statewave-bench` to follow — `README.md:12` "actively being run and published run by run" → "complete 4-tier sweep on `main`".