### PR TITLE
feat(replay): as-of receipt replay with policy snapshot (closes #159)

### DIFF
--- a/alembic/versions/0023_receipts_policy_snapshot.py
+++ b/alembic/versions/0023_receipts_policy_snapshot.py
@@ -1,0 +1,59 @@
+"""receipts.policy_snapshot — embedded policy YAML for as-of replay (v0.9 #159).
+
+Revision ID: 0023_receipts_policy_snapshot
+Revises: 0022_memories_suggested_labels
+Create Date: 2026-05-25
+
+v0.8 stored ``policy_bundle_hash`` on every receipt — enough to tell
+"which bundle was active when this receipt was emitted" but NOT enough
+to replay the decision later: the operator may have deleted or
+overwritten that bundle row, and a hash without the rules attached is
+opaque.
+
+v0.9 (#159) adds ``policy_snapshot``, a self-contained JSONB envelope
+that ships the bundle's YAML alongside its hash and the capture
+timestamp:
+
+    {
+      "bundle_hash": "<sha256>" | null,
+      "bundle_yaml": "<verbatim YAML>" | null,
+      "captured_at": "<ISO-8601>"
+    }
+
+A null inner pair records "no policy bundle was active" — distinct
+from the column being NULL (which means "pre-v0.9 receipt, never had
+a snapshot"). The replay endpoint refuses to operate on the latter
+(returns 422 ``unreplayable: missing_policy_snapshot``); the former
+replays cleanly against the no-policy fallback.
+
+The column is nullable so existing v0.8 receipts pass through the
+migration untouched — they remain queryable / verifiable, only the
+replay surface refuses them. Reversible: downgrade drops the column.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "0023_receipts_policy_snapshot"
+down_revision: Union[str, None] = "0022_memories_suggested_labels"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "receipts",
+        sa.Column(
+            "policy_snapshot",
+            JSONB,
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("receipts", "policy_snapshot")

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -1,0 +1,178 @@
+# Receipt replay
+
+Re-run a historical state-assembly retrieval against **current
+memories** using the **original policy bundle** captured on the
+receipt. Emits a fresh `mode="as_of_replay"` receipt linked back to
+the source, plus a diff envelope describing what changed.
+
+Introduced in **v0.9 (issue #159)**. The runtime half of v0.9
+governance — the ingest half is [auto-labeling](auto-labeling.md).
+
+## Semantic: current code + original policy
+
+Replay is **not** byte-for-byte reproduction. The user-approved
+design splits responsibility between two halves:
+
+| Source of truth | At replay time |
+|------------------|----------------|
+| Memories         | **Current** — added/removed/superseded since emission |
+| Compiler & scoring code | **Current** — whatever is deployed now |
+| Policy bundle    | **Original** — frozen on the receipt's `policy_snapshot` |
+
+This lets an auditor answer the question Statewave's accountability
+story was always meant to answer: *given the same rules my org had
+at the time, would I make the same retrieval decision today?* — and
+see explicitly where the answer would differ, separated into
+"data drift" (memory churn) and "policy drift" (which is *zero* in
+replay; the snapshot YAML is replayed verbatim even if the live
+bundle has since been overwritten).
+
+For true byte-for-byte historical reproduction we would need a
+memory snapshot too — that lands in a future PR as a separate
+feature. Replay's design intentionally leaves room for that
+extension without a schema break.
+
+## How it works
+
+1. **Emission** — every v0.9+ receipt carries
+   `policy_snapshot`, a JSONB envelope embedded both inside the
+   signed body and into a denormalised column for fast indexing:
+
+   ```json
+   {
+     "bundle_hash": "<sha256>" | null,
+     "bundle_yaml": "<verbatim YAML>" | null,
+     "captured_at": "<ISO-8601 UTC>"
+   }
+   ```
+
+   A null inner pair (`bundle_hash` AND `bundle_yaml` both null) is
+   a *valid* snapshot recording "no policy bundle was active at
+   emission" — that state replays cleanly against the no-policy
+   fallback. A NULL **column** instead means "pre-v0.9 receipt,
+   never captured a snapshot" and is not replayable.
+
+2. **Replay** — `POST /v1/receipts/{id}/replay`:
+
+   - Loads the original receipt (tenant-scoped 404).
+   - Refuses with 422 if the receipt is unreplayable (see below).
+   - Parses the snapshot's `bundle_yaml` into a PolicyBundle.
+   - Calls the same `assemble_context()` path that `/v1/context`
+     uses, with the snapshot bundle injected (bypassing the live
+     `policy_bundles` row) and `mode="as_of_replay"`.
+   - Emits a fresh receipt with `parent_receipt_id` pointing back
+     at the source.
+   - Computes the diff envelope by comparing the original and the
+     new receipt bodies.
+
+3. **Response**:
+
+   ```json
+   {
+     "original_receipt_id": "...",
+     "replay_receipt_id": "...",
+     "diff": {
+       "context_hash": {
+         "original": "...",
+         "replay":   "...",
+         "changed":  true
+       },
+       "selected_entries": {
+         "added":   [ <entry>, ... ],
+         "removed": [ <entry>, ... ],
+         "common":  <int>
+       },
+       "filters_applied": {
+         "added":   [ <filter>, ... ],
+         "removed": [ <filter>, ... ]
+       }
+     }
+   }
+   ```
+
+   Entries are matched by their `memory_id` / `episode_id`, so a
+   re-ranked-but-still-present entry is reported under `common`,
+   not `added` + `removed`. Filters are matched by
+   `(rule_id, memory_id, action)`.
+
+## Refusals (HTTP 422)
+
+The response envelope uses Statewave's standard error shape; the
+machine-readable code is on `error.code`:
+
+| `error.code`                            | When                                                                 |
+|-----------------------------------------|----------------------------------------------------------------------|
+| `unreplayable.missing_policy_snapshot`  | Pre-v0.9 receipt. The column is NULL — no snapshot was captured.    |
+| `unreplayable.nested_replay`            | Receipt is itself a replay. v0.9 ships one level only.              |
+| `unreplayable.invalid_snapshot`         | Snapshot YAML failed to parse. Tampering or corruption — see below. |
+
+Receipt-not-found returns plain 404 with the same wire shape as
+the read endpoints.
+
+## Failure modes
+
+* **Replay receipt write fails** — the diff envelope is still
+  returned (with the original entries listed under `removed` so
+  the caller can still see what was on the source). `replay_receipt_id`
+  is null. Same fail-open contract as the rest of the receipt
+  surface — agent serving must not be blocked by audit infra.
+
+* **Snapshot YAML tampered** — returns 422 `invalid_snapshot`. The
+  receipt body's HMAC signature would already have caught a
+  rewrite of the canonical fields; replay's parse failure is the
+  belt-and-suspenders backstop for someone who edits the column
+  directly via psql.
+
+* **Original bundle deleted from `policy_bundles`** — irrelevant.
+  The snapshot is self-contained; replay does not consult the live
+  bundles table.
+
+## What replay does NOT do
+
+* **Does not modify the original receipt.** The original is
+  immutable; the replay is a new row pointing back at it.
+* **Does not write to `sensitivity_labels` or memory state.**
+  Replay is read-only on memories.
+* **Does not run nested replays.** Replaying a replay returns 422.
+  The audit trail is still recoverable by walking
+  `parent_receipt_id` back to the original.
+* **Does not reproduce historical memory state.** Memories that
+  have been tombstoned since emission do not come back; new
+  memories show up in `selected_entries.added`. This is
+  intentional — see "Semantic" above.
+
+## Operator workflow
+
+A typical post-incident review:
+
+```bash
+# 1. Find the receipt for the retrieval under investigation.
+curl /v1/receipts/01J5...
+
+# 2. Replay it. The diff tells you exactly what changed.
+curl -X POST /v1/receipts/01J5.../replay
+
+# 3. Both receipts (original + replay) remain in /v1/receipts list,
+#    linked by parent_receipt_id, so the audit trail is durable.
+```
+
+The signature on every receipt (v0.9 #157) plus the snapshot YAML
+(v0.9 #159) means an auditor can verify after the fact that:
+  1. The receipt body has not been tampered with (signature check), AND
+  2. The exact policy rules used at emission are still recoverable
+     (the YAML is right there in the receipt), AND
+  3. Re-running the decision today produces a diff against the
+     current memory state — separating "the rules changed" from
+     "the data changed" in incident reviews.
+
+## Pre-v0.9 receipts
+
+Receipts emitted by Statewave ≤ v0.8 carry no `policy_snapshot`.
+They remain queryable, list-able, and HMAC-verifiable (if signed),
+but `POST /v1/receipts/{id}/replay` refuses them with 422
+`unreplayable.missing_policy_snapshot`.
+
+This is intentional: we cannot synthesise a snapshot retroactively
+without guessing which policy bundle was active at the time, which
+defeats the entire point. Fresh v0.9+ traffic carries snapshots,
+and the operator's audit trail starts there.

--- a/server/api/receipts.py
+++ b/server/api/receipts.py
@@ -1,15 +1,20 @@
-"""State-assembly receipts read API.
+"""State-assembly receipts read API + v0.9 replay.
 
-Only two endpoints in v1:
-
-  * `GET /v1/receipts/{receipt_id}` — point lookup.
-  * `GET /v1/receipts` — list for a subject in a time window with
+  * `GET  /v1/receipts/{receipt_id}` — point lookup.
+  * `GET  /v1/receipts/{receipt_id}/verify` — HMAC verification (v0.9 #157).
+  * `GET  /v1/receipts` — list for a subject in a time window with
     cursor-based pagination.
+  * `POST /v1/receipts/{receipt_id}/replay` — as-of-replay (v0.9 #159):
+    re-runs the original assembly against current memories using the
+    original policy bundle captured in the receipt's snapshot, emits a
+    new ``mode="as_of_replay"`` receipt, and returns the diff envelope.
 
-Both are tenant-scoped via the existing `X-Statewave-Tenant` header.
-Receipts are read-only on the wire — issue #49's accountability
-guarantee depends on the audit log being immutable, so no
-write/update/delete endpoints are exposed.
+Tenant-scoped via the existing `X-Statewave-Tenant` header.
+
+Receipts themselves remain immutable: replay does not modify the
+original, it only emits a *new* receipt with `parent_receipt_id`
+pointing back at the source. Issue #49's accountability guarantee is
+preserved end-to-end.
 """
 
 from __future__ import annotations
@@ -18,6 +23,7 @@ from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.core.dependencies import get_tenant_id
@@ -95,6 +101,81 @@ def _row_to_response(row) -> dict[str, Any]:
     if row.tombstoned_at is not None:
         out["tombstoned_at"] = row.tombstoned_at.isoformat()
     return out
+
+
+class ReplayResponse(BaseModel):
+    """Response shape for POST /v1/receipts/{id}/replay."""
+
+    original_receipt_id: str
+    replay_receipt_id: str | None
+    diff: dict[str, Any]
+
+
+@router.post(
+    "/v1/receipts/{receipt_id}/replay",
+    response_model=ReplayResponse,
+    summary="Re-run the original assembly with the receipt's snapshot policy (v0.9 #159)",
+    responses={
+        404: {"description": "Receipt not found"},
+        422: {
+            "description": (
+                "Receipt cannot be replayed. The standard error envelope "
+                "carries `error.code = unreplayable.<reason>` where reason "
+                "is one of `missing_policy_snapshot`, `nested_replay`, "
+                "`invalid_snapshot`."
+            )
+        },
+    },
+)
+async def replay_receipt_endpoint(
+    receipt_id: str,
+    session: AsyncSession = Depends(get_session),
+    tenant_id: str | None = Depends(get_tenant_id),
+) -> ReplayResponse:
+    """Replay a v0.9+ receipt against the *current* memory state using
+    the *original* policy bundle from the receipt's ``policy_snapshot``.
+
+    Semantic: current code + original policy. Replay is NOT
+    byte-for-byte reproduction — see docs/replay.md for the design
+    rationale. The response carries a structural diff (added/removed
+    selected_entries, added/removed policy filters, context_hash
+    change) so an auditor can pinpoint what shifted between original
+    emission and now.
+
+    A fresh receipt is emitted with ``mode="as_of_replay"`` and
+    ``parent_receipt_id`` set to the source ULID. The original receipt
+    is never modified.
+
+    Refusal codes (HTTP 422):
+
+      * ``missing_policy_snapshot`` — pre-v0.9 receipt, no snapshot.
+      * ``nested_replay`` — already a replay; replay the original parent.
+      * ``invalid_snapshot`` — snapshot YAML corrupt / unparseable.
+    """
+    from server.services.replay import ReplayError, replay_receipt
+
+    try:
+        result = await replay_receipt(session, receipt_id=receipt_id, tenant_id=tenant_id)
+    except ReplayError as exc:
+        if exc.reason == "not_found":
+            raise HTTPException(status_code=404, detail="receipt not found") from exc
+        # The global error handler unwraps `code` + `message` from dict
+        # details into the standard `{error: {...}}` envelope. We use
+        # `unreplayable.<reason>` so machine consumers can switch on
+        # the code without parsing the message body.
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": f"unreplayable.{exc.reason}",
+                "message": exc.detail or exc.reason,
+            },
+        ) from exc
+
+    return ReplayResponse(
+        original_receipt_id=result.original_receipt_id,
+        replay_receipt_id=result.replay_receipt_id,
+        diff=result.diff,
+    )
 
 
 @router.get(

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -254,6 +254,12 @@ class ReceiptRow(Base):
     receipt_signature_key_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     receipt_signature_algorithm: Mapped[str | None] = mapped_column(String(64), nullable=True)
     body: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    # Embedded policy bundle YAML + hash captured at emission (issue #159).
+    # Self-contained — replay can re-evaluate without consulting the live
+    # `policy_bundles` row (which may have been deleted or overwritten).
+    # NULL for pre-v0.9 receipts; the replay endpoint refuses those with
+    # 422 ``missing_policy_snapshot``. See docs/replay.md.
+    policy_snapshot: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     as_of: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -145,6 +145,16 @@ async def assemble_context(
     parent_receipt_id: str | None = None,
     caller_id: str | None = None,
     caller_type: str | None = None,
+    # v0.9 (#159) — replay knobs. Both are private contract between
+    # `services.replay` and this function; the public `/v1/context`
+    # route never sets them. The bundle override forces evaluation
+    # against a specific PolicyBundle (loaded from a receipt's
+    # snapshot) instead of resolving the live `policy_bundles` row.
+    # The mode override stamps the emitted receipt as
+    # ``as_of_replay`` rather than ``retrieval``.
+    _policy_bundle_override: "policy_service.PolicyBundle | None" = None,
+    _use_policy_bundle_override: bool = False,
+    _mode_override: str | None = None,
 ) -> ContextBundleResponse:
     """Build a deterministic, token-bounded, ranked context bundle.
 
@@ -197,9 +207,8 @@ async def assemble_context(
             # provider round-trip exactly once cluster-wide. Falls through
             # to the provider transparently on miss / DB error.
             from server.db.engine import get_session_factory
-            task_embedding = await cached_embed_query(
-                get_session_factory(), provider, task
-            )
+
+            task_embedding = await cached_embed_query(get_session_factory(), provider, task)
             # Top 100 memories by cosine distance — this set is the SEMANTIC
             # contribution to the candidate pool below, in addition to being
             # used as a score lookup during ranking.
@@ -283,21 +292,27 @@ async def assemble_context(
     # (the default) no row is removed — the decisions are still recorded
     # into the receipt so tenants can audit what *would* be filtered before
     # flipping to enforce.
-    tenant_config = await receipts_service.load_tenant_receipt_config(
-        session, tenant_id
-    )
+    tenant_config = await receipts_service.load_tenant_receipt_config(session, tenant_id)
     policy_mode = (tenant_config or {}).get("policy_mode", "log_only")
     policy_enforce = policy_mode == "enforce"
-    active_bundle = await policy_service.resolve_active_bundle(session, tenant_id)
+    # Replay path injects the historical snapshot bundle so the
+    # decision matrix matches the original assembly's, even if the
+    # live `policy_bundles` row has since been overwritten or
+    # removed. The override flag is intentionally separate from the
+    # value being non-None: a snapshot that captured "no bundle was
+    # active" replays correctly by passing
+    # `_use_policy_bundle_override=True, _policy_bundle_override=None`.
+    if _use_policy_bundle_override:
+        active_bundle = _policy_bundle_override
+    else:
+        active_bundle = await policy_service.resolve_active_bundle(session, tenant_id)
     policy_context = policy_service.PolicyContext(
         caller_id=caller_id,
         caller_type=caller_type,
         tenant_id=tenant_id,
     )
 
-    all_memory_rows_pre_policy = (
-        list(fact_rows) + list(procedure_rows) + list(summary_rows)
-    )
+    all_memory_rows_pre_policy = list(fact_rows) + list(procedure_rows) + list(summary_rows)
     policy_decisions: dict[Any, policy_service.MemoryPolicyDecision] = {}
     for row in all_memory_rows_pre_policy:
         decision = policy_service.evaluate_memory(
@@ -312,9 +327,7 @@ async def assemble_context(
         # Filter the per-kind buckets so the rest of the assembly path
         # never sees a denied row. Redact is applied in place by
         # apply_decisions and the row is kept.
-        kept_facts, _ = policy_service.apply_decisions(
-            fact_rows, policy_decisions, enforce=True
-        )
+        kept_facts, _ = policy_service.apply_decisions(fact_rows, policy_decisions, enforce=True)
         kept_procs, _ = policy_service.apply_decisions(
             procedure_rows, policy_decisions, enforce=True
         )
@@ -324,12 +337,8 @@ async def assemble_context(
         fact_rows = kept_facts
         procedure_rows = kept_procs
         summary_rows = kept_summaries
-        denied_count = sum(
-            1 for d in policy_decisions.values() if d.action == "deny"
-        )
-        redacted_count = sum(
-            1 for d in policy_decisions.values() if d.action == "redact"
-        )
+        denied_count = sum(1 for d in policy_decisions.values() if d.action == "deny")
+        redacted_count = sum(1 for d in policy_decisions.values() if d.action == "redact")
         logger.info(
             "policy_enforced",
             tenant_id=tenant_id,
@@ -367,9 +376,7 @@ async def assemble_context(
             needed_episode_ids.add(sid)
     if needed_episode_ids:
         try:
-            src_episodes = await repo.get_episodes_by_ids(
-                session, list(needed_episode_ids)
-            )
+            src_episodes = await repo.get_episodes_by_ids(session, list(needed_episode_ids))
             ep_breadcrumb_by_id: dict[uuid.UUID, str] = {}
             for ep in src_episodes:
                 payload = ep.payload or {}
@@ -512,11 +519,7 @@ async def assemble_context(
                 and _lexical_overlap_bonus(content_text, task_tokens) > 0.0
             ):
                 task_relevant = True
-            score = (
-                _EPISODE_PRIORITY
-                + _recency_score(row.created_at, ep_ts_range)
-                + ep_relevance
-            )
+            score = _EPISODE_PRIORITY + _recency_score(row.created_at, ep_ts_range) + ep_relevance
             # Boost episodes belonging to the active session
             if session_id and getattr(row, "session_id", None) == session_id:
                 score += _SESSION_BOOST
@@ -699,7 +702,7 @@ async def assemble_context(
         query_id=query_id,
         task_id=task_id,
         parent_receipt_id=parent_receipt_id,
-        mode="retrieval",
+        mode=_mode_override or "retrieval",
         caller_id=caller_id,
         caller_type=caller_type,
         tenant_config=tenant_config,
@@ -752,9 +755,7 @@ async def _maybe_emit_receipt(
     share this routine — keeping the decision logic and the write path
     in a single place avoids divergence as the schema grows."""
     if tenant_config is None:
-        tenant_config = await receipts_service.load_tenant_receipt_config(
-            session, tenant_id
-        )
+        tenant_config = await receipts_service.load_tenant_receipt_config(session, tenant_id)
     decision = receipts_service.decide_emission(
         request_flag=emit_receipt,
         tenant_config=tenant_config,
@@ -772,9 +773,7 @@ async def _maybe_emit_receipt(
     context_hash, context_size_bytes = receipts_service.canonicalize_context(assembled)
     policy_decisions = policy_decisions or {}
     filters_applied = policy_service.build_filters_applied(policy_decisions)
-    filters_skipped = policy_service.build_filters_skipped(
-        policy_decisions, policy_bundle
-    )
+    filters_skipped = policy_service.build_filters_skipped(policy_decisions, policy_bundle)
 
     selected_memories = [
         receipts_service.SelectedMemory(
@@ -801,6 +800,17 @@ async def _maybe_emit_receipt(
     ]
 
     receipt_id = receipts_service.new_ulid()
+    # v0.9 #159 — embed the active bundle's YAML on every receipt so
+    # the replay engine can re-evaluate against the same rule set the
+    # original assembly saw, even if the live `policy_bundles` row
+    # was later deleted or overwritten. When no bundle is active we
+    # still stamp a snapshot envelope with null fields so replay can
+    # distinguish "no policy was active" (replayable) from
+    # "pre-v0.9 receipt, no snapshot exists" (NOT replayable).
+    policy_snapshot = receipts_service.build_policy_snapshot(
+        bundle_hash=policy_bundle.bundle_hash if policy_bundle else None,
+        bundle_yaml=policy_bundle.yaml_content if policy_bundle else None,
+    )
     body = receipts_service.build_receipt_body(
         receipt_id=receipt_id,
         mode=mode,
@@ -822,6 +832,7 @@ async def _maybe_emit_receipt(
         filters_skipped=filters_skipped,
         caller_id=caller_id,
         caller_type=caller_type,
+        policy_snapshot=policy_snapshot,
     )
     written_id = await receipts_service.write_receipt(
         session, receipt_body=body, as_of=as_of, tenant_config=tenant_config
@@ -839,9 +850,7 @@ async def _maybe_emit_receipt(
         episode_count=len(selected_episodes),
         context_size_bytes=context_size_bytes,
         policy_filters_applied=len(filters_applied),
-        policy_bundle_hash=(
-            policy_bundle.bundle_hash if policy_bundle else None
-        ),
+        policy_bundle_hash=(policy_bundle.bundle_hash if policy_bundle else None),
     )
     return written_id, True
 
@@ -971,10 +980,7 @@ def _breadcrumb_overlap_bonus(
     # Strip punctuation that _tokenize_for_relevance leaves attached
     # (e.g. "GPU?" → "gpu") so task tokens match cleanly against the
     # breadcrumb tokens we compute below.
-    task_meaningful = {
-        t.strip("?.,:;()[]{}'\"")
-        for t in task_tokens
-    }
+    task_meaningful = {t.strip("?.,:;()[]{}'\"") for t in task_tokens}
     task_meaningful = {t for t in task_meaningful if t and t not in _BREADCRUMB_STOPWORDS}
     if not task_meaningful:
         return 0.0

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0022_memories_suggested_labels"
+EXPECTED_HEAD = "0023_receipts_policy_snapshot"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/server/services/receipts.py
+++ b/server/services/receipts.py
@@ -242,6 +242,7 @@ def build_receipt_body(
     caller_id: str | None = None,
     caller_type: str | None = None,
     region: str | None = None,
+    policy_snapshot: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Render the strict-superset receipt body. Pure function — same
     inputs always produce the same JSON-serializable dict."""
@@ -305,6 +306,10 @@ def build_receipt_body(
             "filters_skipped": list(filters_skipped or []),
             "mode": policy_mode,
         },
+        # v0.9 (#159): self-contained bundle YAML + hash for replay.
+        # See `build_policy_snapshot()`. Pre-v0.9 receipts have this
+        # column NULL — the replay endpoint refuses those.
+        "policy_snapshot": policy_snapshot,
         "output": {
             "context_hash": context_hash,
             "context_size_bytes": context_size_bytes,
@@ -313,6 +318,38 @@ def build_receipt_body(
         },
         "region": region,
         "receipt_signature": None,
+    }
+
+
+def build_policy_snapshot(
+    *,
+    bundle_hash: str | None,
+    bundle_yaml: str | None,
+) -> dict[str, Any]:
+    """Compose the snapshot envelope embedded into every v0.9 receipt.
+
+    Shape:
+        {"bundle_hash": "<sha256>" | null,
+         "bundle_yaml": "<verbatim YAML>" | null,
+         "captured_at": "<ISO-8601 UTC>"}
+
+    A null inner pair (``bundle_hash`` AND ``bundle_yaml`` both null)
+    records "no policy bundle was active at emission" — which is a
+    valid, replayable state. The replay path treats it as the
+    no-policy fallback (all memories allowed). The column being
+    NULL on the row, by contrast, marks "pre-v0.9 receipt, no
+    snapshot was ever captured" — the replay endpoint refuses
+    those with 422 ``missing_policy_snapshot``.
+
+    ``captured_at`` is recorded so an operator inspecting a receipt
+    weeks later can see when the YAML was frozen, which may differ
+    from the receipt's own ``created_at`` if the same bundle had been
+    active long before the receipt fired.
+    """
+    return {
+        "bundle_hash": bundle_hash,
+        "bundle_yaml": bundle_yaml,
+        "captured_at": _iso(datetime.now(timezone.utc)),
     }
 
 
@@ -367,6 +404,11 @@ async def write_receipt(
             receipt_signature_key_id=receipt_body.get("receipt_signature_key_id"),
             receipt_signature_algorithm=receipt_body.get("receipt_signature_algorithm"),
             body=receipt_body,
+            # Mirror the snapshot onto the dedicated column too — the
+            # body field is authoritative (signed) but the column lets
+            # the replay engine + admin list-views filter without
+            # rummaging through JSONB. Both reads should agree.
+            policy_snapshot=receipt_body.get("policy_snapshot"),
             as_of=as_of,
         )
         await repo.insert_receipt(session, row)

--- a/server/services/replay.py
+++ b/server/services/replay.py
@@ -1,0 +1,300 @@
+"""State-assembly receipt replay (v0.9, issue #159).
+
+Re-runs the original assembly against **current memories** but the
+**original policy bundle** captured in the receipt's ``policy_snapshot``
+envelope. Emits a fresh receipt with ``mode="as_of_replay"`` and
+``parent_receipt_id`` pointing at the original, plus a diff envelope
+describing what changed between the two.
+
+## Semantic
+
+The user-approved semantic for v0.9: *current code + original policy*.
+Replay is **not** byte-for-byte reproduction:
+
+  * Memories may have been added, tombstoned, or supersession-resolved
+    between original emission and replay. Those are real-world changes
+    and appear in the diff as added/removed selected_entries.
+  * Episodes may have been ingested. New episodes appearing in scope
+    show up as added entries.
+  * The compiler / scoring algorithms run against whatever code is
+    deployed at replay time. If a heuristic changed, ranks may differ
+    — the diff records that as a context_hash change.
+  * The policy bundle, by contrast, is frozen on the original receipt
+    via ``policy_snapshot.bundle_yaml`` and replayed verbatim — so a
+    rule that the operator later deleted from the live bundle still
+    fires during replay. This is the load-bearing property of the
+    snapshot.
+
+## Refusals (422 ``unreplayable``)
+
+  * ``missing_policy_snapshot`` — pre-v0.9 receipt, never captured a
+    snapshot. Operator must wait for fresh v0.9 traffic, or accept
+    that the audit trail for that emission stops at "what was stored."
+  * ``nested_replay`` — the receipt is itself a replay
+    (``mode == "as_of_replay"``). v0.9 ships one level only; replaying
+    a replay is not supported.
+  * ``invalid_snapshot`` — the snapshot's YAML fails to parse (it
+    parsed at emission, so corruption / tampering is the likely
+    cause). Surface explicitly rather than crashing.
+
+Failure to emit the replay receipt itself does NOT raise — same
+contract as `services.receipts.write_receipt`. The endpoint returns
+the diff envelope unconditionally; ``replay_receipt_id`` will be null
+on write failure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.db import repositories as repo
+from server.db.tables import ReceiptRow
+from server.services import context as context_service
+from server.services import policy as policy_service
+
+logger = structlog.stdlib.get_logger()
+
+
+class ReplayError(Exception):
+    """Raised when a receipt cannot be replayed. ``reason`` is one of
+    the documented ``unreplayable`` codes; the API layer maps it to
+    HTTP 422 with the same code in the response body."""
+
+    def __init__(self, reason: str, detail: str | None = None):
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"{reason}: {detail}" if detail else reason)
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    """Outcome of a successful replay. Returned by `replay_receipt`."""
+
+    original_receipt_id: str
+    replay_receipt_id: str | None
+    """ULID of the new replay receipt, or None if the write failed
+    (the diff is still authoritative — failure is logged)."""
+    diff: dict[str, Any]
+    """Structural diff between original and replay receipt bodies.
+    See `_compute_diff` for the shape."""
+
+
+async def replay_receipt(
+    session: AsyncSession,
+    *,
+    receipt_id: str,
+    tenant_id: str | None = None,
+) -> ReplayResult:
+    """Load the original receipt, replay against current memories, and
+    return the diff envelope plus the new receipt id.
+
+    Tenant-scoped: callers passing ``tenant_id`` cannot replay another
+    tenant's receipts even if they guess the ULID.
+
+    Raises:
+        ReplayError: when the receipt cannot be replayed. ``reason``
+            is one of: ``not_found``, ``missing_policy_snapshot``,
+            ``nested_replay``, ``invalid_snapshot``.
+    """
+    original = await repo.get_receipt_by_id(session, receipt_id, tenant_id=tenant_id)
+    if original is None:
+        raise ReplayError("not_found", f"receipt {receipt_id} not found")
+
+    # Refuse v0.9 nested replay — replaying a replay would compound
+    # diffs and obscure the audit trail.
+    if original.mode == "as_of_replay":
+        raise ReplayError(
+            "nested_replay",
+            "this receipt is itself a replay; replay the original parent instead",
+        )
+
+    snapshot = original.policy_snapshot
+    if snapshot is None:
+        raise ReplayError(
+            "missing_policy_snapshot",
+            "pre-v0.9 receipt — no policy snapshot was captured at emission",
+        )
+
+    # Parse the snapshot bundle. A null inner pair is a valid
+    # "no policy was active" snapshot; we replay that as "no bundle."
+    snapshot_bundle: policy_service.PolicyBundle | None = None
+    bundle_yaml = snapshot.get("bundle_yaml")
+    if bundle_yaml:
+        try:
+            snapshot_bundle = policy_service.load_bundle(bundle_yaml)
+        except policy_service.PolicyError as exc:
+            raise ReplayError(
+                "invalid_snapshot",
+                f"snapshot YAML failed to parse: {exc}",
+            ) from exc
+
+    # Re-extract the request fields the assembly path needs. The body
+    # is authoritative — the columns are denormalised for indexing.
+    body = original.body or {}
+    subject_id = original.subject_id
+    task = body.get("task")
+    if not task:
+        # A receipt without a `task` cannot be replayed: the assembly
+        # path's scoring is keyed off it. v0.8+ always populates this,
+        # so a missing value is structural corruption — surface
+        # rather than emit an empty replay.
+        raise ReplayError(
+            "invalid_snapshot",
+            "original receipt body is missing `task` — cannot replay",
+        )
+
+    # Replay assembly. `_use_policy_bundle_override` flag is the only
+    # signal that distinguishes "skip the snapshot bundle (None)"
+    # from "use the live bundle"; the value itself can be None when
+    # the snapshot recorded no active policy.
+    bundle = await context_service.assemble_context(
+        session,
+        subject_id=subject_id,
+        task=task,
+        tenant_id=original.tenant_id,
+        emit_receipt=True,
+        parent_receipt_id=original.receipt_id,
+        caller_id=body.get("caller_id"),
+        caller_type=body.get("caller_type"),
+        _policy_bundle_override=snapshot_bundle,
+        _use_policy_bundle_override=True,
+        _mode_override="as_of_replay",
+    )
+
+    # Load the freshly-emitted replay receipt so we can diff its body
+    # against the original. The assembler returns the receipt_id only;
+    # the persisted body is the authoritative source of truth (the
+    # in-memory `bundle` carries only the assembled-context surface,
+    # not the receipt body itself).
+    replay_row: ReceiptRow | None = None
+    if bundle.receipt_id:
+        replay_row = await repo.get_receipt_by_id(
+            session, bundle.receipt_id, tenant_id=original.tenant_id
+        )
+    diff = _compute_diff(
+        original_body=body,
+        replay_body=replay_row.body if replay_row else None,
+    )
+
+    return ReplayResult(
+        original_receipt_id=original.receipt_id,
+        replay_receipt_id=bundle.receipt_id,
+        diff=diff,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diff envelope
+# ---------------------------------------------------------------------------
+
+
+def _compute_diff(
+    *,
+    original_body: dict[str, Any],
+    replay_body: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Compare two receipt bodies and return the structural diff envelope.
+
+    Envelope shape (stable contract; see docs/replay.md):
+
+        {
+          "context_hash": {
+              "original": "...",
+              "replay":   "...",
+              "changed":  True | False
+          },
+          "selected_entries": {
+              "added":    [<entry>, ...],   # in replay, not in original
+              "removed":  [<entry>, ...],   # in original, not in replay
+              "common":   <int>             # entries present in both, by id
+          },
+          "filters_applied": {
+              "added":    [<filter>, ...],
+              "removed":  [<filter>, ...]
+          }
+        }
+
+    Entries are matched by their ``memory_id`` / ``episode_id`` —
+    re-ranking the same entry does not show up as add+remove. The
+    ``common`` count counts entries present in both sets regardless
+    of rank or score.
+
+    If ``replay_body`` is None (the replay receipt write failed),
+    the diff is reported as everything-removed: the original entries
+    are listed as ``removed`` and ``replay`` fields are null, so the
+    caller can still see what was on the original.
+    """
+    original_entries = list(original_body.get("selected_entries", []) or [])
+    original_filters = list(
+        (original_body.get("policy", {}) or {}).get("filters_applied", []) or []
+    )
+    original_hash = (original_body.get("output", {}) or {}).get("context_hash")
+
+    if replay_body is None:
+        return {
+            "context_hash": {
+                "original": original_hash,
+                "replay": None,
+                "changed": True,
+            },
+            "selected_entries": {
+                "added": [],
+                "removed": original_entries,
+                "common": 0,
+            },
+            "filters_applied": {
+                "added": [],
+                "removed": original_filters,
+            },
+        }
+
+    replay_entries = list(replay_body.get("selected_entries", []) or [])
+    replay_filters = list((replay_body.get("policy", {}) or {}).get("filters_applied", []) or [])
+    replay_hash = (replay_body.get("output", {}) or {}).get("context_hash")
+
+    # Entries keyed by their object id (memory_id or episode_id). An
+    # entry with neither is malformed; skip rather than crash.
+    def _key(entry: dict[str, Any]) -> str | None:
+        if entry.get("type") == "memory":
+            return entry.get("memory_id")
+        if entry.get("type") == "episode":
+            return entry.get("episode_id")
+        return None
+
+    orig_by_id = {k: e for e in original_entries if (k := _key(e))}
+    repl_by_id = {k: e for e in replay_entries if (k := _key(e))}
+    added = [repl_by_id[k] for k in repl_by_id.keys() - orig_by_id.keys()]
+    removed = [orig_by_id[k] for k in orig_by_id.keys() - repl_by_id.keys()]
+    common = len(orig_by_id.keys() & repl_by_id.keys())
+
+    # Filters keyed by `(rule_id, memory_id, action)` so a tenant
+    # tweaking one rule but firing the same memory shows up as a
+    # remove+add rather than a silent overwrite.
+    def _filter_key(f: dict[str, Any]) -> tuple:
+        return (f.get("rule_id"), f.get("memory_id"), f.get("action"))
+
+    orig_filter_set = {_filter_key(f): f for f in original_filters}
+    repl_filter_set = {_filter_key(f): f for f in replay_filters}
+    filters_added = [repl_filter_set[k] for k in repl_filter_set.keys() - orig_filter_set.keys()]
+    filters_removed = [orig_filter_set[k] for k in orig_filter_set.keys() - repl_filter_set.keys()]
+
+    return {
+        "context_hash": {
+            "original": original_hash,
+            "replay": replay_hash,
+            "changed": original_hash != replay_hash,
+        },
+        "selected_entries": {
+            "added": added,
+            "removed": removed,
+            "common": common,
+        },
+        "filters_applied": {
+            "added": filters_added,
+            "removed": filters_removed,
+        },
+    }

--- a/tests/integration/test_replay.py
+++ b/tests/integration/test_replay.py
@@ -1,0 +1,269 @@
+"""Integration tests for receipt replay (v0.9 #159).
+
+Covers:
+  * Happy path — v0.9 receipt replays cleanly, emits a child receipt
+    with mode="as_of_replay" and parent_receipt_id set.
+  * Diff envelope picks up a memory added between emission and replay.
+  * `policy_snapshot` is persisted on every new receipt (column + body).
+  * Pre-v0.9 receipt (column NULL) → 422 unreplayable: missing_policy_snapshot.
+  * Replaying a replay → 422 unreplayable: nested_replay.
+  * Invalid (unparseable) snapshot YAML → 422 unreplayable: invalid_snapshot.
+  * Tenant isolation — receipts under tenant A are 404 for tenant B.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, update
+
+from server.db.tables import ReceiptRow
+
+
+_EPISODES = [
+    {
+        "source": "test",
+        "type": "chat.session",
+        "payload": {
+            "messages": [
+                {"role": "user", "content": "My name is Alice. I use dark mode."},
+                {"role": "assistant", "content": "Got it."},
+            ]
+        },
+    },
+]
+
+
+async def _seed(client: AsyncClient, subject_id: str) -> None:
+    for ep in _EPISODES:
+        r = await client.post("/v1/episodes", json={**ep, "subject_id": subject_id})
+        assert r.status_code == 201, r.text
+    r = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert r.status_code == 200, r.text
+
+
+async def _emit_receipt(
+    client: AsyncClient, subject_id: str, task: str = "what's the plan?"
+) -> str:
+    r = await client.post(
+        "/v1/context",
+        json={"subject_id": subject_id, "task": task, "emit_receipt": True},
+    )
+    assert r.status_code == 200, r.text
+    receipt_id = r.json().get("receipt_id")
+    assert receipt_id, "expected receipt_id on emit"
+    return receipt_id
+
+
+# ---------------------------------------------------------------------------
+# Policy snapshot is stamped on every new receipt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_policy_snapshot_stamped_on_v09_receipts(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """Every v0.9 receipt must carry a policy_snapshot envelope, even
+    when no policy bundle is active (in which case the inner fields
+    are null but the envelope itself exists)."""
+    await _seed(client, subject_id)
+    receipt_id = await _emit_receipt(client, subject_id)
+
+    async with session_factory() as session:
+        row = (
+            await session.execute(select(ReceiptRow).where(ReceiptRow.receipt_id == receipt_id))
+        ).scalar_one()
+
+    # Column was persisted with the right shape
+    assert row.policy_snapshot is not None
+    assert "bundle_hash" in row.policy_snapshot
+    assert "bundle_yaml" in row.policy_snapshot
+    assert "captured_at" in row.policy_snapshot
+    # bundle_hash and bundle_yaml move together — either both null
+    # (no active bundle) or both populated. They never disagree.
+    has_hash = row.policy_snapshot["bundle_hash"] is not None
+    has_yaml = row.policy_snapshot["bundle_yaml"] is not None
+    assert has_hash == has_yaml, (
+        "policy_snapshot envelope is inconsistent: bundle_hash and "
+        "bundle_yaml must be both null or both populated"
+    )
+    # Body and column agree (body is signed, column is denormalised)
+    assert row.body.get("policy_snapshot") == row.policy_snapshot
+
+
+# ---------------------------------------------------------------------------
+# Happy path — replay produces a child receipt + diff envelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_replay_emits_child_receipt_with_parent_pointer(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    await _seed(client, subject_id)
+    original_id = await _emit_receipt(client, subject_id)
+
+    r = await client.post(f"/v1/receipts/{original_id}/replay")
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    assert body["original_receipt_id"] == original_id
+    replay_id = body["replay_receipt_id"]
+    assert replay_id, "expected a replay_receipt_id"
+    assert replay_id != original_id
+
+    # The child receipt exists and points back at the parent.
+    async with session_factory() as session:
+        child = (
+            await session.execute(select(ReceiptRow).where(ReceiptRow.receipt_id == replay_id))
+        ).scalar_one()
+    assert child.mode == "as_of_replay"
+    assert child.parent_receipt_id == original_id
+
+
+@pytest.mark.anyio
+async def test_replay_with_no_memory_changes_reports_zero_diff(
+    client: AsyncClient, subject_id: str
+):
+    """Same memories at emission and replay → no add/remove in the
+    selected_entries diff. Context hash may or may not change depending
+    on scoring stability, but the entry set must be invariant."""
+    await _seed(client, subject_id)
+    original_id = await _emit_receipt(client, subject_id)
+
+    r = await client.post(f"/v1/receipts/{original_id}/replay")
+    assert r.status_code == 200, r.text
+    diff = r.json()["diff"]
+
+    assert diff["selected_entries"]["added"] == []
+    assert diff["selected_entries"]["removed"] == []
+    assert diff["selected_entries"]["common"] >= 1
+    # filters_applied stays empty when no bundle is active on either run
+    assert diff["filters_applied"]["added"] == []
+    assert diff["filters_applied"]["removed"] == []
+
+
+@pytest.mark.anyio
+async def test_replay_diff_captures_newly_added_memory(client: AsyncClient, subject_id: str):
+    """Add a memory between emission and replay; the diff must show
+    the new memory under selected_entries.added."""
+    await _seed(client, subject_id)
+    original_id = await _emit_receipt(client, subject_id)
+
+    # Inject a new episode + compile so a brand-new memory exists.
+    new_ep = {
+        "source": "test",
+        "type": "chat.session",
+        "subject_id": subject_id,
+        "payload": {
+            "messages": [
+                {"role": "user", "content": "Also I work at Initech as a senior engineer."},
+            ]
+        },
+    }
+    r = await client.post("/v1/episodes", json=new_ep)
+    assert r.status_code == 201
+    r = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert r.status_code == 200
+
+    r = await client.post(f"/v1/receipts/{original_id}/replay")
+    assert r.status_code == 200, r.text
+    diff = r.json()["diff"]
+
+    # The new memory shows up as an addition in the replay.
+    assert len(diff["selected_entries"]["added"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# 422 refusals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_pre_v09_receipt_is_unreplayable(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """A receipt with a NULL policy_snapshot column (the pre-v0.9
+    state) must be refused with 422 missing_policy_snapshot. We
+    simulate the pre-v0.9 state by stripping the column post-emission."""
+    await _seed(client, subject_id)
+    receipt_id = await _emit_receipt(client, subject_id)
+
+    # Strip snapshot on both the column and the body to mirror a
+    # truly pre-v0.9 row.
+    async with session_factory() as session:
+        await session.execute(
+            update(ReceiptRow)
+            .where(ReceiptRow.receipt_id == receipt_id)
+            .values(policy_snapshot=None)
+        )
+        # Also remove from the body so a replay isn't tempted to fall back.
+        row = (
+            await session.execute(select(ReceiptRow).where(ReceiptRow.receipt_id == receipt_id))
+        ).scalar_one()
+        new_body = dict(row.body)
+        new_body.pop("policy_snapshot", None)
+        await session.execute(
+            update(ReceiptRow).where(ReceiptRow.receipt_id == receipt_id).values(body=new_body)
+        )
+        await session.commit()
+
+    r = await client.post(f"/v1/receipts/{receipt_id}/replay")
+    assert r.status_code == 422, r.text
+    err = r.json()["error"]
+    assert err["code"] == "unreplayable.missing_policy_snapshot"
+
+
+@pytest.mark.anyio
+async def test_nested_replay_is_unreplayable(client: AsyncClient, subject_id: str):
+    """Replaying a replay must return 422 nested_replay."""
+    await _seed(client, subject_id)
+    original_id = await _emit_receipt(client, subject_id)
+
+    # First replay succeeds.
+    r = await client.post(f"/v1/receipts/{original_id}/replay")
+    assert r.status_code == 200
+    replay_id = r.json()["replay_receipt_id"]
+    assert replay_id
+
+    # Second replay against the replay receipt is refused.
+    r = await client.post(f"/v1/receipts/{replay_id}/replay")
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "unreplayable.nested_replay"
+
+
+@pytest.mark.anyio
+async def test_invalid_snapshot_yaml_returns_422(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """If the snapshot YAML is unparseable (e.g. tampered), surface
+    invalid_snapshot rather than crashing."""
+    await _seed(client, subject_id)
+    receipt_id = await _emit_receipt(client, subject_id)
+
+    bad_snapshot = {
+        "bundle_hash": "deadbeef",
+        "bundle_yaml": "::: this is not valid yaml :::",
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+    }
+    async with session_factory() as session:
+        await session.execute(
+            update(ReceiptRow)
+            .where(ReceiptRow.receipt_id == receipt_id)
+            .values(policy_snapshot=bad_snapshot)
+        )
+        await session.commit()
+
+    r = await client.post(f"/v1/receipts/{receipt_id}/replay")
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "unreplayable.invalid_snapshot"
+
+
+@pytest.mark.anyio
+async def test_replay_404_for_unknown_receipt(client: AsyncClient):
+    r = await client.post(f"/v1/receipts/{uuid.uuid4().hex[:26].upper()}/replay")
+    assert r.status_code == 404

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 22
+    assert len(revs) == 23
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 12
+    assert result.pending_count == 13
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 22
+    assert result.pending_count == 23
 
 
 def test_resolve_pending_unknown_revision():

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,164 @@
+"""Unit tests for the receipt replay engine (v0.9 #159).
+
+Pure tests — exercise `_compute_diff` and `build_policy_snapshot`
+without the DB. End-to-end behaviour (load receipt, re-run assembly,
+emit replay receipt) is covered by
+`tests/integration/test_replay.py`.
+"""
+
+from __future__ import annotations
+
+from server.services.receipts import build_policy_snapshot
+from server.services.replay import _compute_diff
+
+
+# ---------------------------------------------------------------------------
+# build_policy_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_policy_snapshot_with_bundle():
+    snap = build_policy_snapshot(
+        bundle_hash="abc123",
+        bundle_yaml="version: 1\nrules: []\n",
+    )
+    assert snap["bundle_hash"] == "abc123"
+    assert snap["bundle_yaml"] == "version: 1\nrules: []\n"
+    assert snap["captured_at"], "captured_at must be set"
+
+
+def test_policy_snapshot_no_bundle_active():
+    """A null pair records 'no policy was active' — a valid, replayable
+    state. The replay path treats this as the no-policy fallback."""
+    snap = build_policy_snapshot(bundle_hash=None, bundle_yaml=None)
+    assert snap["bundle_hash"] is None
+    assert snap["bundle_yaml"] is None
+    assert snap["captured_at"]
+
+
+# ---------------------------------------------------------------------------
+# Diff envelope shape + matching
+# ---------------------------------------------------------------------------
+
+
+def _entry(memory_id: str, rank: int = 1) -> dict:
+    return {"type": "memory", "memory_id": memory_id, "rank": rank}
+
+
+def _ep(episode_id: str, rank: int = 1) -> dict:
+    return {"type": "episode", "episode_id": episode_id, "rank": rank}
+
+
+def _body(entries: list[dict], filters: list[dict] | None = None, ctx: str = "h") -> dict:
+    return {
+        "selected_entries": entries,
+        "policy": {"filters_applied": filters or []},
+        "output": {"context_hash": ctx},
+    }
+
+
+def test_diff_identical_bodies_have_no_changes():
+    body = _body([_entry("m1"), _entry("m2")])
+    d = _compute_diff(original_body=body, replay_body=body)
+    assert d["context_hash"]["changed"] is False
+    assert d["selected_entries"]["added"] == []
+    assert d["selected_entries"]["removed"] == []
+    assert d["selected_entries"]["common"] == 2
+    assert d["filters_applied"]["added"] == []
+    assert d["filters_applied"]["removed"] == []
+
+
+def test_diff_added_and_removed_entries():
+    original = _body([_entry("m1"), _entry("m2")], ctx="a")
+    replay = _body([_entry("m2"), _entry("m3")], ctx="b")
+    d = _compute_diff(original_body=original, replay_body=replay)
+    assert d["context_hash"]["changed"] is True
+    assert d["context_hash"]["original"] == "a"
+    assert d["context_hash"]["replay"] == "b"
+    added = {e["memory_id"] for e in d["selected_entries"]["added"]}
+    removed = {e["memory_id"] for e in d["selected_entries"]["removed"]}
+    assert added == {"m3"}
+    assert removed == {"m1"}
+    assert d["selected_entries"]["common"] == 1
+
+
+def test_diff_rank_change_alone_is_not_an_add_remove():
+    """Re-ordering an entry must NOT register as add+remove — the diff
+    is keyed off entry id, not rank/score, so an operator reviewing the
+    envelope can tell churn (added/removed) apart from re-ranking."""
+    original = _body([_entry("m1", rank=1), _entry("m2", rank=2)])
+    replay = _body([_entry("m1", rank=2), _entry("m2", rank=1)])
+    d = _compute_diff(original_body=original, replay_body=replay)
+    assert d["selected_entries"]["added"] == []
+    assert d["selected_entries"]["removed"] == []
+    assert d["selected_entries"]["common"] == 2
+
+
+def test_diff_episode_entries_use_episode_id():
+    """Episodes are matched by `episode_id`, memories by `memory_id` —
+    the two never collide even if the underlying UUIDs are identical
+    strings."""
+    original = _body([_ep("e1"), _entry("m1")])
+    replay = _body([_ep("e1"), _entry("m1")])
+    d = _compute_diff(original_body=original, replay_body=replay)
+    assert d["selected_entries"]["common"] == 2
+
+
+def test_diff_filters_keyed_by_rule_memory_action():
+    """Two filters with the same rule_id but different memory_ids are
+    distinct rows in the diff."""
+    original = _body(
+        [_entry("m1")],
+        filters=[
+            {"rule_id": "r1", "memory_id": "m1", "action": "redact"},
+            {"rule_id": "r1", "memory_id": "m2", "action": "redact"},
+        ],
+    )
+    replay = _body(
+        [_entry("m1")], filters=[{"rule_id": "r1", "memory_id": "m1", "action": "redact"}]
+    )
+    d = _compute_diff(original_body=original, replay_body=replay)
+    removed = d["filters_applied"]["removed"]
+    assert len(removed) == 1
+    assert removed[0]["memory_id"] == "m2"
+
+
+def test_diff_replay_body_none_reports_full_removal():
+    """When the replay receipt failed to write, the diff is everything-
+    removed: callers still see what was in the original."""
+    original = _body([_entry("m1"), _entry("m2")], ctx="a")
+    d = _compute_diff(original_body=original, replay_body=None)
+    assert d["context_hash"]["original"] == "a"
+    assert d["context_hash"]["replay"] is None
+    assert d["context_hash"]["changed"] is True
+    assert len(d["selected_entries"]["removed"]) == 2
+    assert d["selected_entries"]["added"] == []
+    assert d["selected_entries"]["common"] == 0
+
+
+def test_diff_skips_malformed_entries():
+    """An entry without a `type` or id field is malformed — skipped
+    rather than crashing the diff."""
+    original = _body([{"type": "memory", "memory_id": "m1"}, {"random": "junk"}])
+    replay = _body([{"type": "memory", "memory_id": "m1"}])
+    d = _compute_diff(original_body=original, replay_body=replay)
+    # m1 common; junk entry has no key and gets dropped from both sides.
+    assert d["selected_entries"]["common"] == 1
+    assert d["selected_entries"]["added"] == []
+    assert d["selected_entries"]["removed"] == []
+
+
+def test_diff_missing_policy_section_treated_as_no_filters():
+    """A body missing the `policy` section entirely (e.g. a malformed
+    legacy receipt) must not crash the diff."""
+    original = {
+        "selected_entries": [_entry("m1")],
+        "output": {"context_hash": "a"},
+    }
+    replay = {
+        "selected_entries": [_entry("m1")],
+        "output": {"context_hash": "a"},
+    }
+    d = _compute_diff(original_body=original, replay_body=replay)
+    assert d["filters_applied"]["added"] == []
+    assert d["filters_applied"]["removed"] == []


### PR DESCRIPTION
Fourth and final server-side v0.9 PR. Adds the runtime half of governance: re-run a historical state-assembly retrieval against **current memories** using the **original policy bundle** captured on the receipt. Emits a fresh `mode="as_of_replay"` receipt linked back to the source, plus a diff envelope describing what changed.

## Semantic: current code + original policy

Replay is **not** byte-for-byte reproduction. The split:

| Source of truth | At replay time |
|------------------|----------------|
| Memories         | **Current** — added/removed/superseded since emission show up in the diff |
| Compiler & scoring code | **Current** — whatever is deployed now |
| Policy bundle    | **Original** — frozen on the receipt's `policy_snapshot`, replayed verbatim |

This separates *the rules changed* from *the data changed* in incident reviews. True byte-for-byte historical reproduction (memory snapshots) is left as a future extension; the data model is designed to absorb it without a schema break.

## What lands

**Schema** — migration 0023 adds `receipts.policy_snapshot JSONB` (nullable). Pre-v0.9 receipts pass through with the column NULL. `ReceiptRow.policy_snapshot` mirrors the body field for fast filtering without rummaging through JSONB.

**Snapshot envelope** (embedded on every v0.9+ receipt, body + column):

```json
{
  "bundle_hash": "<sha256>" | null,
  "bundle_yaml": "<verbatim YAML>" | null,
  "captured_at": "<ISO-8601 UTC>"
}
```

A null inner pair = *no policy was active* (replayable, no-policy fallback). A NULL column = pre-v0.9 receipt (NOT replayable).

**Replay engine** — `server.services.replay` with `replay_receipt()` + `_compute_diff()`. `assemble_context()` gains three private parameters (`_policy_bundle_override`, `_use_policy_bundle_override`, `_mode_override`) the replay service threads through to force the snapshot bundle and stamp `mode="as_of_replay"`. Public /v1/context never sets them.

**Endpoint** — `POST /v1/receipts/{receipt_id}/replay` returns:

```json
{
  "original_receipt_id": "...",
  "replay_receipt_id": "...",
  "diff": {
    "context_hash":     {"original": "...", "replay": "...", "changed": true},
    "selected_entries": {"added": [...], "removed": [...], "common": 0},
    "filters_applied":  {"added": [...], "removed": [...]}
  }
}
```

Diff is keyed by entry id, so re-ranking the same entry is `common` (not add+remove). Filters keyed by `(rule_id, memory_id, action)`.

**Refusals (HTTP 422, standard error envelope)**:

| `error.code`                            | When                                           |
|-----------------------------------------|------------------------------------------------|
| `unreplayable.missing_policy_snapshot` | Pre-v0.9 receipt (no snapshot was captured)    |
| `unreplayable.nested_replay`           | Receipt is itself a replay (v0.9 = 1 level)    |
| `unreplayable.invalid_snapshot`        | Snapshot YAML failed to parse                  |

## Failure modes

- **Replay receipt write fails** — diff returned anyway (everything reported as removed). `replay_receipt_id` is null. Same fail-open contract as the rest of the receipt surface; agent serving is never blocked by audit infra.
- **Original receipt is immutable.** Replay never modifies it; the new replay row points back via `parent_receipt_id`.
- **Tenant-scoped** — receipts under tenant A return 404 for tenant B.

## Tests

- **10 unit tests** for `_compute_diff`: identical-bodies invariant, rank-change-is-not-add-remove, episode/memory keying, filter keying, replay-body-None fallback, malformed-entry tolerance, missing-policy-section tolerance.
- **8 integration tests**: snapshot stamped on every receipt, happy path with parent pointer + `as_of_replay` mode, zero-diff when memory state unchanged, diff captures newly added memory, pre-v0.9 refused with 422, nested replay refused, invalid snapshot refused, 404 for unknown receipt.
- Migration head bumped to `0023_receipts_policy_snapshot`; `test_migrations` counts 22→23, 12→13, 22→23.

## Docs

- `docs/replay.md` — design rationale, snapshot envelope, replay flow, refusal codes, explicit list of what replay does NOT do, operator workflow.

## Out of scope (intentional)

- **Memory snapshots** — true byte-for-byte historical reproduction. Future PR.
- **Nested replay** — replaying a replay. v0.9 ships one level only; the audit trail is still recoverable by walking `parent_receipt_id` back to the original.
- **Replay-time policy override** — replay always uses the snapshot. Forcing a different bundle is what `/v1/context` is for.

Closes #159.