### PR TITLE
feat(server): add make test-cold for cold-install verification (#68)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,33 @@ pytest tests/ -v
 
 Please run `ruff` and the test suite locally before opening a PR.
 
+## Verifying a cold install
+
+To validate the full fresh-user path (wipe volumes → compose up → readiness → smoke
+checks), use the root Makefile target:
+
+```bash
+cp .env.example .env   # if you have not already
+pip install -e ".[dev]"
+make test-cold
+```
+
+`make test-cold` will:
+
+1. `docker compose down -v` (wipe persisted state)
+2. `docker compose up -d`
+3. Poll `GET /readyz` until `status` is `ready` (60s timeout by default)
+4. Run the smoke suite: `pytest tests/smoke/ -m smoke`
+5. Print **time-to-first-ready** in seconds
+
+Override defaults if needed:
+
+```bash
+API_URL=http://127.0.0.1:8100 READYZ_TIMEOUT=90 make test-cold
+```
+
+Requires Docker, `curl`, and Python dev dependencies (`httpx`, `pytest`).
+
 ## Discussing changes before opening a PR
 
 Use the lightest-weight venue that fits the change:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+COMPOSE ?= docker compose
+API_URL ?= http://localhost:8100
+READYZ_TIMEOUT ?= 60
+STATEWAVE_COLD_TIMING_FILE ?= /tmp/statewave_cold_ready_seconds
+
+.PHONY: test-cold
+test-cold:
+	@test -f .env || cp .env.example .env
+	$(COMPOSE) down -v
+	$(COMPOSE) up -d
+	@chmod +x scripts/wait_readyz.sh
+	@STATEWAVE_COLD_TIMING_FILE=$(STATEWAVE_COLD_TIMING_FILE) \
+		scripts/wait_readyz.sh "$(API_URL)" $(READYZ_TIMEOUT)
+	@python3 -m pytest tests/smoke/ -m smoke -v
+	@echo "Time to first ready: $$(cat $(STATEWAVE_COLD_TIMING_FILE))s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,6 @@ line-length = 100
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 testpaths = ["tests"]
+markers = [
+    "smoke: live-stack smoke tests (require docker compose; see make test-cold)",
+]

--- a/scripts/wait_readyz.sh
+++ b/scripts/wait_readyz.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Poll /readyz until status=ready or timeout. Prints elapsed seconds on success.
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:8100}"
+BASE_URL="${BASE_URL%/}"
+TIMEOUT="${2:-60}"
+INTERVAL="${3:-2}"
+
+start=$SECONDS
+deadline=$((start + TIMEOUT))
+
+while (( SECONDS < deadline )); do
+  if resp=$(curl -sf "${BASE_URL}/readyz" 2>/dev/null); then
+    status=$(printf '%s' "$resp" | python3 -c "import sys, json; print(json.load(sys.stdin).get('status', ''))")
+    if [[ "$status" == "ready" ]]; then
+      elapsed=$((SECONDS - start))
+      echo "readyz: status=ready in ${elapsed}s"
+      printf '%s\n' "$elapsed" > "${STATEWAVE_COLD_TIMING_FILE:-/tmp/statewave_cold_ready_seconds}"
+      exit 0
+    fi
+  fi
+  sleep "$INTERVAL"
+done
+
+echo "readyz: did not reach status=ready within ${TIMEOUT}s (url=${BASE_URL})" >&2
+exit 1

--- a/tests/smoke/test_live_stack.py
+++ b/tests/smoke/test_live_stack.py
@@ -1,0 +1,41 @@
+"""Smoke tests against a live Statewave stack (docker compose).
+
+Run via `make test-cold` or manually after `docker compose up -d`:
+
+    STATEWAVE_SMOKE_URL=http://localhost:8100 pytest tests/smoke/ -m smoke -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+BASE_URL = os.environ.get("STATEWAVE_SMOKE_URL", "http://localhost:8100").rstrip("/")
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.mark.asyncio
+async def test_healthz():
+    async with httpx.AsyncClient(base_url=BASE_URL, timeout=10.0) as client:
+        resp = await client.get("/healthz")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_readyz_ready():
+    async with httpx.AsyncClient(base_url=BASE_URL, timeout=10.0) as client:
+        resp = await client.get("/readyz")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("status") == "ready", body
+
+
+@pytest.mark.asyncio
+async def test_openapi_available():
+    async with httpx.AsyncClient(base_url=BASE_URL, timeout=10.0) as client:
+        resp = await client.get("/openapi.json")
+    assert resp.status_code == 200
+    assert "openapi" in resp.json()


### PR DESCRIPTION
## Summary

Fixes #68.

Adds `make test-cold` — a one-command validation of the fresh-user install path:

1. `docker compose down -v` (wipe state)
2. `docker compose up -d`
3. Poll `GET /readyz` until `status=ready` (60s timeout, configurable via `READYZ_TIMEOUT`)
4. Run smoke tests: `pytest tests/smoke/ -m smoke`
5. Print **time-to-first-ready** in seconds

Also includes:
- `scripts/wait_readyz.sh` — reusable readyz poller
- `tests/smoke/test_live_stack.py` — HTTP smoke checks against a live stack (`/healthz`, `/readyz`, `/openapi.json`)
- **Verifying a cold install** section in `CONTRIBUTING.md`
- `@pytest.mark.smoke` registered in `pyproject.toml`

## Test plan

- [x] `cp .env.example .env && pip install -e ".[dev]"`
- [x] `make test-cold` — stack comes up, smoke tests pass, timing printed
- [x] `READYZ_TIMEOUT=90 API_URL=http://127.0.0.1:8100 make test-cold` — overrides work

Signed-off-by for DCO per CONTRIBUTING.md.


Made with [Cursor](https://cursor.com)