### PR TITLE
feat(receipts): scheduled retention-purge worker (#156)

### DIFF
--- a/alembic/versions/0020_receipts_retention.py
+++ b/alembic/versions/0020_receipts_retention.py
@@ -1,0 +1,79 @@
+"""receipts: status + tombstoned_at for the v0.9 retention worker
+
+Revision ID: 0020_receipts_retention
+Revises: 0019_per_tenant_bundles
+Create Date: 2026-05-25
+
+v0.8 shipped the receipt-retention surface (`tenant_configs.config ->>
+'receipt_retention_days'`) but explicitly deferred the worker to v0.9.
+This migration adds the row-level state the worker needs to
+soft-tombstone receipts past their tenant's retention window:
+
+  * ``receipts.status``     — string enum, default 'active'. Matches
+    the memory `status` vocabulary (`active | superseded | tombstoned`
+    — though receipts only ever move active → tombstoned today; the
+    other values are reserved for parity with the memories surface).
+  * ``receipts.tombstoned_at`` — nullable timestamp; stamped when the
+    worker transitions a row to `tombstoned`. Memories don't store
+    this separately, but receipts are themselves audit artifacts so
+    preserving "when was this audit record retired?" is part of the
+    audit trail.
+
+A **partial index** on `(tenant_id, created_at) WHERE status='active'`
+keeps the retention scan cheap as the table grows — the scan only
+visits not-yet-tombstoned rows, which is the small set even at scale
+(active rows are bounded by the retention window).
+
+The migration is reversible. Downgrade preserves the data (no DELETE),
+just drops the columns + index. A re-upgrade re-stamps every existing
+row as 'active' which is the correct "not-yet-tombstoned" default.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0020_receipts_retention"
+down_revision: Union[str, None] = "0019_per_tenant_bundles"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # status: default 'active' (server_default applies on INSERT for new
+    # rows; the backfill below covers rows that pre-date this migration).
+    op.add_column(
+        "receipts",
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'active'"),
+        ),
+    )
+    # tombstoned_at: nullable timestamp. Populated by the retention
+    # worker on the active -> tombstoned transition.
+    op.add_column(
+        "receipts",
+        sa.Column(
+            "tombstoned_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+    # Partial index — only active rows are scanned by the retention
+    # worker; tombstoned rows are excluded. Keeps the index narrow
+    # even on tables with millions of tombstoned receipts.
+    op.execute(
+        "CREATE INDEX ix_receipts_active_tenant_created "
+        "ON receipts (tenant_id, created_at) WHERE status = 'active'"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_receipts_active_tenant_created")
+    op.drop_column("receipts", "tombstoned_at")
+    op.drop_column("receipts", "status")

--- a/docs/state-assembly-receipts.md
+++ b/docs/state-assembly-receipts.md
@@ -103,10 +103,15 @@ deployments should additionally grant the service role
 from v1 of this feature).
 
 Retention is tenant-controlled via
-`tenant_configs.config.receipt_retention_days`. `0` (default) means
-forever; positive integers enable a future scheduled purge worker.
-v1 ships the *surface*, not the worker — receipts accumulate
-indefinitely unless the operator runs a manual purge.
+`tenant_configs.config.receipt_retention_days`. Absent or `null` means
+forever (the default); positive integers enable the scheduled purge
+worker (v0.9). Once a receipt is past its tenant's retention window,
+the worker transitions its row to `status = "tombstoned"` (soft delete
+— rows persist for forensic lookup of "an audit record existed and was
+retired"). The default list endpoint hides tombstoned rows; pass
+`?include_tombstoned=true` to surface them. Detail lookup
+(`GET /v1/receipts/{id}`) always returns tombstoned rows with the
+`status` and `tombstoned_at` fields populated.
 
 ## Failure mode
 
@@ -164,4 +169,3 @@ assembly internals:
 - Receipt-driven replay / time-travel debugging tooling.
 - Cross-tenant receipt aggregation / fleet-wide audit views.
 - HMAC signing of receipt bodies (column reserved, no signing path).
-- Scheduled retention-purge worker (config field accepted, no worker).

--- a/server/api/receipts.py
+++ b/server/api/receipts.py
@@ -43,7 +43,25 @@ async def get_receipt(
     row = await repo.get_receipt_by_id(session, receipt_id, tenant_id=tenant_id)
     if row is None:
         raise HTTPException(status_code=404, detail="receipt not found")
-    return row.body
+    return _row_to_response(row)
+
+
+def _row_to_response(row) -> dict[str, Any]:
+    """Merge row-level lifecycle metadata into the receipt body for the wire.
+
+    The body itself is the immutable audit artifact (never updated on
+    disk after emission). `status` and `tombstoned_at` are row-level
+    state — when the retention worker tombstones a receipt, those are
+    the only columns that change. They surface as siblings of the body
+    fields on the response so a client can tell "this audit record is
+    still active" vs "this was retired by retention" without parsing a
+    separate metadata blob.
+    """
+    out = dict(row.body)
+    out["status"] = row.status
+    if row.tombstoned_at is not None:
+        out["tombstoned_at"] = row.tombstoned_at.isoformat()
+    return out
 
 
 @router.get(
@@ -63,6 +81,15 @@ async def list_receipts(
         ),
     ),
     limit: int = Query(50, ge=1, le=200),
+    include_tombstoned: bool = Query(
+        False,
+        description=(
+            "Include receipts that the retention worker has tombstoned. "
+            "Default `false` — tombstoned rows persist for forensic lookup "
+            "via `GET /v1/receipts/{id}` but are filtered out of the list "
+            "view unless explicitly requested."
+        ),
+    ),
     session: AsyncSession = Depends(get_session),
     tenant_id: str | None = Depends(get_tenant_id),
 ) -> dict[str, Any]:
@@ -77,9 +104,10 @@ async def list_receipts(
         until=until,
         cursor=cursor,
         limit=limit,
+        include_tombstoned=include_tombstoned,
     )
     next_cursor = rows[-1].receipt_id if len(rows) == limit else None
     return {
-        "receipts": [row.body for row in rows],
+        "receipts": [_row_to_response(row) for row in rows],
         "next_cursor": next_cursor,
     }

--- a/server/app.py
+++ b/server/app.py
@@ -38,6 +38,7 @@ async def _cleanup_loop():
     from server.services.compile_jobs_durable import cleanup_old_jobs
     from server.services.ratelimit import cleanup_expired_windows
     from server.services.memory_ttl import cleanup_expired_memories
+    from server.services.receipts import cleanup_expired_receipts
 
     while True:
         await asyncio.sleep(3600)  # every hour
@@ -78,6 +79,22 @@ async def _cleanup_loop():
             except Exception as exc:
                 logger.warning("memory_ttl_cleanup_error", error=str(exc))
 
+        # Receipt retention (v0.9, issue #156) — tombstones receipts past
+        # their tenant's `receipt_retention_days`. Soft-delete only; rows
+        # persist with `status='tombstoned'` for the audit trail of "this
+        # receipt was emitted and later retired." Gated INSIDE the worker
+        # by per-tenant config (no settings-level switch) so admin-set
+        # retention starts taking effect on the next tick without a
+        # restart.
+        try:
+            async with get_session_factory()() as session:
+                tombstoned = await cleanup_expired_receipts(session)
+                await session.commit()
+            if tombstoned:
+                logger.info("receipts_retention_cleanup_done", tombstoned=tombstoned)
+        except Exception as exc:
+            logger.warning("receipts_retention_cleanup_error", error=str(exc))
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -93,16 +110,14 @@ async def lifespan(app: FastAPI):
     )
     await webhooks.start_worker()
 
-    # Start background cleanup (snapshots + compile job retention + rate limit + memory TTL)
-    cleanup_task = None
-    needs_cleanup = (
-        settings.enable_snapshots
-        or settings.compile_job_retention_hours > 0
-        or (settings.rate_limit_rpm > 0 and settings.rate_limit_strategy == "distributed")
-        or bool(settings.kind_ttl_days)
-    )
-    if needs_cleanup:
-        cleanup_task = asyncio.create_task(_cleanup_loop())
+    # Background cleanup — runs once per hour, short-circuits each block
+    # when its feature isn't configured. v0.9 added per-tenant receipt
+    # retention (issue #156), which can be enabled/disabled at runtime
+    # via the admin endpoint — gating the loop on a settings-time check
+    # would mean a restart to start picking up tenant retention changes.
+    # Always-on is cheap (one sleep + a handful of conditional skips per
+    # hour on minimal deployments) and removes that footgun.
+    cleanup_task = asyncio.create_task(_cleanup_loop())
 
     # Schema compatibility check
     try:

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -629,6 +629,7 @@ async def list_receipts(
     until: datetime | None = None,
     cursor: str | None = None,
     limit: int = 50,
+    include_tombstoned: bool = False,
 ) -> Sequence[ReceiptRow]:
     """List receipts for a subject, newest first.
 
@@ -636,6 +637,11 @@ async def list_receipts(
     creation time, so the cursor is simply the last `receipt_id` from
     the previous page. Offset pagination is unsafe for an append-only
     audit log where rows are continuously inserted.
+
+    ``include_tombstoned`` defaults to False so the list returns the
+    active audit trail. Tombstoned (retention-retired) receipts remain
+    individually addressable via `get_receipt_by_id` for forensic
+    lookup of "a receipt with id X was emitted and later retired."
     """
     stmt = (
         select(ReceiptRow)
@@ -650,6 +656,8 @@ async def list_receipts(
         stmt = stmt.where(ReceiptRow.created_at <= until)
     if cursor is not None:
         stmt = stmt.where(ReceiptRow.receipt_id < cursor)
+    if not include_tombstoned:
+        stmt = stmt.where(ReceiptRow.status == "active")
     result = await session.execute(stmt)
     return result.scalars().all()
 

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import Boolean, DateTime, Float, Index, Integer, String, Text, func
+from sqlalchemy import Boolean, DateTime, Float, Index, Integer, String, Text, func, text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -242,6 +242,16 @@ class ReceiptRow(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+    # Row-level lifecycle state. `active` for fresh receipts; the v0.9
+    # retention worker (`cleanup_expired_receipts`) transitions rows to
+    # `tombstoned` once `created_at + tenant.receipt_retention_days` has
+    # passed. Soft-delete only — the row persists for audit lookup.
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="active"
+    )
+    tombstoned_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     __table_args__ = (
         Index(
@@ -249,6 +259,16 @@ class ReceiptRow(Base):
             "tenant_id",
             "subject_id",
             "created_at",
+        ),
+        # Partial index — only active rows are visited by the retention
+        # worker. Created in the alembic migration with raw SQL because
+        # alembic 1.13's `op.create_index` doesn't surface the partial
+        # `WHERE` clause; declared here for ORM parity.
+        Index(
+            "ix_receipts_active_tenant_created",
+            "tenant_id",
+            "created_at",
+            postgresql_where=text("status = 'active'"),
         ),
     )
 

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0019_per_tenant_bundles"
+EXPECTED_HEAD = "0020_receipts_retention"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/server/services/receipts.py
+++ b/server/services/receipts.py
@@ -31,14 +31,15 @@ import secrets
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable
 
 import structlog
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.db import repositories as repo
-from server.db.tables import ReceiptRow
+from server.db.tables import ReceiptRow, TenantConfigRow
 
 logger = structlog.stdlib.get_logger()
 
@@ -408,3 +409,67 @@ async def load_tenant_receipt_config(
     if row is None:
         return {}
     return row.config or {}
+
+
+# ---------------------------------------------------------------------------
+# Retention worker — v0.9 (issue #156)
+# ---------------------------------------------------------------------------
+
+
+async def cleanup_expired_receipts(session: AsyncSession) -> int:
+    """Tombstone receipts past their tenant's retention window.
+
+    v0.8 shipped the configurable surface (``tenant_configs.config ->>
+    'receipt_retention_days'``) but no worker. This function is that
+    worker — called once an hour from `_cleanup_loop` in `server.app`.
+
+    Walks every tenant with a positive integer ``receipt_retention_days``
+    in its config and issues one ``UPDATE`` per tenant transitioning
+    ``status='active'`` receipts older than ``now() - retention_days``
+    into ``status='tombstoned'``. Soft-delete only — the rows persist so
+    a forensic lookup ("a receipt with id X was emitted and later
+    retired") still works.
+
+    Idempotent — re-running against the same DB state is a no-op (no
+    active rows past the cutoff remain to transition).
+
+    Tenant isolation is structural: each ``UPDATE`` is scoped to a
+    single ``tenant_id``, so misconfiguring tenant A cannot tombstone
+    tenant B's receipts.
+
+    Caller is responsible for committing the session.
+    """
+    # Find tenants with retention configured. JSONB `->>` returns NULL
+    # for missing keys; the `IS NOT NULL` lets non-configured tenants
+    # short-circuit without paying for a full ReceiptRow scan.
+    stmt = select(TenantConfigRow.tenant_id, TenantConfigRow.config).where(
+        TenantConfigRow.config.op("->>")("receipt_retention_days").isnot(None)
+    )
+    result = await session.execute(stmt)
+    tenants = result.all()
+    if not tenants:
+        return 0
+
+    now = datetime.now(timezone.utc)
+    total = 0
+    for tenant_id, config in tenants:
+        days = (config or {}).get("receipt_retention_days")
+        # Defensive: the per-tenant config endpoint validates the type
+        # at write time, but a SQL-shell write or pre-v0.9 garbage
+        # entry could land non-int values. Skip silently — we don't
+        # want one bad tenant config to halt the whole purge tick.
+        if not isinstance(days, int) or isinstance(days, bool) or days <= 0:
+            continue
+        cutoff = now - timedelta(days=days)
+        update_stmt = (
+            update(ReceiptRow)
+            .where(ReceiptRow.tenant_id == tenant_id)
+            .where(ReceiptRow.status == "active")
+            .where(ReceiptRow.created_at < cutoff)
+            .values(status="tombstoned", tombstoned_at=now)
+        )
+        r = await session.execute(update_stmt)
+        total += r.rowcount or 0
+    if total:
+        logger.info("receipts_retention_tombstoned", count=total)
+    return total

--- a/tests/integration/test_receipts_retention.py
+++ b/tests/integration/test_receipts_retention.py
@@ -1,0 +1,391 @@
+"""Integration tests for the v0.9 receipt retention worker (issue #156).
+
+`cleanup_expired_receipts` reads from `tenant_configs` and writes to
+`receipts` — both DB tables — so the function isn't pure and lives here
+rather than in the unit-test file.
+
+Pattern follows `tests/integration/test_memory_ttl.py`: insert rows
+directly through the session factory so the test controls `created_at`
+precisely (compiling through the API would stamp `created_at` from
+``now()`` and force monkey-patching).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from server.db.tables import ReceiptRow, TenantConfigRow
+from server.services.receipts import cleanup_expired_receipts, new_ulid
+
+
+# ---------------------------------------------------------------------------
+# Helpers — direct DB writes so created_at is fully controlled
+# ---------------------------------------------------------------------------
+
+
+async def _insert_receipt(
+    session_factory,
+    *,
+    tenant_id: str | None,
+    subject_id: str,
+    created_at: datetime,
+    status: str = "active",
+    receipt_id: str | None = None,
+) -> str:
+    rid = receipt_id or new_ulid()
+    async with session_factory() as session:
+        session.add(
+            ReceiptRow(
+                receipt_id=rid,
+                parent_receipt_id=None,
+                mode="retrieval",
+                tenant_id=tenant_id,
+                subject_id=subject_id,
+                query_id=None,
+                task_id=None,
+                context_hash="0" * 64,
+                context_size_bytes=0,
+                policy_bundle_hash=None,
+                region=None,
+                receipt_signature=None,
+                body={
+                    "receipt_id": rid,
+                    "mode": "retrieval",
+                    "subject_id": subject_id,
+                    "tenant_id": tenant_id,
+                    "stub": True,
+                },
+                as_of=created_at,
+                created_at=created_at,
+                status=status,
+            )
+        )
+        await session.commit()
+    return rid
+
+
+async def _set_tenant_retention(
+    session_factory,
+    tenant_id: str,
+    days: int | None | object,
+) -> None:
+    """Set (or unset) `tenant_configs.config.receipt_retention_days`.
+
+    ``days=None`` clears the key; non-int values are accepted (the
+    worker's input-validation path is exercised by passing through here)."""
+    async with session_factory() as session:
+        existing = await session.get(TenantConfigRow, tenant_id)
+        if existing is None:
+            cfg: dict = {} if days is None else {"receipt_retention_days": days}
+            session.add(TenantConfigRow(tenant_id=tenant_id, config=cfg, version=1))
+        else:
+            new_cfg = dict(existing.config or {})
+            if days is None:
+                new_cfg.pop("receipt_retention_days", None)
+            else:
+                new_cfg["receipt_retention_days"] = days
+            existing.config = new_cfg
+            existing.version = (existing.version or 0) + 1
+        await session.commit()
+
+
+def _t(label: str) -> str:
+    return f"tenant-{label}-{uuid.uuid4().hex[:6]}"
+
+
+# ---------------------------------------------------------------------------
+# Worker — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_tombstones_expired_active_receipt(session_factory, subject_id):
+    tenant = _t("tomb")
+    await _set_tenant_retention(session_factory, tenant, 30)
+    old = datetime.now(timezone.utc) - timedelta(days=40)
+    rid = await _insert_receipt(
+        session_factory, tenant_id=tenant, subject_id=subject_id, created_at=old
+    )
+
+    async with session_factory() as session:
+        count = await cleanup_expired_receipts(session)
+        await session.commit()
+    assert count == 1
+
+    async with session_factory() as session:
+        row = await session.get(ReceiptRow, rid)
+        assert row.status == "tombstoned"
+        assert row.tombstoned_at is not None
+
+
+async def test_leaves_active_receipt_within_window(session_factory, subject_id):
+    tenant = _t("within")
+    await _set_tenant_retention(session_factory, tenant, 30)
+    recent = datetime.now(timezone.utc) - timedelta(days=5)
+    rid = await _insert_receipt(
+        session_factory, tenant_id=tenant, subject_id=subject_id, created_at=recent
+    )
+
+    async with session_factory() as session:
+        count = await cleanup_expired_receipts(session)
+        await session.commit()
+    assert count == 0
+
+    async with session_factory() as session:
+        row = await session.get(ReceiptRow, rid)
+        assert row.status == "active"
+        assert row.tombstoned_at is None
+
+
+async def test_tenant_without_retention_is_untouched(session_factory, subject_id):
+    """A tenant that hasn't configured retention sees no transitions, even
+    on ancient receipts — retention is an explicit opt-in per tenant."""
+    tenant = _t("noret")
+    # No tenant_configs row for this tenant at all
+    old = datetime.now(timezone.utc) - timedelta(days=400)
+    rid = await _insert_receipt(
+        session_factory, tenant_id=tenant, subject_id=subject_id, created_at=old
+    )
+
+    async with session_factory() as session:
+        count = await cleanup_expired_receipts(session)
+        await session.commit()
+    assert count == 0
+
+    async with session_factory() as session:
+        row = await session.get(ReceiptRow, rid)
+        assert row.status == "active"
+
+
+# ---------------------------------------------------------------------------
+# Worker — idempotency + replay safety
+# ---------------------------------------------------------------------------
+
+
+async def test_idempotent_second_pass_is_noop(session_factory, subject_id):
+    tenant = _t("idem")
+    await _set_tenant_retention(session_factory, tenant, 30)
+    old = datetime.now(timezone.utc) - timedelta(days=40)
+    await _insert_receipt(
+        session_factory, tenant_id=tenant, subject_id=subject_id, created_at=old
+    )
+
+    async with session_factory() as session:
+        first = await cleanup_expired_receipts(session)
+        await session.commit()
+    async with session_factory() as session:
+        second = await cleanup_expired_receipts(session)
+        await session.commit()
+    assert first == 1
+    assert second == 0
+
+
+async def test_already_tombstoned_row_is_untouched(session_factory, subject_id):
+    tenant = _t("alreadytomb")
+    await _set_tenant_retention(session_factory, tenant, 30)
+    old = datetime.now(timezone.utc) - timedelta(days=40)
+    rid = await _insert_receipt(
+        session_factory,
+        tenant_id=tenant,
+        subject_id=subject_id,
+        created_at=old,
+        status="tombstoned",
+    )
+
+    async with session_factory() as session:
+        count = await cleanup_expired_receipts(session)
+        await session.commit()
+    assert count == 0
+
+    # `tombstoned_at` is still None because the row was inserted as
+    # tombstoned without one — the worker shouldn't backfill it.
+    async with session_factory() as session:
+        row = await session.get(ReceiptRow, rid)
+        assert row.tombstoned_at is None
+
+
+# ---------------------------------------------------------------------------
+# Worker — tenant isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_tenant_isolation(session_factory, subject_id):
+    """Tenant A's retention setting must not affect tenant B's receipts."""
+    tenant_a = _t("iso-a")
+    tenant_b = _t("iso-b")
+    await _set_tenant_retention(session_factory, tenant_a, 30)
+    # tenant_b has no retention — its 40-day-old receipt must survive.
+    old = datetime.now(timezone.utc) - timedelta(days=40)
+    rid_a = await _insert_receipt(
+        session_factory, tenant_id=tenant_a, subject_id=subject_id, created_at=old
+    )
+    rid_b = await _insert_receipt(
+        session_factory, tenant_id=tenant_b, subject_id=subject_id, created_at=old
+    )
+
+    async with session_factory() as session:
+        count = await cleanup_expired_receipts(session)
+        await session.commit()
+    assert count == 1
+
+    async with session_factory() as session:
+        a = await session.get(ReceiptRow, rid_a)
+        b = await session.get(ReceiptRow, rid_b)
+        assert a.status == "tombstoned"
+        assert b.status == "active"
+
+
+# ---------------------------------------------------------------------------
+# Worker — defensive parsing of malformed config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_value", ["thirty", -5, 0, True, [30], {"days": 30}])
+async def test_malformed_retention_value_is_skipped_not_fatal(
+    session_factory, subject_id, bad_value
+):
+    """A SQL-shell-poked or pre-v0.9 garbage value in tenant_configs.config
+    must not halt the purge tick — the worker skips that tenant and
+    keeps processing the rest. Per-tenant config endpoint validates at
+    write time but the worker can't trust historical writes."""
+    bad_tenant = _t("bad")
+    good_tenant = _t("good")
+    await _set_tenant_retention(session_factory, bad_tenant, bad_value)
+    await _set_tenant_retention(session_factory, good_tenant, 30)
+
+    old = datetime.now(timezone.utc) - timedelta(days=40)
+    bad_rid = await _insert_receipt(
+        session_factory, tenant_id=bad_tenant, subject_id=subject_id, created_at=old
+    )
+    good_rid = await _insert_receipt(
+        session_factory, tenant_id=good_tenant, subject_id=subject_id, created_at=old
+    )
+
+    async with session_factory() as session:
+        count = await cleanup_expired_receipts(session)
+        await session.commit()
+
+    # Bad tenant's receipt untouched; good tenant's receipt tombstoned.
+    assert count == 1
+    async with session_factory() as session:
+        assert (await session.get(ReceiptRow, bad_rid)).status == "active"
+        assert (await session.get(ReceiptRow, good_rid)).status == "tombstoned"
+
+
+# ---------------------------------------------------------------------------
+# API — GET /v1/receipts/{id} surfaces `status` and `tombstoned_at`
+# ---------------------------------------------------------------------------
+
+
+async def test_get_receipt_shows_active_status(client, session_factory, subject_id):
+    tenant = _t("api-active")
+    rid = await _insert_receipt(
+        session_factory,
+        tenant_id=tenant,
+        subject_id=subject_id,
+        created_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+
+    resp = await client.get(f"/v1/receipts/{rid}", headers={"X-Tenant-ID": tenant})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "active"
+    assert "tombstoned_at" not in body
+    assert body["receipt_id"] == rid
+
+
+async def test_get_receipt_shows_tombstoned_status_with_timestamp(
+    client, session_factory, subject_id
+):
+    """Tombstoned receipts remain individually addressable for forensic
+    lookup, with `status` + `tombstoned_at` surfaced on the wire."""
+    tenant = _t("api-tomb")
+    await _set_tenant_retention(session_factory, tenant, 30)
+    rid = await _insert_receipt(
+        session_factory,
+        tenant_id=tenant,
+        subject_id=subject_id,
+        created_at=datetime.now(timezone.utc) - timedelta(days=40),
+    )
+
+    # Run the worker to transition the row.
+    async with session_factory() as session:
+        await cleanup_expired_receipts(session)
+        await session.commit()
+
+    resp = await client.get(f"/v1/receipts/{rid}", headers={"X-Tenant-ID": tenant})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "tombstoned"
+    assert "tombstoned_at" in body
+    assert body["receipt_id"] == rid
+
+
+# ---------------------------------------------------------------------------
+# API — GET /v1/receipts list filters by status
+# ---------------------------------------------------------------------------
+
+
+async def test_list_excludes_tombstoned_by_default(client, session_factory, subject_id):
+    tenant = _t("api-list-default")
+    await _set_tenant_retention(session_factory, tenant, 30)
+    active_rid = await _insert_receipt(
+        session_factory,
+        tenant_id=tenant,
+        subject_id=subject_id,
+        created_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    tomb_rid = await _insert_receipt(
+        session_factory,
+        tenant_id=tenant,
+        subject_id=subject_id,
+        created_at=datetime.now(timezone.utc) - timedelta(days=40),
+    )
+    async with session_factory() as session:
+        await cleanup_expired_receipts(session)
+        await session.commit()
+
+    resp = await client.get(
+        f"/v1/receipts?subject_id={subject_id}",
+        headers={"X-Tenant-ID": tenant},
+    )
+    assert resp.status_code == 200
+    ids = [r["receipt_id"] for r in resp.json()["receipts"]]
+    assert active_rid in ids
+    assert tomb_rid not in ids
+
+
+async def test_list_includes_tombstoned_when_requested(
+    client, session_factory, subject_id
+):
+    tenant = _t("api-list-include")
+    await _set_tenant_retention(session_factory, tenant, 30)
+    active_rid = await _insert_receipt(
+        session_factory,
+        tenant_id=tenant,
+        subject_id=subject_id,
+        created_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    tomb_rid = await _insert_receipt(
+        session_factory,
+        tenant_id=tenant,
+        subject_id=subject_id,
+        created_at=datetime.now(timezone.utc) - timedelta(days=40),
+    )
+    async with session_factory() as session:
+        await cleanup_expired_receipts(session)
+        await session.commit()
+
+    resp = await client.get(
+        f"/v1/receipts?subject_id={subject_id}&include_tombstoned=true",
+        headers={"X-Tenant-ID": tenant},
+    )
+    assert resp.status_code == 200
+    ids = [r["receipt_id"] for r in resp.json()["receipts"]]
+    statuses = {r["receipt_id"]: r["status"] for r in resp.json()["receipts"]}
+    assert active_rid in ids
+    assert tomb_rid in ids
+    assert statuses[active_rid] == "active"
+    assert statuses[tomb_rid] == "tombstoned"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 19
+    assert len(revs) == 20
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 9
+    assert result.pending_count == 10
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 19
+    assert result.pending_count == 20
 
 
 def test_resolve_pending_unknown_revision():


### PR DESCRIPTION
## v0.9 PR 1 — Retention-purge worker

Closes [#156](https://github.com/smaramwbc/statewave/issues/156). First server PR of the v0.9 milestone.

### Why

v0.8 shipped the receipt-retention surface (`tenant_configs.config.receipt_retention_days`) and explicitly deferred the worker to v0.9. Tenants can configure retention today but it does nothing because no worker drains it — production deployments would see runaway receipt growth and compliance-grade tenants can't age out audit artifacts.

### What

A scheduled background worker (`cleanup_expired_receipts` in `server/services/receipts.py`) that walks tenants with a positive integer `receipt_retention_days` and tombstones `status='active'` receipts older than the cutoff. **Soft-delete only** — rows persist for the forensic lookup "a receipt existed and was retired."

### Changes

| File | Change |
|---|---|
| `alembic/versions/0020_receipts_retention.py` | Adds `receipts.status` (default `'active'`) + `receipts.tombstoned_at` columns. Partial index `ix_receipts_active_tenant_created` on `(tenant_id, created_at) WHERE status='active'` keeps the retention scan cheap at scale — the worker only visits active rows. |
| `server/db/tables.py` | `ReceiptRow.status` + `tombstoned_at` ORM declarations; partial index declared with `postgresql_where`. |
| `server/services/receipts.py` | New `cleanup_expired_receipts(session)` — one UPDATE per tenant (atomic, replica-safe, idempotent). Defensive parsing of malformed `receipt_retention_days` values (non-int, ≤0, bool) — skipped silently per-tenant rather than halting the whole tick. |
| `server/app.py` | Worker wired into `_cleanup_loop` alongside the memory-TTL pass. **`needs_cleanup` startup gate dropped** so admin-set retention takes effect on the next tick without a server restart. The loop's per-block short-circuits keep cost negligible on minimal deployments. |
| `server/db/repositories.py` | `list_receipts` gains `include_tombstoned: bool = False`. Filters `status='active'` by default. |
| `server/api/receipts.py` | `GET /v1/receipts/{id}` surfaces `status` + `tombstoned_at` on the response (sibling fields of the body, **not** mutations to the audit body itself). `GET /v1/receipts` gains an `include_tombstoned` query param. |
| `server/services/migrations.py` + `tests/test_migrations.py` | `EXPECTED_HEAD` bumped to `0020_receipts_retention`; pending counts updated. |
| `docs/state-assembly-receipts.md` | Retention paragraph rewritten (worker is no longer "future"); "no worker" out-of-scope bullet removed. |

### Tests — 16 new in `tests/integration/test_receipts_retention.py`

- **Worker behaviour:** expired receipt tombstoned; receipt within window untouched; tenant without retention configured untouched.
- **Idempotency:** second pass against the same DB state is a no-op (zero rowcount); already-tombstoned rows aren't re-tombstoned.
- **Tenant isolation:** tenant A's retention setting only affects tenant A's receipts (asserted with two tenants, one configured, one not).
- **Defensive parsing (parametrized):** non-int / negative / zero / bool / list / dict values in `receipt_retention_days` skipped without halting the tick. Other tenants in the same pass still process correctly.
- **API:** active receipts surface `status: "active"`; tombstoned receipts surface `status: "tombstoned"` + `tombstoned_at`. List endpoint excludes tombstoned by default; `?include_tombstoned=true` includes them.

```
ruff check server/ tests/                     # all checks passed
pytest tests/test_*.py                         # 661 passed, 1 skipped
pytest tests/integration/                      # 133 passed
alembic upgrade head                           # 0019 -> 0020 clean
```

### Backward compatibility

- **No-op for unconfigured tenants** — without `receipt_retention_days`, nothing changes.
- **Pre-v0.9 receipts** default to `status='active'` via the alembic `server_default`; existing detail/list calls return them unchanged.
- **New response fields** (`status`, `tombstoned_at`) are additive — Pydantic-based SDKs ignore unknowns by default, plain-dict consumers see one new key.
- **No SDK release blocker** — the support-endpoint SDKs (`statewave==0.10.0`, `@statewavedev/sdk@0.10.0`) work unchanged against this server. An SDK minor bump can pick up the new fields whenever convenient.

### Out of scope (per the issue brief)

- Hard delete of receipt rows. Tombstone is the v0.9 contract.
- Episode retention (episodes are append-only and immutable by design).
- Per-receipt retention overrides (tenant-level only).
- An admin endpoint to force-purge (worker is the only path).

### Sibling docs PR

Companion entry in `statewave-docs/CHANGELOG.md` lands separately under the v0.9 work-in-progress section.

### Next up

PR 2 — HMAC-signed receipts ([#157](https://github.com/smaramwbc/statewave/issues/157)).
