### PR TITLE
feat(receipts): HMAC-signed receipts with tenant-scoped key ids (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ All settings use the `STATEWAVE_` env prefix. Copy `.env.example` to `.env` to g
 | `STATEWAVE_WEBHOOK_URL` | — | Webhook callback URL (empty = disabled) |
 | `STATEWAVE_WEBHOOK_TIMEOUT` | `5.0` | Webhook HTTP timeout in seconds |
 | `STATEWAVE_WEBHOOK_EVENTS` | — | Comma-separated event-type allowlist (empty = deliver every event) |
+| `STATEWAVE_RECEIPT_SIGNING_KEYS` | — | JSON `{"<key_id>": "<base64>"}` map of HMAC keys for receipt signing (≥32 bytes each). Never persisted to the DB; per-tenant active key id set via `tenant_configs.config.receipt_signing_key_id`. |
 | `STATEWAVE_TENANT_HEADER` | `X-Tenant-ID` | Header for multi-tenant isolation |
 | `STATEWAVE_REQUIRE_TENANT` | `false` | Reject requests without tenant header |
 | `STATEWAVE_DEFAULT_MAX_CONTEXT_TOKENS` | `4000` | Default token budget for context assembly |

--- a/alembic/versions/0021_receipts_signature_keyid.py
+++ b/alembic/versions/0021_receipts_signature_keyid.py
@@ -1,0 +1,61 @@
+"""receipts: add signature_key_id + signature_algorithm columns (v0.9 #157)
+
+Revision ID: 0021_receipts_signature_keyid
+Revises: 0020_receipts_retention
+Create Date: 2026-05-25
+
+v0.8 reserved `receipts.receipt_signature` for HMAC tamper-evidence.
+v0.9 (issue #157) lights it up. This migration adds the two columns
+the verifier needs alongside the signature itself:
+
+  * ``receipt_signature_key_id`` — the operator's key identifier that
+    signed this receipt. Public information (it's just a name). The
+    actual key bytes live in operator config / secret manager and are
+    never persisted in the database.
+
+  * ``receipt_signature_algorithm`` — the signing algorithm + canonical
+    form version, baked into a single string (``hmac-sha256-canonical-v1``
+    in v0.9). Future migrations to JCS canonicalization or asymmetric
+    signing land as new algorithm strings without a schema break.
+
+All three fields (signature + key_id + algorithm) are nullable: pre-v0.9
+receipts and v0.9 receipts emitted on tenants without signing configured
+remain unsigned, and the verifier reports `valid: null, reason: "no_signature"`
+for those. The migration is reversible — downgrade drops the two columns
+and leaves the existing `receipt_signature` column from v0.8.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0021_receipts_signature_keyid"
+down_revision: Union[str, None] = "0020_receipts_retention"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "receipts",
+        sa.Column(
+            "receipt_signature_key_id",
+            sa.String(length=64),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "receipts",
+        sa.Column(
+            "receipt_signature_algorithm",
+            sa.String(length=64),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("receipts", "receipt_signature_algorithm")
+    op.drop_column("receipts", "receipt_signature_key_id")

--- a/docs/state-assembly-receipts.md
+++ b/docs/state-assembly-receipts.md
@@ -131,6 +131,72 @@ response so callers can detect the gap.
 `POST /v1/llm/complete` does not embed memory and so does not emit
 receipts.
 
+## HMAC signing (v0.9)
+
+Receipts can be tamper-evidently signed under an operator-provided
+HMAC-SHA256 key. The body's `receipt_signature` slot (reserved in
+v0.8) is populated when:
+
+1. The operator has configured a non-empty
+   `STATEWAVE_RECEIPT_SIGNING_KEYS` map at process startup —
+   `{"<key_id>": "<base64-of-32-or-more-bytes>"}`. The server **never
+   persists raw signing keys to the database**; they live only in
+   this process's in-memory config, sourced from env or a
+   secret-manager mount.
+2. The tenant's `tenant_configs.config.receipt_signing_key_id`
+   names a `key_id` that's present in that map.
+
+When both are true, the body's canonical form (sorted keys, no
+whitespace, UTF-8, `receipt_signature` excluded; tagged as
+`hmac-sha256-canonical-v1`) is HMAC-SHA256-signed and the signature
+stored alongside `receipt_signature_key_id` and
+`receipt_signature_algorithm`. Both metadata fields are inside the
+signature's coverage, so an attacker who swaps the key_id or
+algorithm on a stored receipt invalidates the signature too.
+
+**Failure modes are fail-open** — agent serving must never be
+blocked by audit infrastructure:
+
+- Invalid config at startup (bad JSON, key shorter than 32 bytes,
+  base64 corruption) **fails the server boot**. Operators see the
+  problem before any unsigned receipt slips out.
+- Runtime signing failure (tenant points at a `key_id` the operator
+  hasn't loaded in this process, or an unlikely hash error) **emits
+  the receipt unsigned** with a structured warning
+  (`receipt_signing_key_unavailable` or `receipt_signing_failed`).
+  Verify reports `valid: null, reason: "key_unavailable"` for the
+  former; `no_signature` for the latter.
+
+**Rotation** works by adding a new `key_id` to operator config
+alongside the old one, then updating
+`tenant_configs.config.receipt_signing_key_id` to the new id. New
+receipts sign with the new key; historical receipts remain
+verifiable as long as the old `key_id` stays loaded. Removing the
+old `key_id` flips its receipts to `valid: null, reason:
+"key_unavailable"` — they're still inspectable, just not
+re-verifiable on this binary.
+
+`GET /v1/receipts/{id}/verify` returns:
+
+```json
+{
+  "valid": true | false | null,
+  "key_id": "<operator key_id>" | null,
+  "algorithm": "hmac-sha256-canonical-v1" | null,
+  "reason": "ok" | "signature_mismatch" | "key_unavailable" | "no_signature" | "unsupported_algorithm"
+}
+```
+
+`valid: null` is the "we couldn't determine" verdict (no signature
+on the row, or the key isn't loaded, or the algorithm string names
+a variant this binary doesn't implement). `valid: false` is reserved
+for "we checked the math and the signature doesn't cover the body."
+The response **never** returns the key bytes, a hash of them, or a
+length hint.
+
+Pre-v0.9 receipts have no signature columns populated and verify
+cleanly as `{valid: null, reason: "no_signature"}` — never a 500.
+
 ## Read API
 
 | Method + Path | Purpose |
@@ -168,4 +234,6 @@ assembly internals:
 - Review-time redaction UI.
 - Receipt-driven replay / time-travel debugging tooling.
 - Cross-tenant receipt aggregation / fleet-wide audit views.
-- HMAC signing of receipt bodies (column reserved, no signing path).
+- KMS / Vault-backed signing (architecture is compatible — a future PR swaps the key resolver behind the same `receipt_signing_keys` settings field; v0.9 reads keys from env / secret-manager mount).
+- Asymmetric signatures (the `algorithm` field reserves space for `ed25519-canonical-v1` etc.; v0.9 ships HMAC only).
+- Bulk re-signing of pre-v0.9 receipts (forward-only signing — they verify as `no_signature`).

--- a/server/api/receipts.py
+++ b/server/api/receipts.py
@@ -46,6 +46,39 @@ async def get_receipt(
     return _row_to_response(row)
 
 
+@router.get(
+    "/v1/receipts/{receipt_id}/verify",
+    summary="Verify the HMAC signature on a state-assembly receipt",
+)
+async def verify_receipt_endpoint(
+    receipt_id: str,
+    session: AsyncSession = Depends(get_session),
+    tenant_id: str | None = Depends(get_tenant_id),
+) -> dict[str, Any]:
+    """Verify the HMAC signature stored on a receipt (v0.9, issue #157).
+
+    Returns the verification verdict — `valid: true | false | null` —
+    plus the `key_id` and `algorithm` used. Never echoes the signing
+    key or any derivative on the response.
+
+    `valid: null` distinguishes "we couldn't determine" cases
+    (`no_signature`, `key_unavailable`, `unsupported_algorithm`) from
+    `valid: false` ("we checked the math and the signature doesn't
+    cover the body"). `key_unavailable` keeps historical receipts
+    forensically inspectable when keys rotate out of operator config —
+    never a 500.
+
+    404 if the receipt doesn't exist (or belongs to a different tenant —
+    indistinguishable on the wire, same as the detail endpoint)."""
+    # Lazy import to keep this module's import graph shallow.
+    from server.services.receipts import verify_receipt
+
+    row = await repo.get_receipt_by_id(session, receipt_id, tenant_id=tenant_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="receipt not found")
+    return verify_receipt(row)
+
+
 def _row_to_response(row) -> dict[str, Any]:
     """Merge row-level lifecycle metadata into the receipt body for the wire.
 

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -176,6 +176,93 @@ class Settings(BaseSettings):
         delivered. See `parse_webhook_event_filter`."""
         return parse_webhook_event_filter(self.webhook_events)
 
+    # Receipt HMAC signing (v0.9, issue #157) — operator-provided keys
+    # per key_id. Set via env (JSON object):
+    #
+    #     STATEWAVE_RECEIPT_SIGNING_KEYS='{"key-2026-01":"<base64-32B>",...}'
+    #
+    # Per-tenant active key_id is in tenant_configs.config.receipt_signing_key_id.
+    # The server NEVER persists raw signing keys to the database — they
+    # live only in this process's in-memory config, sourced from
+    # env / secret-manager mount. The field is excluded from __repr__ so
+    # an accidental settings dump can't leak the keys.
+    receipt_signing_keys: dict[str, bytes] = Field(default_factory=dict, repr=False)
+
+    @field_validator("receipt_signing_keys", mode="before")
+    @classmethod
+    def _parse_receipt_signing_keys(cls, value):
+        """Parse + validate the signing-key map at startup. Failures here
+        fail the server boot — better than a silent fallback to unsigned
+        receipts because a base64 typo went unnoticed.
+
+        Accepts (a) a real dict (in-process tests / env-decoded), (b) a
+        JSON-encoded string (defensive — pydantic-settings does the
+        JSON decode itself for complex env fields, but this branch
+        keeps programmatic construction symmetrical with the env path),
+        or (c) None/"" for no signing. Per-key value can be either
+        base64 (env path) or raw `bytes` (in-process tests)."""
+        import base64
+        import json as _json
+
+        if value is None or value == "":
+            return {}
+        if isinstance(value, dict):
+            parsed = value
+        elif isinstance(value, str):
+            try:
+                parsed = _json.loads(value)
+            except _json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"STATEWAVE_RECEIPT_SIGNING_KEYS is not valid JSON: {exc.msg}"
+                ) from exc
+            if not isinstance(parsed, dict):
+                raise ValueError(
+                    "STATEWAVE_RECEIPT_SIGNING_KEYS must decode to a JSON "
+                    f"object of key_id -> base64 key (got {type(parsed).__name__})"
+                )
+        else:
+            raise ValueError(
+                "STATEWAVE_RECEIPT_SIGNING_KEYS must be a JSON object or dict, "
+                f"got {type(value).__name__}"
+            )
+
+        clean: dict[str, bytes] = {}
+        for key_id, raw in parsed.items():
+            if not isinstance(key_id, str) or not key_id:
+                raise ValueError(
+                    "STATEWAVE_RECEIPT_SIGNING_KEYS: every key_id must be a "
+                    f"non-empty string (got {key_id!r})"
+                )
+            if isinstance(raw, (bytes, bytearray)):
+                key_bytes = bytes(raw)
+            elif isinstance(raw, str):
+                try:
+                    # validate=True rejects non-base64 chars; raises on bad input.
+                    key_bytes = base64.b64decode(raw, validate=True)
+                except Exception as exc:
+                    raise ValueError(
+                        f"STATEWAVE_RECEIPT_SIGNING_KEYS[{key_id!r}] is not "
+                        "valid base64 (operator config should base64-encode "
+                        "the raw secret bytes)"
+                    ) from exc
+            else:
+                raise ValueError(
+                    f"STATEWAVE_RECEIPT_SIGNING_KEYS[{key_id!r}] must be a "
+                    "base64 string or raw bytes, got "
+                    f"{type(raw).__name__}"
+                )
+            if len(key_bytes) < 32:
+                # HMAC-SHA256 best practice: key length ≥ output length.
+                # Refuse weaker keys at config-load rather than allow
+                # weak signatures into production.
+                raise ValueError(
+                    f"STATEWAVE_RECEIPT_SIGNING_KEYS[{key_id!r}] is too "
+                    f"short: {len(key_bytes)} bytes (minimum 32 for "
+                    "HMAC-SHA256)."
+                )
+            clean[key_id] = key_bytes
+        return clean
+
     # Multi-tenant (empty = single-tenant mode)
     tenant_header: str = "X-Tenant-ID"
     require_tenant: bool = False

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -237,6 +237,17 @@ class ReceiptRow(Base):
     policy_bundle_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     region: Mapped[str | None] = mapped_column(String(64), nullable=True)
     receipt_signature: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # v0.9 (issue #157): HMAC signing metadata. Key bytes never persist
+    # in the DB — these columns reference what's in operator config.
+    # Both nullable: pre-v0.9 receipts and unsigned-by-policy v0.9
+    # receipts leave them null; the verifier reports `valid: null` /
+    # `reason: "no_signature"` for those.
+    receipt_signature_key_id: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
+    receipt_signature_algorithm: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
     body: Mapped[dict] = mapped_column(JSONB, nullable=False)
     as_of: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -824,7 +824,7 @@ async def _maybe_emit_receipt(
         caller_type=caller_type,
     )
     written_id = await receipts_service.write_receipt(
-        session, receipt_body=body, as_of=as_of
+        session, receipt_body=body, as_of=as_of, tenant_config=tenant_config
     )
     if written_id is None:
         # Failure path: bundle still authoritative, log already emitted.

--- a/server/services/handoff.py
+++ b/server/services/handoff.py
@@ -414,7 +414,7 @@ async def _maybe_emit_handoff_receipt(
         caller_type=caller_type,
     )
     written_id = await receipts_service.write_receipt(
-        session, receipt_body=body, as_of=as_of
+        session, receipt_body=body, as_of=as_of, tenant_config=tenant_config
     )
     return (written_id, written_id is not None)
 

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0020_receipts_retention"
+EXPECTED_HEAD = "0021_receipts_signature_keyid"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/server/services/receipts.py
+++ b/server/services/receipts.py
@@ -26,6 +26,8 @@ docs/state-assembly-receipts.md.
 from __future__ import annotations
 
 import hashlib
+import hmac
+import json
 import os
 import secrets
 import time
@@ -330,11 +332,25 @@ async def write_receipt(
     *,
     receipt_body: dict[str, Any],
     as_of: datetime,
+    tenant_config: dict[str, Any] | None = None,
 ) -> str | None:
     """Persist a receipt. Returns the receipt_id on success, None on
     failure. **Never raises** — receipt write failure must not break
-    agent serving (see docs/state-assembly-receipts.md → Failure mode)."""
+    agent serving (see docs/state-assembly-receipts.md → Failure mode).
+
+    When ``tenant_config`` carries ``receipt_signing_key_id`` AND the
+    referenced key is configured in ``settings.receipt_signing_keys``,
+    the body is signed via HMAC-SHA256 over its canonical v1 form
+    before persistence (v0.9 / issue #157). If signing is configured
+    but the key is unavailable, the receipt emits unsigned and a
+    `receipt_signing_key_unavailable` warning is logged — agent
+    serving is never blocked by audit infra."""
     try:
+        # In-place stamp `receipt_signature`, `receipt_signature_key_id`,
+        # and `receipt_signature_algorithm` on the body if signing
+        # applies. No-op for tenants without signing configured.
+        _apply_signature(receipt_body, tenant_config or {})
+
         row = ReceiptRow(
             receipt_id=receipt_body["receipt_id"],
             parent_receipt_id=receipt_body.get("parent_receipt_id"),
@@ -348,6 +364,8 @@ async def write_receipt(
             policy_bundle_hash=receipt_body["policy"].get("policy_bundle_hash"),
             region=receipt_body.get("region"),
             receipt_signature=receipt_body.get("receipt_signature"),
+            receipt_signature_key_id=receipt_body.get("receipt_signature_key_id"),
+            receipt_signature_algorithm=receipt_body.get("receipt_signature_algorithm"),
             body=receipt_body,
             as_of=as_of,
         )
@@ -473,3 +491,226 @@ async def cleanup_expired_receipts(session: AsyncSession) -> int:
     if total:
         logger.info("receipts_retention_tombstoned", count=total)
     return total
+
+
+# ---------------------------------------------------------------------------
+# HMAC signing & verification — v0.9 (issue #157)
+#
+# Receipts are immutable per-retrieval audit artifacts. v0.8 stored a
+# SHA-256 of the assembled context bytes inside the body, but the body
+# itself wasn't tamper-evident. v0.9 signs the body with HMAC-SHA256
+# under a tenant-scoped operator-provided key.
+#
+# Algorithm string is `hmac-sha256-canonical-v1` — algorithm + canonical
+# form version baked into one slot so a future migration (RFC 8785 JCS,
+# or asymmetric signing) lands as a new string without a schema break.
+#
+# The `receipt_signature` field is excluded from canonicalization
+# (signing a body that contains its own signature is circular). All
+# other fields — including `receipt_signature_key_id` and
+# `receipt_signature_algorithm` — are inside the signature's coverage,
+# so an attacker can't tell the verifier "this was signed by a
+# different key" without invalidating the signature.
+#
+# Keys never persist in the database. The dict lives in
+# `settings.receipt_signing_keys`, sourced from operator env / secret
+# manager at process startup, with the field marked `repr=False` so a
+# stray `print(settings)` cannot leak them.
+# ---------------------------------------------------------------------------
+
+
+#: The only signature algorithm + canonicalization variant v0.9 emits.
+#: Verify accepts the same. Future bumps (`-v2`, JCS, ed25519) extend
+#: this constant and the verify dispatch without a schema migration.
+SUPPORTED_SIGNATURE_ALGORITHM = "hmac-sha256-canonical-v1"
+
+#: Body fields excluded from canonicalization (the signature signs
+#: everything else). Wrapped in a frozenset for fast lookup.
+_UNSIGNED_BODY_FIELDS = frozenset({"receipt_signature"})
+
+
+def canonicalize_receipt_body_v1(body: dict[str, Any]) -> bytes:
+    """Stable byte representation of a receipt body for HMAC signing.
+
+    v1 = ``json.dumps(body_minus_signature, sort_keys=True,
+    separators=(",", ":"), ensure_ascii=False)`` UTF-8 encoded. Sorted
+    keys keep the bytes deterministic across Python dict-ordering
+    quirks; the compact separators eliminate whitespace ambiguity;
+    ``ensure_ascii=False`` keeps multi-byte content as its UTF-8
+    representation rather than \\uXXXX escapes (the body already
+    contains user content that may include non-ASCII).
+
+    The version string is baked into the algorithm tag stored on each
+    receipt, so a future move to RFC 8785 JCS or another canonical form
+    lands as ``canonicalize_receipt_body_v2`` + a new algorithm string,
+    with v1 still verifying historical receipts.
+    """
+    sanitized = {k: v for k, v in body.items() if k not in _UNSIGNED_BODY_FIELDS}
+    return json.dumps(
+        sanitized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def sign_receipt_body(body: dict[str, Any], key: bytes) -> str:
+    """Compute HMAC-SHA256 over the canonical v1 form of ``body``.
+
+    Returns the signature as a lowercase hex string (64 chars). The
+    raw key bytes are passed directly to ``hmac.new`` — never logged,
+    never serialised, never returned by any caller-visible surface.
+    """
+    canonical = canonicalize_receipt_body_v1(body)
+    return hmac.new(key, canonical, hashlib.sha256).hexdigest()
+
+
+def _apply_signature(
+    receipt_body: dict[str, Any],
+    tenant_config: dict[str, Any],
+) -> None:
+    """Sign ``receipt_body`` in place if the tenant has a key id configured
+    AND the key is resolvable from ``settings.receipt_signing_keys``.
+
+    Three terminal states:
+
+    - **Signed** — body gains ``receipt_signature``,
+      ``receipt_signature_key_id``, ``receipt_signature_algorithm``.
+    - **Configured but key unavailable** — body left unsigned; a
+      ``receipt_signing_key_unavailable`` warning is emitted with the
+      key_id only (never the key bytes). The verifier later reports
+      ``valid: null, reason: "key_unavailable"`` for this receipt.
+    - **Unconfigured** — body untouched. The verifier reports
+      ``valid: null, reason: "no_signature"``.
+
+    Signing failures past key resolution (an unlikely Python-level
+    error inside ``sign_receipt_body``) are swallowed with a warning
+    so the receipt still emits unsigned — agent serving must not be
+    blocked by audit infra.
+    """
+    key_id = tenant_config.get("receipt_signing_key_id") if tenant_config else None
+    if not key_id:
+        return  # tenant hasn't opted in
+
+    # Lazy import keeps the receipts module testable without booting
+    # the full Settings object.
+    from server.core.config import settings
+
+    keys_map = settings.receipt_signing_keys or {}
+    key = keys_map.get(key_id)
+    if key is None:
+        logger.warning(
+            "receipt_signing_key_unavailable",
+            tenant_id=receipt_body.get("tenant_id"),
+            key_id=key_id,
+        )
+        return
+
+    # Stamp the metadata BEFORE computing the signature so the key_id
+    # and algorithm are covered by the HMAC — an attacker who swaps
+    # them on a stored receipt then has to also rewrite the signature.
+    # On signing failure we roll back the stamps so the body persists
+    # in a consistent unsigned state.
+    receipt_body["receipt_signature_key_id"] = key_id
+    receipt_body["receipt_signature_algorithm"] = SUPPORTED_SIGNATURE_ALGORITHM
+    try:
+        signature = sign_receipt_body(receipt_body, key)
+    except Exception:
+        # Defensive: a hash computation should never fail at runtime,
+        # but if it does we emit unsigned + warn rather than fail the
+        # whole assembly.
+        receipt_body.pop("receipt_signature_key_id", None)
+        receipt_body.pop("receipt_signature_algorithm", None)
+        logger.warning(
+            "receipt_signing_failed",
+            tenant_id=receipt_body.get("tenant_id"),
+            key_id=key_id,
+            exc_info=True,
+        )
+        return
+
+    receipt_body["receipt_signature"] = signature
+
+
+def verify_receipt(
+    row: ReceiptRow,
+    *,
+    keys_map: dict[str, bytes] | None = None,
+) -> dict[str, Any]:
+    """Verify the HMAC signature on a stored receipt row.
+
+    Returns a dict with the shape documented in ``api/v1-contract.md``:
+
+        { "valid": True | False | None,
+          "key_id": "..." | None,
+          "algorithm": "..." | None,
+          "reason": "ok" | "signature_mismatch" | "key_unavailable"
+                    | "no_signature" | "unsupported_algorithm" }
+
+    ``valid: null`` covers the "cannot determine" cases (key was
+    removed from operator config, no signature present, or the
+    algorithm string names a variant this binary doesn't implement).
+    ``valid: false`` is reserved for "we checked the math and the
+    signature doesn't cover the body."
+
+    Comparison uses ``hmac.compare_digest`` for constant-time
+    behaviour against timing attacks. The signing key bytes never
+    appear in the response.
+
+    ``keys_map`` defaults to ``settings.receipt_signing_keys``;
+    overridable for tests.
+    """
+    # No-signature path — pre-v0.9 receipts or tenants that didn't
+    # opt in to signing. Distinct from `key_unavailable`: the receipt
+    # was never signed in the first place.
+    if not row.receipt_signature or not row.receipt_signature_key_id:
+        return {
+            "valid": None,
+            "key_id": None,
+            "algorithm": None,
+            "reason": "no_signature",
+        }
+
+    algorithm = row.receipt_signature_algorithm or SUPPORTED_SIGNATURE_ALGORITHM
+    if algorithm != SUPPORTED_SIGNATURE_ALGORITHM:
+        # Future-proofing: a receipt signed under `canonical-v2` or
+        # `ed25519-canonical-v1` on a newer server would land here on
+        # a v0.9 binary. Report explicitly rather than misleading the
+        # caller with `signature_mismatch`.
+        return {
+            "valid": None,
+            "key_id": row.receipt_signature_key_id,
+            "algorithm": algorithm,
+            "reason": "unsupported_algorithm",
+        }
+
+    if keys_map is None:
+        from server.core.config import settings
+
+        keys_map = settings.receipt_signing_keys or {}
+
+    key = keys_map.get(row.receipt_signature_key_id)
+    if key is None:
+        # Key rotated out of operator config; historical receipt is
+        # no longer verifiable on this binary. Never a 500.
+        return {
+            "valid": None,
+            "key_id": row.receipt_signature_key_id,
+            "algorithm": algorithm,
+            "reason": "key_unavailable",
+        }
+
+    expected = sign_receipt_body(row.body, key)
+    if hmac.compare_digest(expected, row.receipt_signature):
+        return {
+            "valid": True,
+            "key_id": row.receipt_signature_key_id,
+            "algorithm": algorithm,
+            "reason": "ok",
+        }
+    return {
+        "valid": False,
+        "key_id": row.receipt_signature_key_id,
+        "algorithm": algorithm,
+        "reason": "signature_mismatch",
+    }

--- a/tests/integration/test_receipts_signing.py
+++ b/tests/integration/test_receipts_signing.py
@@ -1,0 +1,558 @@
+"""Integration tests for HMAC receipt signing (v0.9, issue #157).
+
+Covers four layers:
+
+1. **Pure crypto** — `canonicalize_receipt_body_v1`, `sign_receipt_body`,
+   `verify_receipt` with stand-in row objects. No DB, no config.
+2. **Config parsing** — `STATEWAVE_RECEIPT_SIGNING_KEYS` validator
+   rejects malformed input at startup (base64 errors, short keys,
+   wrong types, malformed JSON).
+3. **Emission integration** — `write_receipt` signs when the tenant
+   has a key id and the key is available; emits unsigned otherwise.
+4. **Verify endpoint + security** — `GET /v1/receipts/{id}/verify`
+   returns the documented shape; signing keys never appear in logs
+   or admin responses; rotation flow works.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import secrets
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from server.core.config import Settings, settings
+from server.db.tables import ReceiptRow, TenantConfigRow
+from server.services.receipts import (
+    SUPPORTED_SIGNATURE_ALGORITHM,
+    canonicalize_receipt_body_v1,
+    new_ulid,
+    sign_receipt_body,
+    verify_receipt,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _gen_key(n_bytes: int = 32) -> bytes:
+    return secrets.token_bytes(n_bytes)
+
+
+def _b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+def _make_row(
+    body: dict,
+    *,
+    signature: str | None,
+    key_id: str | None,
+    algorithm: str | None = SUPPORTED_SIGNATURE_ALGORITHM,
+) -> ReceiptRow:
+    """A free-standing ReceiptRow for unit-testing verify_receipt without DB."""
+    return ReceiptRow(
+        receipt_id=body.get("receipt_id", new_ulid()),
+        parent_receipt_id=None,
+        mode="retrieval",
+        tenant_id=body.get("tenant_id"),
+        subject_id=body.get("subject_id", "sub-1"),
+        query_id=None,
+        task_id=None,
+        context_hash=body.get("output", {}).get("context_hash", "0" * 64),
+        context_size_bytes=body.get("output", {}).get("context_size_bytes", 0),
+        policy_bundle_hash=None,
+        region=None,
+        receipt_signature=signature,
+        receipt_signature_key_id=key_id,
+        receipt_signature_algorithm=algorithm if signature else None,
+        body=body,
+        as_of=datetime.now(timezone.utc),
+        status="active",
+    )
+
+
+def _seed_body(**overrides) -> dict:
+    """A minimally-valid receipt body suitable for signing/verifying."""
+    rid = overrides.pop("receipt_id", new_ulid())
+    base = {
+        "receipt_id": rid,
+        "mode": "retrieval",
+        "tenant_id": "tenant-x",
+        "subject_id": "sub-x",
+        "selected_entries": [],
+        "policy": {"filters_applied": [], "filters_skipped": [], "mode": "log_only"},
+        "output": {
+            "context_hash": "0" * 64,
+            "context_size_bytes": 0,
+            "canonicalization_version": 1,
+            "token_estimate": 0,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure crypto — canonicalization
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalize_is_deterministic():
+    body = _seed_body(subject_id="u1")
+    assert canonicalize_receipt_body_v1(body) == canonicalize_receipt_body_v1(body)
+
+
+def test_canonicalize_is_order_independent_for_keys():
+    """Sorted keys means dict-insertion order can't change the bytes."""
+    a = _seed_body(subject_id="u1")
+    b = {k: a[k] for k in reversed(list(a.keys()))}
+    assert canonicalize_receipt_body_v1(a) == canonicalize_receipt_body_v1(b)
+
+
+def test_canonicalize_excludes_receipt_signature_field():
+    """Signing a body that contains its own signature is circular —
+    the canonical form strips `receipt_signature` so the signature can
+    be embedded into the body afterwards."""
+    body_unsigned = _seed_body()
+    canonical = canonicalize_receipt_body_v1(body_unsigned)
+    body_signed = dict(body_unsigned)
+    body_signed["receipt_signature"] = "deadbeef"
+    assert canonicalize_receipt_body_v1(body_signed) == canonical
+
+
+def test_canonicalize_covers_key_id_and_algorithm():
+    """An attacker swapping key_id or algorithm on a stored receipt
+    body must invalidate the signature — those fields are inside the
+    canonical form."""
+    body = _seed_body(
+        receipt_signature_key_id="key-A",
+        receipt_signature_algorithm=SUPPORTED_SIGNATURE_ALGORITHM,
+    )
+    swapped = dict(body)
+    swapped["receipt_signature_key_id"] = "key-B"
+    assert canonicalize_receipt_body_v1(body) != canonicalize_receipt_body_v1(swapped)
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure crypto — sign / verify
+# ---------------------------------------------------------------------------
+
+
+def test_sign_then_verify_round_trips():
+    key = _gen_key()
+    body = _seed_body()
+    sig = sign_receipt_body(body, key)
+    body["receipt_signature"] = sig
+    row = _make_row(body, signature=sig, key_id="key-1")
+    result = verify_receipt(row, keys_map={"key-1": key})
+    assert result == {
+        "valid": True,
+        "key_id": "key-1",
+        "algorithm": SUPPORTED_SIGNATURE_ALGORITHM,
+        "reason": "ok",
+    }
+
+
+def test_tampered_subject_id_invalidates_signature():
+    key = _gen_key()
+    body = _seed_body(subject_id="alice")
+    sig = sign_receipt_body(body, key)
+    body["receipt_signature"] = sig
+    body["subject_id"] = "mallory"  # tampered after signing
+    row = _make_row(body, signature=sig, key_id="key-1")
+    result = verify_receipt(row, keys_map={"key-1": key})
+    assert result["valid"] is False
+    assert result["reason"] == "signature_mismatch"
+
+
+def test_tampered_context_hash_invalidates_signature():
+    key = _gen_key()
+    body = _seed_body()
+    sig = sign_receipt_body(body, key)
+    body["receipt_signature"] = sig
+    body["output"]["context_hash"] = "f" * 64  # tampered
+    row = _make_row(body, signature=sig, key_id="key-1")
+    assert verify_receipt(row, keys_map={"key-1": key})["valid"] is False
+
+
+def test_verify_no_signature_for_unsigned_row():
+    body = _seed_body()
+    row = _make_row(body, signature=None, key_id=None, algorithm=None)
+    result = verify_receipt(row, keys_map={})
+    assert result == {
+        "valid": None,
+        "key_id": None,
+        "algorithm": None,
+        "reason": "no_signature",
+    }
+
+
+def test_verify_key_unavailable_when_operator_dropped_the_key():
+    """Historical receipt + key rotated out → verify reports the reason
+    distinctly, never a 500."""
+    key = _gen_key()
+    body = _seed_body()
+    sig = sign_receipt_body(body, key)
+    body["receipt_signature"] = sig
+    row = _make_row(body, signature=sig, key_id="key-rotated-out")
+    result = verify_receipt(row, keys_map={})  # operator removed the key
+    assert result == {
+        "valid": None,
+        "key_id": "key-rotated-out",
+        "algorithm": SUPPORTED_SIGNATURE_ALGORITHM,
+        "reason": "key_unavailable",
+    }
+
+
+def test_verify_unsupported_algorithm_reports_explicitly():
+    """A future receipt signed with `canonical-v2` would land on a v0.9
+    binary like this — distinct from signature_mismatch."""
+    body = _seed_body()
+    row = _make_row(body, signature="ff" * 32, key_id="key-1", algorithm="hmac-sha256-canonical-v999")
+    result = verify_receipt(row, keys_map={"key-1": _gen_key()})
+    assert result["valid"] is None
+    assert result["reason"] == "unsupported_algorithm"
+
+
+# ---------------------------------------------------------------------------
+# 2. Config parsing — fails fast on bad input at startup
+# ---------------------------------------------------------------------------
+
+
+def test_config_accepts_valid_base64_dict():
+    key = _gen_key()
+    s = Settings(receipt_signing_keys={"k1": _b64(key)})
+    assert s.receipt_signing_keys == {"k1": key}
+
+
+def test_config_accepts_json_string():
+    key = _gen_key()
+    s = Settings(receipt_signing_keys=f'{{"k1": "{_b64(key)}"}}')
+    assert s.receipt_signing_keys == {"k1": key}
+
+
+def test_config_rejects_short_key():
+    too_short = _b64(_gen_key(16))  # 16 bytes < 32-byte minimum
+    with pytest.raises(ValidationError, match="too short"):
+        Settings(receipt_signing_keys={"k1": too_short})
+
+
+def test_config_rejects_non_base64():
+    with pytest.raises(ValidationError, match="not valid base64"):
+        Settings(receipt_signing_keys={"k1": "!!!not-base64!!!"})
+
+
+def test_config_rejects_malformed_json():
+    with pytest.raises(ValidationError, match="not valid JSON"):
+        Settings(receipt_signing_keys="not-json")
+
+
+def test_config_rejects_non_object_json():
+    with pytest.raises(ValidationError, match="JSON object"):
+        Settings(receipt_signing_keys='["k1", "k2"]')
+
+
+def test_config_rejects_empty_key_id():
+    with pytest.raises(ValidationError, match="non-empty string"):
+        Settings(receipt_signing_keys={"": _b64(_gen_key())})
+
+
+def test_config_empty_means_no_signing():
+    s = Settings(receipt_signing_keys="")
+    assert s.receipt_signing_keys == {}
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end via the `/v1/context` API: emission signs + verify works
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant_signing(
+    session_factory,
+    tenant_id: str,
+    key_id: str | None,
+) -> None:
+    """Set `tenant_configs.config.receipt_signing_key_id` and force
+    receipts to emit (`receipts: always`) so tests don't need to also
+    flip the per-request opt-in."""
+    async with session_factory() as session:
+        existing = await session.get(TenantConfigRow, tenant_id)
+        cfg: dict = {"receipts": "always"}
+        if key_id is not None:
+            cfg["receipt_signing_key_id"] = key_id
+        if existing is None:
+            session.add(TenantConfigRow(tenant_id=tenant_id, config=cfg, version=1))
+        else:
+            merged = dict(existing.config or {})
+            merged.update(cfg)
+            existing.config = merged
+            existing.version = (existing.version or 0) + 1
+        await session.commit()
+
+
+@pytest.fixture
+def operator_keys(monkeypatch):
+    """Configure a pair of operator signing keys on the global Settings
+    singleton for the duration of one test. The settings object is the
+    one `_apply_signature` reads via lazy import."""
+    keys = {"key-2026-01": _gen_key(), "key-2026-02": _gen_key()}
+    monkeypatch.setattr(settings, "receipt_signing_keys", dict(keys))
+    yield keys
+
+
+async def _emit_context_receipt(client, *, tenant: str, subject: str) -> str:
+    """POST /v1/context with emit_receipt=true; return the receipt_id."""
+    resp = await client.post(
+        "/v1/context",
+        json={"subject_id": subject, "task": "test signing flow", "emit_receipt": True},
+        headers={"X-Tenant-ID": tenant},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body.get("receipt_id"), f"emit_receipt=true did not produce a receipt: {body}"
+    return body["receipt_id"]
+
+
+async def test_signed_receipt_verifies_ok_end_to_end(
+    client, session_factory, subject_id, operator_keys
+):
+    tenant = f"tenant-sig-{uuid.uuid4().hex[:6]}"
+    await _seed_tenant_signing(session_factory, tenant, "key-2026-01")
+
+    rid = await _emit_context_receipt(client, tenant=tenant, subject=subject_id)
+
+    resp = await client.get(
+        f"/v1/receipts/{rid}/verify", headers={"X-Tenant-ID": tenant}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is True
+    assert body["reason"] == "ok"
+    assert body["key_id"] == "key-2026-01"
+    assert body["algorithm"] == SUPPORTED_SIGNATURE_ALGORITHM
+
+
+async def test_tenant_without_signing_emits_unsigned_receipt(
+    client, session_factory, subject_id, operator_keys
+):
+    """Tenant has no `receipt_signing_key_id` configured → receipt
+    emits unsigned, verify reports `no_signature` cleanly."""
+    tenant = f"tenant-unsigned-{uuid.uuid4().hex[:6]}"
+    # Receipts forced on, but no signing_key_id set
+    await _seed_tenant_signing(session_factory, tenant, key_id=None)
+
+    rid = await _emit_context_receipt(client, tenant=tenant, subject=subject_id)
+
+    resp = await client.get(
+        f"/v1/receipts/{rid}/verify", headers={"X-Tenant-ID": tenant}
+    )
+    body = resp.json()
+    assert body["valid"] is None
+    assert body["reason"] == "no_signature"
+    assert body["key_id"] is None
+
+
+async def test_tenant_signing_with_missing_key_emits_unsigned_and_warns(
+    client, session_factory, subject_id, operator_keys, caplog
+):
+    """Tenant points at a key_id the operator hasn't loaded in this
+    process. Per the failure-mode rule, the receipt still emits — just
+    unsigned — and a structured warning fires."""
+    tenant = f"tenant-missing-key-{uuid.uuid4().hex[:6]}"
+    await _seed_tenant_signing(session_factory, tenant, "key-not-loaded")
+
+    with caplog.at_level(logging.WARNING):
+        rid = await _emit_context_receipt(client, tenant=tenant, subject=subject_id)
+
+    # Receipt exists, no signature.
+    resp = await client.get(
+        f"/v1/receipts/{rid}/verify", headers={"X-Tenant-ID": tenant}
+    )
+    assert resp.json()["reason"] == "no_signature"
+
+    # Warning was emitted with key_id but never raw key bytes.
+    warned = " ".join(r.getMessage() for r in caplog.records)
+    assert "receipt_signing_key_unavailable" in warned
+    assert "key-not-loaded" in warned
+
+
+async def test_tampered_signed_receipt_verifies_false(
+    client, session_factory, subject_id, operator_keys
+):
+    """End-to-end: tamper directly in the DB body, verify reports
+    signature_mismatch — proving the body is signature-covered."""
+    tenant = f"tenant-tamper-{uuid.uuid4().hex[:6]}"
+    await _seed_tenant_signing(session_factory, tenant, "key-2026-01")
+    rid = await _emit_context_receipt(client, tenant=tenant, subject=subject_id)
+
+    # Surgically tamper inside the body.
+    async with session_factory() as session:
+        row = await session.get(ReceiptRow, rid)
+        tampered_body = dict(row.body)
+        tampered_body["subject_id"] = "different-subject"
+        row.body = tampered_body
+        await session.commit()
+
+    resp = await client.get(
+        f"/v1/receipts/{rid}/verify", headers={"X-Tenant-ID": tenant}
+    )
+    body = resp.json()
+    assert body["valid"] is False
+    assert body["reason"] == "signature_mismatch"
+
+
+async def test_key_rotation_old_receipts_still_verify(
+    client, session_factory, subject_id, operator_keys, monkeypatch
+):
+    """Rotation flow: tenant moves from `key-2026-01` → `key-2026-02`.
+    Receipts emitted under the old key remain verifiable as long as the
+    old key is still configured."""
+    tenant = f"tenant-rotate-{uuid.uuid4().hex[:6]}"
+
+    # Emit under key-2026-01.
+    await _seed_tenant_signing(session_factory, tenant, "key-2026-01")
+    old_rid = await _emit_context_receipt(client, tenant=tenant, subject=subject_id)
+
+    # Rotate the tenant pointer to key-2026-02 (both keys still loaded).
+    await _seed_tenant_signing(session_factory, tenant, "key-2026-02")
+    new_rid = await _emit_context_receipt(client, tenant=tenant, subject=subject_id)
+
+    # Both verify ok with the right key ids.
+    for rid, expected_kid in [(old_rid, "key-2026-01"), (new_rid, "key-2026-02")]:
+        resp = await client.get(
+            f"/v1/receipts/{rid}/verify", headers={"X-Tenant-ID": tenant}
+        )
+        body = resp.json()
+        assert body["valid"] is True
+        assert body["key_id"] == expected_kid
+
+
+async def test_rotated_out_key_returns_key_unavailable(
+    client, session_factory, subject_id, monkeypatch
+):
+    """Operator removes the old key from config → historical receipts
+    signed with it report `key_unavailable`, never crash."""
+    # Two keys loaded initially.
+    initial_keys = {"key-temp": _gen_key(), "key-survivor": _gen_key()}
+    monkeypatch.setattr(settings, "receipt_signing_keys", dict(initial_keys))
+
+    tenant = f"tenant-rotated-out-{uuid.uuid4().hex[:6]}"
+    await _seed_tenant_signing(session_factory, tenant, "key-temp")
+    rid = await _emit_context_receipt(client, tenant=tenant, subject=subject_id)
+
+    # Drop the temp key from operator config.
+    monkeypatch.setattr(settings, "receipt_signing_keys", {"key-survivor": initial_keys["key-survivor"]})
+
+    resp = await client.get(
+        f"/v1/receipts/{rid}/verify", headers={"X-Tenant-ID": tenant}
+    )
+    body = resp.json()
+    assert body["valid"] is None
+    assert body["reason"] == "key_unavailable"
+    assert body["key_id"] == "key-temp"
+
+
+# ---------------------------------------------------------------------------
+# 4. Security — no key material in logs or responses
+# ---------------------------------------------------------------------------
+
+
+async def test_signing_keys_never_appear_in_logs(
+    client, session_factory, subject_id, operator_keys, caplog
+):
+    """End-to-end caplog scan: emit a receipt under a configured key,
+    verify it, tamper + re-verify, hit the missing-key path. None of
+    those flows should leak the key bytes (or even their hex/base64
+    rendering) into structured logs."""
+    tenant = f"tenant-keylogs-{uuid.uuid4().hex[:6]}"
+    await _seed_tenant_signing(session_factory, tenant, "key-2026-01")
+    key_bytes = operator_keys["key-2026-01"]
+    key_hex = key_bytes.hex()
+    key_b64 = _b64(key_bytes)
+
+    with caplog.at_level(logging.DEBUG):
+        rid = await _emit_context_receipt(client, tenant=tenant, subject=subject_id)
+        await client.get(f"/v1/receipts/{rid}/verify", headers={"X-Tenant-ID": tenant})
+
+        # Tamper + re-verify
+        async with session_factory() as session:
+            row = await session.get(ReceiptRow, rid)
+            tampered = dict(row.body)
+            tampered["subject_id"] = "evil"
+            row.body = tampered
+            await session.commit()
+        await client.get(f"/v1/receipts/{rid}/verify", headers={"X-Tenant-ID": tenant})
+
+    all_log_text = " ".join(r.getMessage() for r in caplog.records)
+    assert key_hex not in all_log_text, "Raw key hex must never appear in logs"
+    assert key_b64 not in all_log_text, "Base64 key must never appear in logs"
+    # Sanity — we DID actually log something during the flow.
+    assert caplog.records, "log capture didn't see any records"
+
+
+async def test_verify_response_never_echoes_key_material(
+    client, session_factory, subject_id, operator_keys
+):
+    """The verify endpoint must surface validity + key_id name + algorithm,
+    but never the key bytes, a hash of them, or any field whose value
+    matches the raw key."""
+    tenant = f"tenant-resp-{uuid.uuid4().hex[:6]}"
+    await _seed_tenant_signing(session_factory, tenant, "key-2026-01")
+    rid = await _emit_context_receipt(client, tenant=tenant, subject=subject_id)
+
+    resp = await client.get(
+        f"/v1/receipts/{rid}/verify", headers={"X-Tenant-ID": tenant}
+    )
+    body = resp.json()
+
+    raw_key = operator_keys["key-2026-01"]
+    serialised = str(body)
+    assert raw_key.hex() not in serialised
+    assert _b64(raw_key) not in serialised
+    # And the response shape is just the documented fields — no surprise
+    # bonus key-derivative field.
+    assert set(body.keys()) == {"valid", "key_id", "algorithm", "reason"}
+
+
+def test_settings_repr_does_not_leak_signing_keys():
+    """The field is declared `repr=False` so a stray `print(settings)`
+    or pydantic error wrapping the model can't accidentally dump the
+    operator's raw key bytes."""
+    key = _gen_key()
+    s = Settings(receipt_signing_keys={"k1": _b64(key)})
+    rendered = repr(s)
+    assert "receipt_signing_keys" not in rendered
+    assert key.hex() not in rendered
+    assert _b64(key) not in rendered
+
+
+# ---------------------------------------------------------------------------
+# 4. Security — `unset` env produces no signing without warning noise
+# ---------------------------------------------------------------------------
+
+
+def test_unset_env_means_no_signing_no_error():
+    """A deployment that hasn't opted into signing must boot cleanly
+    and emit unsigned receipts without any startup error or noise."""
+    # The default settings have no signing keys.
+    s = Settings()
+    assert s.receipt_signing_keys == {}
+
+
+def test_env_var_path_parses_real_env(monkeypatch):
+    """Confirm the pydantic-settings env path goes through the
+    validator the same way the in-process dict path does."""
+    key = _gen_key()
+    monkeypatch.setenv(
+        "STATEWAVE_RECEIPT_SIGNING_KEYS", f'{{"k1": "{_b64(key)}"}}'
+    )
+    # Force pydantic-settings to read fresh from env.
+    s = Settings()
+    assert s.receipt_signing_keys == {"k1": key}

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 20
+    assert len(revs) == 21
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 10
+    assert result.pending_count == 11
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 20
+    assert result.pending_count == 21
 
 
 def test_resolve_pending_unknown_revision():


### PR DESCRIPTION
## v0.9 PR 2 — HMAC-signed receipts (security)

Closes [#157](https://github.com/smaramwbc/statewave/issues/157). Second of the v0.9 server PRs.

This is the security one. Designs you signed off on the prior checkpoint are wired in exactly as approved, with the failure-mode refinement you proposed.

### What ships

- **Algorithm**: HMAC-SHA256 over canonical v1 form of the receipt body — sorted keys, no whitespace, UTF-8, `ensure_ascii=False`, `receipt_signature` excluded from canonicalization (signing-circularity fix). Stored as `hmac-sha256-canonical-v1` so a later RFC 8785 JCS or asymmetric variant extends the schema without breaking historical verifies.
- **Key storage**: `STATEWAVE_RECEIPT_SIGNING_KEYS='{"<key_id>": "<base64-32B+>", ...}'`, parsed once at startup, base64-decoded, ≥32-byte minimum enforced. **Never persisted to the DB.** Field is `Field(repr=False)` so a stray `print(settings)` can't leak it. Lazy-imported into the signing path so the keys live in process memory only.
- **Per-tenant active pointer**: `tenant_configs.config.receipt_signing_key_id`. Receipts sign when the tenant has a key_id AND the operator has loaded that key_id.
- **Coverage**: `receipt_signature_key_id` and `receipt_signature_algorithm` are **inside** the HMAC's coverage. Only `receipt_signature` itself is excluded from canonicalization. An attacker swapping the key_id on a stored row invalidates the signature.
- **Failure mode** (your refinement applied):
  - Invalid config at startup → **fail boot** (bad JSON, short key, base64 corruption — validators surface all of these as `ValidationError` from `Settings`).
  - Runtime signing failure (missing tenant active key, hash error) → emit receipt **unsigned**, log `receipt_signing_key_unavailable` / `receipt_signing_failed` warning, verify reports the right `reason`.
  - **Assembly serving is never blocked by audit infrastructure.**
- **New endpoint** `GET /v1/receipts/{id}/verify`:
  ```json
  { "valid": true | false | null,
    "key_id": "<operator key_id>" | null,
    "algorithm": "hmac-sha256-canonical-v1" | null,
    "reason": "ok" | "signature_mismatch" | "key_unavailable"
            | "no_signature" | "unsupported_algorithm" }
  ```
  `valid: null` distinguishes "couldn't determine" cases from `valid: false` ("checked the math; doesn't cover the body"). The response **never** returns key bytes, hash of them, or a length hint. Verify uses `hmac.compare_digest` for constant-time comparison.

### Changes

| File | Change |
|---|---|
| `alembic/versions/0021_receipts_signature_keyid.py` | Adds `receipts.receipt_signature_key_id` (varchar 64) + `receipts.receipt_signature_algorithm` (varchar 64). Both nullable. Reversible. |
| `server/db/tables.py` | ORM mappings for the two new columns. |
| `server/core/config.py` | `receipt_signing_keys` field + `_parse_receipt_signing_keys` validator (JSON-or-dict input, base64 per key, ≥32-byte minimum, empty-key-id rejection, malformed-JSON rejection). `repr=False`. |
| `server/services/receipts.py` | `SUPPORTED_SIGNATURE_ALGORITHM` constant; `canonicalize_receipt_body_v1`, `sign_receipt_body`, `verify_receipt`, `_apply_signature` helper; `write_receipt` accepts `tenant_config` and invokes `_apply_signature` before persistence. |
| `server/services/context.py` + `handoff.py` | Both call sites pass `tenant_config=` through to `write_receipt` (already loaded for the emission decision; no extra DB roundtrip). |
| `server/api/receipts.py` | `GET /v1/receipts/{id}/verify` endpoint. |
| `server/services/migrations.py` + `tests/test_migrations.py` | `EXPECTED_HEAD` → `0021_receipts_signature_keyid`; pending counts updated. |
| `docs/state-assembly-receipts.md` | New "HMAC signing (v0.9)" section explaining config, failure modes, rotation, and verify-response shape. "HMAC signing (column reserved, no signing path)" out-of-scope bullet removed; new bullets added for KMS, asymmetric, bulk re-signing follow-ups. |
| `README.md` | `STATEWAVE_RECEIPT_SIGNING_KEYS` in the env-reference table. |

### Tests — 29 new in `tests/integration/test_receipts_signing.py`

**Pure crypto** (4 tests) — canonicalization determinism, key-order independence, `receipt_signature` exclusion, key_id/algorithm coverage. **Sign + verify** (5) — round-trip, tampered subject_id fails, tampered context_hash fails, no-signature path, key-unavailable path, unsupported-algorithm path.

**Config** (8) — valid base64, valid JSON env, short-key rejection, non-base64 rejection, malformed-JSON rejection, non-object-JSON rejection, empty-key-id rejection, empty-config-means-no-signing.

**End-to-end via `/v1/context`** (5) — signed receipt verifies ok; tenant without signing emits unsigned and verifies as `no_signature`; tenant with missing key emits unsigned + warns + verifies as `no_signature` (per the runtime-failure rule); tampered DB body verifies as `signature_mismatch`; key-rotation flow (two keys loaded, tenant pointer switched mid-stream — old + new receipts both verify with their respective key_ids); key rotated out of config → `key_unavailable`, never a crash.

**Security** (5) — caplog scan: raw key bytes / hex / base64 never appear in logs across emit+verify+tamper+rotate; verify-response shape exactly `{valid, key_id, algorithm, reason}` with no surprise key-derivative field; `repr(settings)` doesn't leak signing keys; unset env means no signing without startup error; real env path parses through the validator.

### Validation

```
ruff check server/ tests/                          # All checks passed
pytest tests/test_*.py                              # 661 passed, 1 skipped
pytest tests/integration/                           # 162 passed (133 prior + 29 new)
alembic upgrade head                                # 0020 → 0021 clean
```

### Backward compatibility

- Tenants without signing configured see no change.
- Pre-v0.9 receipts have NULL `receipt_signature_*` columns and verify as `no_signature`.
- New body fields (`receipt_signature_key_id`, `receipt_signature_algorithm`) are additive; Pydantic-based SDKs ignore unknowns by default; pre-v0.9 SDK callers see the existing `receipt_signature` field unchanged.
- `write_receipt`'s new `tenant_config` kwarg defaults to `None`; legacy callers (tests, scripts) work without modification.

### Out of scope for v0.9 (deferred — design preserves the extension seams)

- KMS / Vault-backed signing. Architecture is compatible — a future PR swaps the key resolver behind the same `receipt_signing_keys` settings field.
- Asymmetric signatures (`ed25519-canonical-v1`). The `algorithm` field already supports it.
- Bulk re-signing of pre-v0.9 receipts. Forward-only signing — historical receipts verify as `no_signature`.

### Next up

PR 3 — auto-labeling pipeline ([#158](https://github.com/smaramwbc/statewave/issues/158)).
