### PR TITLE
feat(auto-labeling): heuristic suggested-label pipeline (closes #158)

### DIFF
--- a/alembic/versions/0022_memories_suggested_labels.py
+++ b/alembic/versions/0022_memories_suggested_labels.py
@@ -1,0 +1,72 @@
+"""memories.suggested_labels — heuristic-derived label hints, separate
+from authoritative sensitivity_labels (v0.9 #158).
+
+Revision ID: 0022_memories_suggested_labels
+Revises: 0021_receipts_signature_keyid
+Create Date: 2026-05-25
+
+v0.8 introduced ``memories.sensitivity_labels`` (0018) as the tenant-
+authoritative input to the policy evaluator. v0.9 (#158) adds an
+*orthogonal* second column, ``memories.suggested_labels``, populated
+automatically by detector heuristics at ingest time.
+
+The split is deliberate and load-bearing:
+
+  * ``sensitivity_labels`` are the source of truth the policy bundle
+    reads on the hot assembly path. Tenants own them; only humans (or
+    explicit tenant SDK calls) write them.
+
+  * ``suggested_labels`` are advisory. The compiler stamps them when
+    a detector matches at ingest. The policy evaluator never reads
+    them. Nothing destructive (retention, redaction, refusal) keys
+    off them in v0.9. They exist so an operator UI can review and
+    promote/dismiss them into ``sensitivity_labels`` later.
+
+This separation means a noisy detector can never tighten policy on
+real traffic — the worst it can do is surface a noisy suggestion in
+the admin UI. Promotion is a deliberate, auditable action.
+
+Both columns share the same shape (TEXT[] with `'{}'::text[]` default,
+GIN index for overlap queries) so the eventual promotion path is a
+trivial array assignment. The GIN index supports the admin endpoint
+``GET /admin/memories/with-suggested-labels`` which surfaces every
+memory carrying at least one suggestion, keyed off
+``suggested_labels && '{<label>}'``.
+
+Reverse-compatible: downgrade drops the column and its index.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import ARRAY
+
+
+revision: str = "0022_memories_suggested_labels"
+down_revision: Union[str, None] = "0021_receipts_signature_keyid"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "memories",
+        sa.Column(
+            "suggested_labels",
+            ARRAY(sa.String()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+    )
+    op.create_index(
+        "ix_memories_suggested_labels",
+        "memories",
+        ["suggested_labels"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_memories_suggested_labels", table_name="memories")
+    op.drop_column("memories", "suggested_labels")

--- a/docs/auto-labeling.md
+++ b/docs/auto-labeling.md
@@ -1,0 +1,146 @@
+# Auto-labeling
+
+Heuristic detectors that stamp advisory **suggested_labels** on
+memories at compile time. Introduced in **v0.9 (issue #158)** as the
+ingest-time half of Statewave's governance story; the runtime half is
+the authoritative `sensitivity_labels` column the policy evaluator
+reads on every assembly call.
+
+## The two columns
+
+Statewave tracks **two** label columns on `memories`:
+
+| Column                | Source              | Read by policy? | Mutable by detectors? |
+|-----------------------|---------------------|-----------------|------------------------|
+| `sensitivity_labels`  | Tenant (explicit)   | ✅ Yes          | ❌ Never               |
+| `suggested_labels`    | Auto-labeling       | ❌ Never        | ✅ At compile time     |
+
+The split is deliberate. Suggestions are *advisory* — surfaced for
+operator review but never used to gate retrieval, refuse a request,
+or change retention. A noisy detector cannot tighten policy on real
+traffic; the worst it can do is produce a noisy suggestion in the
+admin UI. Promotion into the authoritative column is a deliberate,
+audited operator action (admin UI / SDK call); v0.9 ships review
+only and the promotion endpoint lands in a follow-up.
+
+## Enabling
+
+Auto-labeling is **off by default** so a v0.9 upgrade is a no-op for
+existing tenants. To enable it process-wide:
+
+```bash
+STATEWAVE_AUTO_LABELING_ENABLED=true
+STATEWAVE_AUTO_LABELING_PROVIDER=heuristic   # the only v0.9 provider
+```
+
+With the flag on, both compilers (`heuristic` and `llm`) run the
+pipeline after MemoryRow construction. The detector pass is in-process
+and adds a sub-millisecond hop per memory; there is no network call.
+
+## Label schema
+
+Suggested labels follow `<category>.<specific>`:
+
+| Label              | What it flags                                              |
+|--------------------|-------------------------------------------------------------|
+| `pii.email`        | RFC-5322-ish email addresses                                |
+| `pii.phone`        | E.164 international numbers or grouped national US/EU forms |
+| `financial.card`   | 13–19 digit runs that pass the Luhn checksum                |
+| `secret.token`     | Known-provider API keys (AWS, GitHub, OpenAI, Google,        |
+|                    | Slack) or bearer JWTs                                       |
+
+The catalogue is also returned by
+`GET /admin/memories/with-suggested-labels` so an admin UI can build
+filter dropdowns without hard-coding the list.
+
+## Example: pipeline output
+
+Given an episode containing
+
+> "Reach me at alice@example.com or +1 415 555 0199. Card on file is
+> 4111-1111-1111-1111."
+
+a `MemoryRow` derived from that text will be stamped with:
+
+```json
+{
+  "suggested_labels": ["financial.card", "pii.email", "pii.phone"],
+  "sensitivity_labels": []
+}
+```
+
+`sensitivity_labels` stays empty unless an operator promotes the
+suggestions or the tenant set them explicitly.
+
+## Reviewing suggestions
+
+```http
+GET /admin/memories/with-suggested-labels
+    ?subject_id=<id>          # optional
+    &tenant_id=<id>           # optional
+    &label=pii.email          # optional — narrows to one detector
+    &limit=50&offset=0
+```
+
+Response shape:
+
+```json
+{
+  "memories": [
+    {
+      "id": "...",
+      "subject_id": "...",
+      "tenant_id": null,
+      "kind": "profile_fact",
+      "content": "alice@example.com",
+      "summary": "alice email",
+      "suggested_labels": ["pii.email"],
+      "sensitivity_labels": [],
+      "created_at": "..."
+    }
+  ],
+  "total": 1,
+  "limit": 50,
+  "offset": 0,
+  "catalogue": [
+    {"label": "pii.email",      "description": "Email address ..."},
+    {"label": "pii.phone",      "description": "Phone number ..."},
+    {"label": "financial.card", "description": "Credit-card-shaped ..."},
+    {"label": "secret.token",   "description": "Known-provider API key ..."}
+  ]
+}
+```
+
+The filter is GIN-indexed (migration 0022), so the `label=` overlap
+path is cheap even on millions of memories.
+
+## What auto-labeling does **NOT** do (v0.9)
+
+* **Does not refuse or filter retrieval.** The policy evaluator
+  ignores `suggested_labels`.
+* **Does not change retention.** Memory TTL and the receipt
+  retention worker do not key off suggestions.
+* **Does not redact content.** Detectors are read-only; the memory
+  body is preserved verbatim.
+* **Does not promote suggestions automatically.** Promotion into
+  `sensitivity_labels` is operator-driven.
+
+These constraints are tested in
+`tests/integration/test_auto_labeling.py::test_auto_labeling_never_writes_sensitivity_labels`
+and are load-bearing for the governance story.
+
+## Adding a detector
+
+1. Add a pure `detect(text) -> bool` predicate in
+   `server/services/auto_labeling/detectors.py`.
+2. Wrap it in a `Detector` dataclass with a `<category>.<specific>`
+   label and a one-line description.
+3. Append the dataclass to the `DETECTORS` tuple.
+4. Add positive + negative unit tests in
+   `tests/test_auto_labeling.py` and update the registry assertion
+   if you intend the new label to be part of the v0.9 contract.
+
+Detectors should bias toward **precision over recall**: a false
+positive is a noisy admin row; a flood of false positives undermines
+operator trust in the column. Real low-recall gaps are recoverable
+by an operator labelling the row by hand.

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -93,6 +93,35 @@ class MemoryListResponse(BaseModel):
     offset: int
 
 
+class SuggestedLabelMemoryItem(BaseModel):
+    """Memory row enriched with its auto-labeling suggestions.
+
+    Surface for the admin review endpoint that powers the
+    "promote suggested labels into authoritative sensitivity_labels"
+    operator workflow (v0.9, issue #158). `sensitivity_labels` is
+    included so the UI can show what's already authoritative next to
+    what the detectors propose adding.
+    """
+
+    id: str
+    subject_id: str
+    tenant_id: str | None
+    kind: str
+    content: str
+    summary: str
+    suggested_labels: list[str]
+    sensitivity_labels: list[str]
+    created_at: str
+
+
+class SuggestedLabelsListResponse(BaseModel):
+    memories: list[SuggestedLabelMemoryItem]
+    total: int
+    limit: int
+    offset: int
+    catalogue: list[dict[str, str]]
+
+
 class EpisodeListItem(BaseModel):
     id: str
     session_id: str | None
@@ -828,6 +857,92 @@ async def list_citing_memories(
         )
 
 
+# ─── Suggested-label review (auto-labeling, v0.9 #158) ───────────────────────
+
+
+@router.get(
+    "/memories/with-suggested-labels",
+    response_model=SuggestedLabelsListResponse,
+)
+async def list_memories_with_suggested_labels(
+    tenant_id: str | None = Query(None, description="Filter by tenant"),
+    subject_id: str | None = Query(None, description="Filter by subject"),
+    label: str | None = Query(
+        None,
+        description=(
+            "Filter to memories carrying this specific suggested label "
+            "(e.g. `pii.email`). When omitted, lists every memory with at "
+            "least one suggestion."
+        ),
+    ),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    """List memories with at least one auto-derived suggested label.
+
+    Read-only review surface for the v0.9 auto-labeling pipeline (#158).
+    The endpoint exists so operators can audit detector output and
+    decide which suggestions to promote into authoritative
+    ``sensitivity_labels``. v0.9 ships review only — promotion lands
+    in a follow-up PR; the SDK / direct DB write path is the
+    interim escape hatch.
+
+    The endpoint does not require the feature flag to be enabled: an
+    operator can flip the flag off, leave existing suggestions in
+    place, and still see them here to triage.
+    """
+    from sqlalchemy import func, select
+
+    from server.db import engine as engine_module
+    from server.db.tables import MemoryRow
+    from server.services.auto_labeling.detectors import label_catalogue
+
+    async with engine_module.get_session_factory()() as session:
+        # `array_length(col, 1) IS NOT NULL` is the cheap pg-native way to
+        # filter to "non-empty array". The GIN index from migration 0022
+        # makes the `&&`-overlap path that follows a millisecond hop.
+        base = select(MemoryRow).where(func.array_length(MemoryRow.suggested_labels, 1).isnot(None))
+        if tenant_id:
+            base = base.where(MemoryRow.tenant_id == tenant_id)
+        if subject_id:
+            base = base.where(MemoryRow.subject_id == subject_id)
+        if label:
+            # Use the GIN-indexed overlap operator so a label filter
+            # stays cheap even on millions of memories. We pass a
+            # one-element list because `overlap` accepts an array.
+            base = base.where(MemoryRow.suggested_labels.overlap([label]))
+
+        count_stmt = select(func.count()).select_from(base.subquery())
+        total = await session.scalar(count_stmt) or 0
+
+        stmt = base.order_by(MemoryRow.created_at.desc()).limit(limit).offset(offset)
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
+
+        memories = [
+            SuggestedLabelMemoryItem(
+                id=str(m.id),
+                subject_id=m.subject_id,
+                tenant_id=m.tenant_id,
+                kind=m.kind,
+                content=m.content,
+                summary=m.summary,
+                suggested_labels=list(m.suggested_labels or []),
+                sensitivity_labels=list(m.sensitivity_labels or []),
+                created_at=m.created_at.isoformat(),
+            )
+            for m in rows
+        ]
+
+        return SuggestedLabelsListResponse(
+            memories=memories,
+            total=total,
+            limit=limit,
+            offset=offset,
+            catalogue=label_catalogue(),
+        )
+
+
 # ─── Memory Evolution / Related Memories ─────────────────────────────────────
 
 
@@ -1313,9 +1428,7 @@ async def list_compile_jobs(
 
 @router.delete("/jobs")
 async def purge_compile_jobs(
-    status: str | None = Query(
-        None, description="Filter by terminal status: completed or failed"
-    ),
+    status: str | None = Query(None, description="Filter by terminal status: completed or failed"),
     subject_id: str | None = Query(None, description="Filter by subject"),
     tenant_id: str | None = Query(None, description="Filter by tenant"),
 ):
@@ -1328,9 +1441,7 @@ async def purge_compile_jobs(
     from server.services.compile_jobs_durable import purge_jobs
 
     try:
-        deleted = await purge_jobs(
-            status=status, subject_id=subject_id, tenant_id=tenant_id
-        )
+        deleted = await purge_jobs(status=status, subject_id=subject_id, tenant_id=tenant_id)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return {"deleted": deleted}
@@ -1552,11 +1663,7 @@ def _filter_is_empty(f: BulkDeleteFilter) -> bool:
     """
     if f.match_all:
         return False
-    return (
-        not f.subject_id_prefix
-        and f.older_than_days is None
-        and not f.tenant_id
-    )
+    return not f.subject_id_prefix and f.older_than_days is None and not f.tenant_id
 
 
 async def _matching_subjects(
@@ -1577,15 +1684,12 @@ async def _matching_subjects(
     async with engine_module.get_session_factory()() as session:
         # Aggregate per (subject_id, tenant_id) from episodes — this is the
         # authoritative grouping used elsewhere in admin.
-        ep_stmt = (
-            select(
-                EpisodeRow.subject_id,
-                EpisodeRow.tenant_id,
-                func.count().label("ep_count"),
-                func.max(EpisodeRow.created_at).label("last_episode_at"),
-            )
-            .group_by(EpisodeRow.subject_id, EpisodeRow.tenant_id)
-        )
+        ep_stmt = select(
+            EpisodeRow.subject_id,
+            EpisodeRow.tenant_id,
+            func.count().label("ep_count"),
+            func.max(EpisodeRow.created_at).label("last_episode_at"),
+        ).group_by(EpisodeRow.subject_id, EpisodeRow.tenant_id)
         if f.subject_id_prefix:
             ep_stmt = ep_stmt.where(EpisodeRow.subject_id.like(f"{f.subject_id_prefix}%"))
         if f.tenant_id:
@@ -1649,12 +1753,8 @@ async def delete_subject_admin(
     from server.db import repositories as repo
 
     async with engine_module.get_session_factory()() as session:
-        ep_count = await repo.delete_episodes_by_subject(
-            session, subject_id, tenant_id=tenant_id
-        )
-        mem_count = await repo.delete_memories_by_subject(
-            session, subject_id, tenant_id=tenant_id
-        )
+        ep_count = await repo.delete_episodes_by_subject(session, subject_id, tenant_id=tenant_id)
+        mem_count = await repo.delete_memories_by_subject(session, subject_id, tenant_id=tenant_id)
         await session.commit()
 
     if ep_count == 0 and mem_count == 0:
@@ -1869,7 +1969,6 @@ async def trigger_cleanup(
 
     count = await cleanup_ephemeral_subjects(prefix=prefix, max_age_hours=max_age_hours)
     return {"subjects_cleaned": count}
-
 
 
 # ─── Memory portability ───
@@ -2292,9 +2391,7 @@ async def upload_policy_bundle(req: UploadPolicyBundleRequest):
         if req.tenant_id is None:
             existing_stmt = existing_stmt.where(PolicyBundleRow.tenant_id.is_(None))
         else:
-            existing_stmt = existing_stmt.where(
-                PolicyBundleRow.tenant_id == req.tenant_id
-            )
+            existing_stmt = existing_stmt.where(PolicyBundleRow.tenant_id == req.tenant_id)
         existing = await session.execute(existing_stmt)
         existing_row = existing.scalar_one_or_none()
         if existing_row is None:
@@ -2317,9 +2414,7 @@ async def upload_policy_bundle(req: UploadPolicyBundleRequest):
             if req.tenant_id is None:
                 scope_stmt = scope_stmt.where(PolicyBundleRow.tenant_id.is_(None))
             else:
-                scope_stmt = scope_stmt.where(
-                    PolicyBundleRow.tenant_id == req.tenant_id
-                )
+                scope_stmt = scope_stmt.where(PolicyBundleRow.tenant_id == req.tenant_id)
             scope_stmt = scope_stmt.values(active=False)
             await session.execute(scope_stmt)
             # Activate ONLY the row for this (tenant, hash) — without
@@ -2330,13 +2425,9 @@ async def upload_policy_bundle(req: UploadPolicyBundleRequest):
                 PolicyBundleRow.bundle_hash == bundle.bundle_hash
             )
             if req.tenant_id is None:
-                activate_stmt = activate_stmt.where(
-                    PolicyBundleRow.tenant_id.is_(None)
-                )
+                activate_stmt = activate_stmt.where(PolicyBundleRow.tenant_id.is_(None))
             else:
-                activate_stmt = activate_stmt.where(
-                    PolicyBundleRow.tenant_id == req.tenant_id
-                )
+                activate_stmt = activate_stmt.where(PolicyBundleRow.tenant_id == req.tenant_id)
             await session.execute(activate_stmt.values(active=True))
             await session.commit()
             policy_service.invalidate_bundle_cache()
@@ -2395,9 +2486,7 @@ async def get_policy_bundle(bundle_hash: str, tenant_id: str | None = Query(None
     from server.services import policy as policy_service
 
     async with engine_module.get_session_factory()() as session:
-        stmt = select(PolicyBundleRow).where(
-            PolicyBundleRow.bundle_hash == bundle_hash
-        )
+        stmt = select(PolicyBundleRow).where(PolicyBundleRow.bundle_hash == bundle_hash)
         if tenant_id is not None:
             stmt = stmt.where(PolicyBundleRow.tenant_id == tenant_id)
             result = await session.execute(stmt)
@@ -2469,15 +2558,11 @@ async def activate_policy_bundle(req: ActivateBundleRequest):
     from server.services import policy as policy_service
 
     async with engine_module.get_session_factory()() as session:
-        target_stmt = select(PolicyBundleRow).where(
-            PolicyBundleRow.bundle_hash == req.bundle_hash
-        )
+        target_stmt = select(PolicyBundleRow).where(PolicyBundleRow.bundle_hash == req.bundle_hash)
         if req.tenant_id is None:
             target_stmt = target_stmt.where(PolicyBundleRow.tenant_id.is_(None))
         else:
-            target_stmt = target_stmt.where(
-                PolicyBundleRow.tenant_id == req.tenant_id
-            )
+            target_stmt = target_stmt.where(PolicyBundleRow.tenant_id == req.tenant_id)
         result = await session.execute(target_stmt)
         target = result.scalar_one_or_none()
         if target is None:
@@ -2487,9 +2572,7 @@ async def activate_policy_bundle(req: ActivateBundleRequest):
         # bundle, same tenant). Using target.id rather than
         # bundle_hash here is the load-bearing precision: we want to
         # leave the same-hash-different-tenant rows untouched.
-        scope_stmt = sa_update(PolicyBundleRow).where(
-            PolicyBundleRow.id != target.id
-        )
+        scope_stmt = sa_update(PolicyBundleRow).where(PolicyBundleRow.id != target.id)
         if target.tenant_id is None:
             scope_stmt = scope_stmt.where(PolicyBundleRow.tenant_id.is_(None))
         else:
@@ -2497,9 +2580,7 @@ async def activate_policy_bundle(req: ActivateBundleRequest):
         scope_stmt = scope_stmt.values(active=False)
         await session.execute(scope_stmt)
         await session.execute(
-            sa_update(PolicyBundleRow)
-            .where(PolicyBundleRow.id == target.id)
-            .values(active=True)
+            sa_update(PolicyBundleRow).where(PolicyBundleRow.id == target.id).values(active=True)
         )
         await session.commit()
 
@@ -2579,9 +2660,7 @@ async def admin_set_memory_labels(
     from server.db import engine as engine_module
     from server.db.tables import MemoryRow
 
-    normalized = sorted(
-        {lbl.strip().lower() for lbl in req.sensitivity_labels if lbl.strip()}
-    )
+    normalized = sorted({lbl.strip().lower() for lbl in req.sensitivity_labels if lbl.strip()})
     if len(normalized) > 32:
         raise HTTPException(status_code=400, detail="too many labels (max 32)")
 
@@ -2716,8 +2795,7 @@ async def patch_tenant_config(tenant_id: str, patch: TenantConfigPatch):
                 raise HTTPException(
                     status_code=409,
                     detail=(
-                        f"version mismatch: expected {expected_version}, "
-                        f"got 0 (no row exists yet)"
+                        f"version mismatch: expected {expected_version}, got 0 (no row exists yet)"
                     ),
                 )
             new_config = dict(incoming)
@@ -2730,10 +2808,7 @@ async def patch_tenant_config(tenant_id: str, patch: TenantConfigPatch):
             await session.commit()
             await session.refresh(row)
         else:
-            if (
-                expected_version is not None
-                and expected_version != existing.version
-            ):
+            if expected_version is not None and expected_version != existing.version:
                 raise HTTPException(
                     status_code=409,
                     detail=(

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -116,9 +116,7 @@ class Settings(BaseSettings):
             try:
                 parsed = json.loads(value)
             except json.JSONDecodeError as exc:
-                raise ValueError(
-                    f"STATEWAVE_KIND_TTL_DAYS is not valid JSON: {exc.msg}"
-                ) from exc
+                raise ValueError(f"STATEWAVE_KIND_TTL_DAYS is not valid JSON: {exc.msg}") from exc
             if not isinstance(parsed, dict):
                 raise ValueError(
                     "STATEWAVE_KIND_TTL_DAYS must decode to a JSON object "
@@ -262,6 +260,30 @@ class Settings(BaseSettings):
                 )
             clean[key_id] = key_bytes
         return clean
+
+    # Auto-labeling (v0.9, issue #158) — heuristic detectors that stamp
+    # advisory `suggested_labels` on memories at compile time. OFF by default
+    # so the v0.9 → existing-tenant upgrade is a no-op until an operator opts
+    # in. When enabled, the pipeline runs after MemoryRow construction and
+    # writes to `memories.suggested_labels` only. The policy evaluator does
+    # not read this column; promotion into authoritative `sensitivity_labels`
+    # is a deliberate, audited operator action (admin UI / SDK call).
+    #
+    # `auto_labeling_provider` is forward-looking: in v0.9 the only supported
+    # value is `heuristic` (regex + Luhn detectors). Future LLM-based
+    # classifiers land as new provider strings without an API break.
+    auto_labeling_enabled: bool = False
+    auto_labeling_provider: str = "heuristic"  # "heuristic" only in v0.9
+
+    @field_validator("auto_labeling_provider")
+    @classmethod
+    def _validate_auto_labeling_provider(cls, value: str) -> str:
+        allowed = {"heuristic"}
+        if value not in allowed:
+            raise ValueError(
+                f"STATEWAVE_AUTO_LABELING_PROVIDER must be one of {sorted(allowed)}, got {value!r}"
+            )
+        return value
 
     # Multi-tenant (empty = single-tenant mode)
     tenant_header: str = "X-Tenant-ID"

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -80,6 +80,15 @@ class MemoryRow(Base):
     sensitivity_labels: Mapped[list[str]] = mapped_column(
         ARRAY(String()), nullable=False, default=list
     )
+    # Heuristic-derived label hints (issue #158). Populated automatically by
+    # the auto-labeling pipeline at ingest time. ORTHOGONAL to sensitivity_labels:
+    # the policy evaluator does not read this column and no destructive behaviour
+    # (retention, redaction, refusal) keys off it. It exists so operators can
+    # surface and promote suggestions into authoritative labels deliberately.
+    # See migration 0022 for the GIN index backing the admin review endpoint.
+    suggested_labels: Mapped[list[str]] = mapped_column(
+        ARRAY(String()), nullable=False, default=list
+    )
     # Stored as pgvector `vector(EMBEDDING_DIMENSIONS)` since migration 0013.
     # Reads/writes happen as `list[float]` — the pgvector SQLAlchemy adapter
     # serializes/deserializes transparently. Cosine search uses the SQL `<=>`
@@ -242,12 +251,8 @@ class ReceiptRow(Base):
     # Both nullable: pre-v0.9 receipts and unsigned-by-policy v0.9
     # receipts leave them null; the verifier reports `valid: null` /
     # `reason: "no_signature"` for those.
-    receipt_signature_key_id: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
-    receipt_signature_algorithm: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
+    receipt_signature_key_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    receipt_signature_algorithm: Mapped[str | None] = mapped_column(String(64), nullable=True)
     body: Mapped[dict] = mapped_column(JSONB, nullable=False)
     as_of: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
@@ -257,12 +262,8 @@ class ReceiptRow(Base):
     # retention worker (`cleanup_expired_receipts`) transitions rows to
     # `tombstoned` once `created_at + tenant.receipt_retention_days` has
     # passed. Soft-delete only — the row persists for audit lookup.
-    status: Mapped[str] = mapped_column(
-        String(32), nullable=False, server_default="active"
-    )
-    tombstoned_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    status: Mapped[str] = mapped_column(String(32), nullable=False, server_default="active")
+    tombstoned_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     __table_args__ = (
         Index(
@@ -319,9 +320,7 @@ class PolicyBundleRow(Base):
 
     __tablename__ = "policy_bundles"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     bundle_hash: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     yaml_content: Mapped[str] = mapped_column(Text, nullable=False)
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
@@ -354,12 +353,8 @@ class QueryEmbeddingCacheRow(Base):
 
     text_key: Mapped[str] = mapped_column(Text, primary_key=True)
     model: Mapped[str] = mapped_column(Text, primary_key=True)
-    embedding: Mapped[list[float]] = mapped_column(
-        Vector(EMBEDDING_DIMENSIONS), nullable=False
-    )
-    expires_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
-    )
+    embedding: Mapped[list[float]] = mapped_column(Vector(EMBEDDING_DIMENSIONS), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/server/services/auto_labeling/__init__.py
+++ b/server/services/auto_labeling/__init__.py
@@ -1,0 +1,97 @@
+"""Auto-labeling pipeline (v0.9, issue #158).
+
+Heuristic detectors that scan memory `content` at compile time and
+emit advisory `suggested_labels`. The pipeline never touches
+``sensitivity_labels`` — promotion into the authoritative column is a
+deliberate, audited operator action (admin review endpoint or SDK call).
+
+Label schema: ``<category>.<specific>`` (e.g. ``pii.email``,
+``financial.card``, ``secret.token``). Detectors are pure functions
+``(text: str) -> bool`` so they can be unit-tested in isolation and
+composed without ordering assumptions.
+
+Public surface:
+
+  * ``label_suggestions(text)`` — pure, returns the sorted, de-duplicated
+    list of label strings the configured detectors produced.
+  * ``apply_suggestions(memories)`` — in-place mutates ``MemoryRow.
+    suggested_labels`` for each memory. Used by the compilers.
+  * ``DETECTORS`` — the registry tuple, in stable order. Tests assert
+    on this directly.
+
+The pipeline is gated at the call site (compilers check
+``settings.auto_labeling_enabled``). The package itself is always
+importable — keeping it side-effect-free means tests can exercise
+detectors without flipping a global.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from server.db.tables import MemoryRow
+
+from .detectors import DETECTORS, Detector
+
+
+def label_suggestions(text: str) -> list[str]:
+    """Run every configured detector against ``text``. Return the sorted,
+    de-duplicated list of label strings that matched.
+
+    Pure function: no side effects, no I/O, no logging on the happy path.
+    Detectors that raise are treated as no-match (the pipeline does not
+    let a buggy detector break ingest) and the failure is reported by
+    the wrapping call in ``apply_suggestions``.
+    """
+    if not text:
+        return []
+    found: set[str] = set()
+    for det in DETECTORS:
+        try:
+            if det.detect(text):
+                found.add(det.label)
+        except Exception:
+            # A detector raising is a code bug, not a tenant-data
+            # problem. Swallow here; the caller logs (apply_suggestions
+            # has the MemoryRow context for a useful structured log).
+            continue
+    return sorted(found)
+
+
+def apply_suggestions(memories: Iterable[MemoryRow]) -> None:
+    """Stamp ``suggested_labels`` on each memory in-place.
+
+    Idempotent: re-running merges with anything already present (the
+    LLM compiler may run before the heuristic detector, or a tenant
+    may pre-seed via the SDK). De-duplicates and sorts.
+
+    Detectors run against ``memory.content``. The summary is a
+    derivative and adds no signal a detector would miss in the body.
+    """
+    import structlog
+
+    logger = structlog.stdlib.get_logger()
+
+    for mem in memories:
+        try:
+            new_labels = label_suggestions(mem.content)
+        except Exception as exc:  # noqa: BLE001 — defensive boundary
+            logger.warning(
+                "auto_labeling_failed",
+                memory_id=str(mem.id) if mem.id else None,
+                error=str(exc)[:200],
+            )
+            continue
+        if not new_labels:
+            continue
+        existing = list(mem.suggested_labels or [])
+        merged = sorted(set(existing) | set(new_labels))
+        mem.suggested_labels = merged
+
+
+__all__ = [
+    "DETECTORS",
+    "Detector",
+    "apply_suggestions",
+    "label_suggestions",
+]

--- a/server/services/auto_labeling/detectors.py
+++ b/server/services/auto_labeling/detectors.py
@@ -1,0 +1,176 @@
+"""Heuristic detector registry for auto-labeling (v0.9, issue #158).
+
+Each detector is a small dataclass pairing a label string with a pure
+``detect(text) -> bool`` predicate. The detectors here aim for high
+precision over high recall: a false positive surfaces a noisy
+suggestion in the admin UI (annoying), while a false promotion into
+``sensitivity_labels`` requires an explicit operator click (safe).
+
+Detector inventory (v0.9 first wave):
+
+  * ``pii.email``   — RFC-5322-ish email regex
+  * ``pii.phone``   — E.164 + common US/EU loose forms
+  * ``financial.card`` — 13–19 digit groups, validated by Luhn checksum
+  * ``secret.token`` — common high-entropy / known-prefix tokens
+                       (aws, google, github, openai, slack, bearer JWT)
+
+Each detector's ``detect`` is a pure function — no I/O, no global
+state — so they're trivially unit-testable.
+
+Adding a new detector: define a dataclass instance below, append to
+``DETECTORS``, and add a unit test in
+``tests/test_auto_labeling.py``. The label MUST follow the
+``<category>.<specific>`` schema; the admin endpoint's filter UI
+groups suggestions by category.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Detector:
+    """A named, label-emitting predicate over memory text."""
+
+    label: str
+    description: str
+    detect: "callable[[str], bool]"  # type: ignore[valid-type]
+
+
+# ─── pii.email ────────────────────────────────────────────────────────
+# Conservative: requires a TLD with ≥2 letters, no spaces inside the
+# local-part. Matches the common "name@host.tld" shape that operators
+# would expect to be flagged. We accept the occasional false negative
+# on weird-but-valid RFC-5322 addresses; the goal is precision.
+
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
+
+
+def _detect_email(text: str) -> bool:
+    return bool(_EMAIL_RE.search(text))
+
+
+# ─── pii.phone ────────────────────────────────────────────────────────
+# Two shapes:
+#   - E.164 / international:    +<digits> (10–15 digits total, optional
+#                               spaces/dashes/dots between groups).
+#   - Loose national:           10 digits in a row, possibly grouped as
+#                               (NNN) NNN-NNNN or NNN-NNN-NNNN.
+# The regexes are anchored on word boundaries to keep them from firing
+# on bare 10-digit identifiers like timestamps. We additionally require
+# at least one separator OR the leading `+` so a raw `1234567890` in a
+# UUID-ish slug doesn't trip the detector.
+
+_PHONE_INTL_RE = re.compile(r"\+\d[\d\s().\-]{8,18}\d")
+_PHONE_US_RE = re.compile(r"\b\(?\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b")
+
+
+def _detect_phone(text: str) -> bool:
+    if _PHONE_INTL_RE.search(text):
+        return True
+    return bool(_PHONE_US_RE.search(text))
+
+
+# ─── financial.card ───────────────────────────────────────────────────
+# We require:
+#   1. A run of 13–19 digits (allowing single spaces or single dashes
+#      between groups of digits).
+#   2. The digit-only form passes the Luhn checksum.
+# Luhn alone gives a ~10% false-positive rate on random digits; the
+# length window + group-separator pattern keeps random IDs from
+# tripping. We still bias toward false-negatives over false-positives.
+
+_CARD_RE = re.compile(r"\b(?:\d[ \-]?){12,18}\d\b")
+
+
+def _luhn_ok(digits: str) -> bool:
+    total = 0
+    parity = len(digits) % 2
+    for i, ch in enumerate(digits):
+        d = ord(ch) - 48
+        if d < 0 or d > 9:
+            return False
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return total % 10 == 0
+
+
+def _detect_card(text: str) -> bool:
+    for m in _CARD_RE.finditer(text):
+        digits = re.sub(r"[ \-]", "", m.group(0))
+        if 13 <= len(digits) <= 19 and _luhn_ok(digits):
+            return True
+    return False
+
+
+# ─── secret.token ─────────────────────────────────────────────────────
+# Pattern-based: known prefixes from major providers, plus a generic
+# bearer-JWT shape. We deliberately do NOT do entropy-based detection
+# in v0.9 — it produces too many false positives on hashes / UUIDs /
+# git SHAs that an operator would not consider secrets. The
+# precision-first approach means we miss bespoke tokens, but operators
+# can manually label those via the SDK.
+
+_TOKEN_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # AWS access key ID
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    # GitHub fine-grained / classic PATs and OAuth tokens
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36,}\b"),
+    # OpenAI API keys (sk- prefix, ≥40 chars)
+    re.compile(r"\bsk-[A-Za-z0-9_\-]{20,}\b"),
+    # Google API keys
+    re.compile(r"\bAIza[0-9A-Za-z_\-]{35}\b"),
+    # Slack tokens (xoxa/b/p/r/s + dash form)
+    re.compile(r"\bxox[abprs]-[A-Za-z0-9\-]{10,}\b"),
+    # Bearer JWT (three base64url segments). The middle/last segments
+    # require ≥16 chars so a random "a.b.c" doesn't trip the pattern.
+    re.compile(r"\beyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{16,}\.[A-Za-z0-9_\-]{16,}\b"),
+)
+
+
+def _detect_token(text: str) -> bool:
+    return any(p.search(text) for p in _TOKEN_PATTERNS)
+
+
+# ─── Registry ─────────────────────────────────────────────────────────
+# Order is stable but irrelevant for correctness — the pipeline
+# de-duplicates and sorts. Tests assert on this tuple directly to
+# guard against accidental detector deletion in refactors.
+
+DETECTORS: tuple[Detector, ...] = (
+    Detector(
+        label="pii.email",
+        description="Email address (RFC-5322-ish pattern).",
+        detect=_detect_email,
+    ),
+    Detector(
+        label="pii.phone",
+        description="Phone number (E.164 or grouped national form).",
+        detect=_detect_phone,
+    ),
+    Detector(
+        label="financial.card",
+        description="Credit-card-shaped 13–19 digit run passing Luhn.",
+        detect=_detect_card,
+    ),
+    Detector(
+        label="secret.token",
+        description="Known-provider API key or bearer JWT.",
+        detect=_detect_token,
+    ),
+)
+
+
+# Public utility — used by docs / admin UI as the source of truth for
+# the v0.9 label catalogue. Kept as a function so callers can't mutate
+# the tuple.
+def label_catalogue() -> list[dict[str, str]]:
+    return [{"label": d.label, "description": d.description} for d in DETECTORS]
+
+
+__all__ = ["DETECTORS", "Detector", "label_catalogue"]

--- a/server/services/compilers/heuristic.py
+++ b/server/services/compilers/heuristic.py
@@ -16,6 +16,7 @@ from typing import Sequence
 
 from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
+from server.services.auto_labeling import apply_suggestions
 from server.services.memory_ttl import compute_valid_to
 
 
@@ -26,6 +27,12 @@ class HeuristicCompiler:
         memories: list[MemoryRow] = []
         for ep in episodes:
             memories.extend(self._compile_episode(ep))
+        # Auto-labeling runs post-construction: detectors only need
+        # `content`, and running them once at the end keeps a single
+        # apply path that's easy to test in isolation. Gated on the
+        # global flag so a v0.9 upgrade is a no-op for existing tenants.
+        if settings.auto_labeling_enabled and memories:
+            apply_suggestions(memories)
         return memories
 
     def _compile_episode(self, ep: EpisodeRow) -> list[MemoryRow]:

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -30,6 +30,7 @@ import structlog
 from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
 from server.services import llm as llm_adapter
+from server.services.auto_labeling import apply_suggestions
 from server.services.compilers.heuristic import episode_valid_from, extract_payload_text
 from server.services.memory_ttl import compute_valid_to
 
@@ -159,6 +160,13 @@ class LLMCompiler:
         for result in batch_results:
             memories.extend(result)
 
+        # Auto-labeling runs post-extraction so a single code path stamps
+        # `suggested_labels` regardless of whether the LLM batch was a
+        # single or multi-episode call. Gated globally — a v0.9 upgrade
+        # is a no-op for existing tenants until they opt in.
+        if settings.auto_labeling_enabled and memories:
+            apply_suggestions(memories)
+
         logger.info("compile_complete", total_memories=len(memories))
         return memories
 
@@ -212,9 +220,7 @@ class LLMCompiler:
             episode_blocks = []
             for i, (ep, text) in enumerate(batch):
                 ref_label = episode_valid_from(ep).strftime("%Y-%m-%d (%A)")
-                episode_blocks.append(
-                    f"--- Episode {i} | recorded {ref_label} ---\n{text}"
-                )
+                episode_blocks.append(f"--- Episode {i} | recorded {ref_label} ---\n{text}")
             combined_text = "\n\n".join(episode_blocks)
 
             try:

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0021_receipts_signature_keyid"
+EXPECTED_HEAD = "0022_memories_suggested_labels"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/tests/integration/test_auto_labeling.py
+++ b/tests/integration/test_auto_labeling.py
@@ -1,0 +1,276 @@
+"""End-to-end integration tests for auto-labeling (v0.9 #158).
+
+Covers:
+  * Compile path stamps ``suggested_labels`` on real MemoryRows when
+    the feature flag is on, and stamps nothing when it is off.
+  * Authoritative ``sensitivity_labels`` is NEVER mutated by the
+    pipeline — this is the load-bearing isolation property (the
+    policy evaluator reads sensitivity_labels; a regression that
+    leaked suggestions there would silently tighten policy).
+  * ``GET /admin/memories/with-suggested-labels`` returns only rows
+    with suggestions, supports filtering, and surfaces the catalogue.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from server.core.config import settings
+from server.db.tables import MemoryRow
+
+
+_EMAIL_PAYLOAD = {
+    "source": "test",
+    "type": "chat.session",
+    "payload": {
+        "messages": [
+            {"role": "user", "content": "Reach me at alice@example.com any time."},
+            {"role": "assistant", "content": "Got it, will email there."},
+        ]
+    },
+}
+
+_CARD_PAYLOAD = {
+    "source": "test",
+    "type": "chat.session",
+    "payload": {
+        "messages": [
+            {"role": "user", "content": "My card is 4111-1111-1111-1111."},
+        ]
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Compile path — feature flag gates the pipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compile_stamps_suggested_labels_when_enabled(
+    client: AsyncClient, subject_id: str, monkeypatch
+):
+    """With the flag ON, the compile path must stamp pii.email on the
+    memories derived from an email-containing episode."""
+    monkeypatch.setattr(settings, "auto_labeling_enabled", True)
+
+    resp = await client.post("/v1/episodes", json={**_EMAIL_PAYLOAD, "subject_id": subject_id})
+    assert resp.status_code == 201
+
+    resp = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert resp.status_code == 200
+    assert resp.json()["memories_created"] > 0
+
+    # Read back from DB and verify the column.
+    from server.db.engine import get_session_factory
+
+    async with get_session_factory()() as session:
+        rows = (
+            (await session.execute(select(MemoryRow).where(MemoryRow.subject_id == subject_id)))
+            .scalars()
+            .all()
+        )
+
+    assert rows, "compile should have produced memories"
+    assert any("pii.email" in (m.suggested_labels or []) for m in rows), (
+        "at least one memory should carry pii.email"
+    )
+
+
+@pytest.mark.anyio
+async def test_compile_skips_suggested_labels_when_disabled(
+    client: AsyncClient, subject_id: str, monkeypatch
+):
+    """With the flag OFF (the default), no memory should carry any
+    suggested label even when the episode obviously contains PII.
+    This is the backwards-compatibility guarantee."""
+    monkeypatch.setattr(settings, "auto_labeling_enabled", False)
+
+    resp = await client.post("/v1/episodes", json={**_EMAIL_PAYLOAD, "subject_id": subject_id})
+    assert resp.status_code == 201
+
+    resp = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert resp.status_code == 200
+
+    from server.db.engine import get_session_factory
+
+    async with get_session_factory()() as session:
+        rows = (
+            (await session.execute(select(MemoryRow).where(MemoryRow.subject_id == subject_id)))
+            .scalars()
+            .all()
+        )
+
+    assert rows
+    for m in rows:
+        assert (m.suggested_labels or []) == [], (
+            f"memory {m.id} carries suggestions while flag is OFF"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Policy isolation — load-bearing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_auto_labeling_never_writes_sensitivity_labels(
+    client: AsyncClient, subject_id: str, monkeypatch
+):
+    """The pipeline writes to ``suggested_labels`` only; the
+    authoritative ``sensitivity_labels`` column the policy evaluator
+    reads must remain empty (or whatever the tenant set explicitly).
+    A regression that swapped these columns would silently tighten
+    policy on real traffic — keep the assertion explicit."""
+    monkeypatch.setattr(settings, "auto_labeling_enabled", True)
+
+    resp = await client.post("/v1/episodes", json={**_CARD_PAYLOAD, "subject_id": subject_id})
+    assert resp.status_code == 201
+
+    resp = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert resp.status_code == 200
+
+    from server.db.engine import get_session_factory
+
+    async with get_session_factory()() as session:
+        rows = (
+            (await session.execute(select(MemoryRow).where(MemoryRow.subject_id == subject_id)))
+            .scalars()
+            .all()
+        )
+
+    assert rows
+    # At least one row must carry the suggested label; otherwise the
+    # rest of the assertion is meaningless.
+    assert any("financial.card" in (m.suggested_labels or []) for m in rows)
+    # NOT ONE row may carry it under sensitivity_labels.
+    for m in rows:
+        assert "financial.card" not in (m.sensitivity_labels or [])
+        assert "pii.email" not in (m.sensitivity_labels or [])
+        assert "secret.token" not in (m.sensitivity_labels or [])
+
+
+# ---------------------------------------------------------------------------
+# Admin review endpoint
+# ---------------------------------------------------------------------------
+
+
+async def _insert_memory_with_suggested(
+    session_factory,
+    *,
+    subject_id: str,
+    tenant_id: str | None,
+    suggested: list[str],
+) -> uuid.UUID:
+    mid = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(
+            MemoryRow(
+                id=mid,
+                subject_id=subject_id,
+                tenant_id=tenant_id,
+                kind="profile_fact",
+                content="alice@example.com",
+                summary="alice email",
+                confidence=1.0,
+                valid_from=datetime.now(timezone.utc),
+                valid_to=None,
+                source_episode_ids=[],
+                metadata_={},
+                status="active",
+                sensitivity_labels=[],
+                suggested_labels=suggested,
+            )
+        )
+        await session.commit()
+    return mid
+
+
+@pytest.mark.anyio
+async def test_admin_list_only_returns_rows_with_suggestions(client: AsyncClient, session_factory):
+    """The endpoint filters out memories with empty suggested_labels."""
+    s_with = f"with-{uuid.uuid4().hex[:8]}"
+    s_without = f"without-{uuid.uuid4().hex[:8]}"
+
+    await _insert_memory_with_suggested(
+        session_factory, subject_id=s_with, tenant_id=None, suggested=["pii.email"]
+    )
+    await _insert_memory_with_suggested(
+        session_factory, subject_id=s_without, tenant_id=None, suggested=[]
+    )
+
+    resp = await client.get(
+        "/admin/memories/with-suggested-labels",
+        params={"subject_id": s_with},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["memories"][0]["suggested_labels"] == ["pii.email"]
+
+    # Same call against the empty-suggestions subject returns nothing.
+    resp = await client.get(
+        "/admin/memories/with-suggested-labels",
+        params={"subject_id": s_without},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+
+@pytest.mark.anyio
+async def test_admin_list_label_filter(client: AsyncClient, session_factory):
+    """The `label` query param narrows to memories carrying that
+    specific suggestion. Uses the GIN-indexed overlap path."""
+    s = f"filter-{uuid.uuid4().hex[:8]}"
+    await _insert_memory_with_suggested(
+        session_factory, subject_id=s, tenant_id=None, suggested=["pii.email"]
+    )
+    await _insert_memory_with_suggested(
+        session_factory, subject_id=s, tenant_id=None, suggested=["financial.card"]
+    )
+
+    resp = await client.get(
+        "/admin/memories/with-suggested-labels",
+        params={"subject_id": s, "label": "pii.email"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["memories"][0]["suggested_labels"] == ["pii.email"]
+
+
+@pytest.mark.anyio
+async def test_admin_list_includes_catalogue(client: AsyncClient, session_factory):
+    """Response carries the detector catalogue so the admin UI can
+    populate filter dropdowns without a second round-trip."""
+    resp = await client.get("/admin/memories/with-suggested-labels")
+    assert resp.status_code == 200
+    body = resp.json()
+    labels = {entry["label"] for entry in body["catalogue"]}
+    assert {"pii.email", "pii.phone", "financial.card", "secret.token"}.issubset(labels)
+
+
+@pytest.mark.anyio
+async def test_admin_list_pagination(client: AsyncClient, session_factory):
+    """limit + offset behave as advertised."""
+    s = f"page-{uuid.uuid4().hex[:8]}"
+    for _ in range(3):
+        await _insert_memory_with_suggested(
+            session_factory, subject_id=s, tenant_id=None, suggested=["pii.email"]
+        )
+
+    resp = await client.get(
+        "/admin/memories/with-suggested-labels",
+        params={"subject_id": s, "limit": 2, "offset": 0},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 3
+    assert len(body["memories"]) == 2
+    assert body["limit"] == 2
+    assert body["offset"] == 0

--- a/tests/test_auto_labeling.py
+++ b/tests/test_auto_labeling.py
@@ -1,0 +1,302 @@
+"""Unit tests for the auto-labeling detector registry + pipeline (#158).
+
+Pure tests: no DB, no app. Exercises each detector in isolation so
+regressions are pinpointable, plus the pipeline-level dedup / merge
+contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from server.services.auto_labeling import (
+    DETECTORS,
+    apply_suggestions,
+    label_suggestions,
+)
+from server.services.auto_labeling.detectors import label_catalogue
+
+
+# ---------------------------------------------------------------------------
+# Registry contract — guard against accidental detector deletion
+# ---------------------------------------------------------------------------
+
+
+def test_detector_registry_has_v0_9_first_wave():
+    """The v0.9 first wave is `pii.email`, `pii.phone`, `financial.card`,
+    `secret.token`. A regression that silently drops one of these is a
+    governance bug — assert directly on the labels."""
+    labels = {d.label for d in DETECTORS}
+    assert labels == {
+        "pii.email",
+        "pii.phone",
+        "financial.card",
+        "secret.token",
+    }
+
+
+def test_detector_label_schema():
+    """All detector labels must follow `<category>.<specific>` so the
+    admin UI groups them sanely."""
+    for d in DETECTORS:
+        assert "." in d.label, f"{d.label} violates `<category>.<specific>`"
+        category, specific = d.label.split(".", 1)
+        assert category and specific
+
+
+def test_label_catalogue_matches_registry():
+    """The public catalogue helper must mirror DETECTORS one-to-one."""
+    cat = label_catalogue()
+    assert len(cat) == len(DETECTORS)
+    assert {entry["label"] for entry in cat} == {d.label for d in DETECTORS}
+    # Each entry has a non-empty description.
+    for entry in cat:
+        assert entry["description"]
+
+
+# ---------------------------------------------------------------------------
+# pii.email
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Contact me at alice@example.com please.",
+        "alice.brown+tag@sub.example.co.uk",
+        "support@statewave.dev wrote in.",
+    ],
+)
+def test_email_positive(text):
+    assert "pii.email" in label_suggestions(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "no email here, only @handle and @another",
+        "the price is @5usd",
+        "user@",  # no domain
+        "",
+    ],
+)
+def test_email_negative(text):
+    assert "pii.email" not in label_suggestions(text)
+
+
+# ---------------------------------------------------------------------------
+# pii.phone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Call me at +1 415 555 0199.",
+        "+442071234567",
+        "Cell: (415) 555-0199",
+        "415-555-0199",
+        "415.555.0199",
+    ],
+)
+def test_phone_positive(text):
+    assert "pii.phone" in label_suggestions(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Raw 10-digit run with no grouping / no leading +
+        "transaction id 4155550199",
+        "no phone at all",
+        "version 1.2.3",
+    ],
+)
+def test_phone_negative(text):
+    assert "pii.phone" not in label_suggestions(text)
+
+
+# ---------------------------------------------------------------------------
+# financial.card — Luhn-validated
+# ---------------------------------------------------------------------------
+
+
+def test_card_positive_valid_luhn():
+    """4111-1111-1111-1111 is the canonical test card (passes Luhn)."""
+    assert "financial.card" in label_suggestions("card 4111-1111-1111-1111 charge")
+
+
+def test_card_positive_with_spaces():
+    assert "financial.card" in label_suggestions("4111 1111 1111 1111")
+
+
+def test_card_positive_amex_15_digits():
+    """378282246310005 — AmEx test number, passes Luhn at 15 digits."""
+    assert "financial.card" in label_suggestions("amex 378282246310005")
+
+
+def test_card_negative_fails_luhn():
+    """A 16-digit run that does NOT pass Luhn must not trigger. The
+    length-only path would false-positive every order-id; the Luhn
+    gate is what keeps the detector usable."""
+    # 4111-1111-1111-1112 fails the checksum (off by one).
+    assert "financial.card" not in label_suggestions("id 4111-1111-1111-1112")
+
+
+def test_card_negative_short_run():
+    """12 digits is below the 13-digit floor — too short to be a card."""
+    assert "financial.card" not in label_suggestions("ref 123456789012")
+
+
+# ---------------------------------------------------------------------------
+# secret.token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # AWS access key id
+        "key=AKIAIOSFODNN7EXAMPLE",
+        # GitHub PAT
+        "token: ghp_" + "a" * 40,
+        # OpenAI key
+        "OPENAI_API_KEY=sk-" + "a" * 30,
+        # Google API key — must be exactly AIza + 35 chars
+        "GOOGLE_API_KEY=AIza" + "x" * 35,
+        # Slack OAuth
+        "xoxb-1234567890-abcdefg",
+        # JWT (three base64-ish segments)
+        "Authorization: eyJabcdefgh.abcdefghijklmnop.abcdefghijklmnop",
+    ],
+)
+def test_token_positive(text):
+    assert "secret.token" in label_suggestions(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "no token here",
+        # A bare UUID is NOT a token in our v0.9 precision-first policy.
+        "id 550e8400-e29b-41d4-a716-446655440000",
+        # A git SHA is NOT a token.
+        "commit deadbeefcafebabe1234567890abcdef12345678",
+    ],
+)
+def test_token_negative(text):
+    assert "secret.token" not in label_suggestions(text)
+
+
+# ---------------------------------------------------------------------------
+# label_suggestions — composition + ordering
+# ---------------------------------------------------------------------------
+
+
+def test_label_suggestions_dedupes_and_sorts():
+    text = "Email alice@example.com and call +1 415 555 0199."
+    out = label_suggestions(text)
+    assert out == sorted(out)  # sorted
+    assert len(out) == len(set(out))  # de-duplicated
+    assert "pii.email" in out
+    assert "pii.phone" in out
+
+
+def test_label_suggestions_empty_text():
+    assert label_suggestions("") == []
+    assert label_suggestions(None) == []  # type: ignore[arg-type]
+
+
+def test_label_suggestions_multiple_categories():
+    """A single memory can carry multiple categories simultaneously."""
+    text = (
+        "alice@example.com paid with 4111-1111-1111-1111. "
+        "Bearer eyJabcdefgh.abcdefghijklmnop.abcdefghijklmnop"
+    )
+    out = set(label_suggestions(text))
+    assert {"pii.email", "financial.card", "secret.token"}.issubset(out)
+
+
+# ---------------------------------------------------------------------------
+# apply_suggestions — pipeline-level idempotency + merge
+# ---------------------------------------------------------------------------
+
+
+class _StubMemory:
+    """Minimal stand-in for MemoryRow — keeps tests free of SQLAlchemy."""
+
+    def __init__(self, content: str, suggested_labels: list[str] | None = None):
+        self.id = None
+        self.content = content
+        self.suggested_labels = suggested_labels or []
+
+
+def test_apply_suggestions_stamps_labels():
+    mem = _StubMemory("Reach me at alice@example.com")
+    apply_suggestions([mem])
+    assert "pii.email" in mem.suggested_labels
+
+
+def test_apply_suggestions_merges_with_existing():
+    """If suggested_labels already carries values (e.g. from the LLM
+    compiler that ran first), the heuristic apply path must MERGE
+    rather than overwrite."""
+    mem = _StubMemory("alice@example.com", suggested_labels=["pii.custom"])
+    apply_suggestions([mem])
+    assert "pii.email" in mem.suggested_labels
+    assert "pii.custom" in mem.suggested_labels
+    assert mem.suggested_labels == sorted(mem.suggested_labels)
+
+
+def test_apply_suggestions_idempotent():
+    """Running the pipeline twice must not duplicate labels."""
+    mem = _StubMemory("alice@example.com")
+    apply_suggestions([mem])
+    first = list(mem.suggested_labels)
+    apply_suggestions([mem])
+    assert mem.suggested_labels == first
+
+
+def test_apply_suggestions_skips_empty_content():
+    mem = _StubMemory("")
+    apply_suggestions([mem])
+    assert mem.suggested_labels == []
+
+
+def test_apply_suggestions_detector_failure_isolated(monkeypatch):
+    """A detector raising at runtime must NOT prevent the rest of the
+    pipeline from labelling the memory. We monkey-patch one detector
+    to raise and assert the others still fire."""
+    from server.services.auto_labeling import detectors
+
+    # Find pii.email and force it to raise. The text below also
+    # contains a phone number, so we expect pii.phone to still land.
+    original = detectors._detect_email  # type: ignore[attr-defined]
+
+    def _raises(_text):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(detectors, "_detect_email", _raises)
+    # The Detector dataclass is frozen so we rebuild the tuple in-place.
+    new_detectors = tuple(
+        detectors.Detector(label=d.label, description=d.description, detect=_raises)
+        if d.label == "pii.email"
+        else d
+        for d in detectors.DETECTORS
+    )
+    monkeypatch.setattr(detectors, "DETECTORS", new_detectors)
+    # Re-import the pipeline's view of DETECTORS via attribute lookup.
+    from server.services import auto_labeling
+
+    monkeypatch.setattr(auto_labeling, "DETECTORS", new_detectors)
+
+    text = "alice@example.com or +1 415 555 0199"
+    mem = _StubMemory(text)
+    apply_suggestions([mem])
+
+    # pii.email suppressed, pii.phone still landed.
+    assert "pii.email" not in mem.suggested_labels
+    assert "pii.phone" in mem.suggested_labels
+
+    # Restore for sanity.
+    monkeypatch.setattr(detectors, "_detect_email", original)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 21
+    assert len(revs) == 22
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 11
+    assert result.pending_count == 12
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 21
+    assert result.pending_count == 22
 
 
 def test_resolve_pending_unknown_revision():


### PR DESCRIPTION
Third v0.9 PR. Adds the ingest-time half of governance: detectors that stamp advisory `suggested_labels` on memories at compile time, kept strictly separate from the authoritative `sensitivity_labels` the policy evaluator reads.

## What lands

**Schema** — migration 0022 adds `memories.suggested_labels TEXT[]` with a GIN index, reversible, server default `'{}'::text[]` so a v0.9 upgrade is a no-op for existing rows.

**Pipeline** — `server.services.auto_labeling` package with four pure-function detectors:
- `pii.email` — RFC-5322-ish regex
- `pii.phone` — E.164 + grouped national forms (precision-first)
- `financial.card` — 13–19 digit groups, Luhn-validated
- `secret.token` — AWS / GitHub / OpenAI / Google / Slack prefixes + bearer JWT shape

The pipeline is idempotent and merges with existing values, so heuristic + LLM compile passes compose safely. Both compilers run it post-construction, gated on `STATEWAVE_AUTO_LABELING_ENABLED` (off by default).

**Safety guarantees** (asserted in tests):
- Policy evaluator does **NOT** read `suggested_labels`.
- No retention / redaction / refusal behaviour keys off suggestions.
- Detector failures are isolated — a buggy detector cannot break ingest.
- The pipeline NEVER writes to `sensitivity_labels` — promotion is an explicit operator action.

**Review surface** — `GET /admin/memories/with-suggested-labels` filters via the GIN index, supports tenant/subject/label filters, and returns the detector catalogue so the admin UI can populate dropdowns without hard-coding. Available regardless of the feature flag so an operator can flip it off and still triage legacy suggestions.

## Why two columns

Suggestions are *advisory*. A noisy detector cannot tighten policy on real traffic — the worst it can do is produce a noisy admin row. Promotion into the authoritative column is a deliberate, audited operator action; v0.9 ships review only, the promotion endpoint lands in a follow-up.

## Tests

- 49 unit tests (per-detector positives/negatives, registry guard, pipeline idempotency, detector-failure isolation).
- 7 integration tests (compile path stamps when on, stamps nothing when off, **policy isolation**, admin endpoint filtering + pagination + catalogue surfacing).
- Migration head bumped to `0022_memories_suggested_labels`; `test_migrations` counts updated 21→22, 11→12, 21→22.

## Docs

- `docs/auto-labeling.md` — schema, examples, label catalogue, how to add a detector, explicit list of behaviours the pipeline does **not** do.

## Out of scope (intentional)

- Promotion endpoint for `suggested_labels` → `sensitivity_labels` (follow-up).
- LLM / classifier-based providers (provider switch validates only `heuristic` in v0.9).
- IBAN / additional financial detectors (precision review still in progress).
- Entropy-based secret detection (too noisy on hashes / UUIDs / git SHAs).

Closes #158.