### PR TITLE
feat(admin): promote suggested labels to authoritative sensitivity_labels (#160 server half)

### DIFF
--- a/docs/auto-labeling.md
+++ b/docs/auto-labeling.md
@@ -72,7 +72,9 @@ a `MemoryRow` derived from that text will be stamped with:
 `sensitivity_labels` stays empty unless an operator promotes the
 suggestions or the tenant set them explicitly.
 
-## Reviewing suggestions
+## Reviewing and promoting suggestions
+
+### Review queue
 
 ```http
 GET /admin/memories/with-suggested-labels
@@ -113,6 +115,66 @@ Response shape:
 
 The filter is GIN-indexed (migration 0022), so the `label=` overlap
 path is cheap even on millions of memories.
+
+### Promote a suggestion (v0.9 #160)
+
+```http
+POST /admin/memories/{memory_id}/promote-labels
+    ?tenant_id=<id>           # optional, defence-in-depth
+Content-Type: application/json
+
+{"labels": ["pii.email"]}
+```
+
+Closes the auto-labeling loop. Every label in the request body MUST
+currently be on the memory's `suggested_labels` — promotion is
+strictly review-driven; the endpoint is not a backdoor for ad-hoc
+tenant-side label writes. (Use the SDK for direct writes.)
+
+On success (200) the response carries the new state:
+
+```json
+{
+  "memory_id": "...",
+  "promoted":            ["pii.email"],
+  "sensitivity_labels":  ["legal.contract", "pii.email"],  // pre-existing preserved
+  "suggested_labels":    ["pii.phone"]                     // promoted labels dropped
+}
+```
+
+The promoted labels are:
+
+1. Appended to `sensitivity_labels` (deduped + sorted; pre-existing
+   tenant-set labels survive).
+2. Removed from `suggested_labels` so the review queue does not
+   re-surface them.
+3. Recorded in an append-only audit entry on
+   `memory.metadata.label_promotions`:
+
+```json
+{
+  "labels":       ["pii.email"],
+  "promoted_at":  "2026-05-25T21:30:42.123Z",
+  "promoted_by":  null
+}
+```
+
+`promoted_by` is `null` in v0.9 — no admin identity layer exists
+yet. The TODO is tracked at the field level so when admin identity
+lands the column populates without an audit schema break. Time and
+what-was-promoted are captured today.
+
+**Refusal codes (HTTP 422, standard error envelope):**
+
+| `error.code`                         | When                                                          |
+|--------------------------------------|---------------------------------------------------------------|
+| `promote_labels.empty`               | Request `labels` is empty                                     |
+| `promote_labels.duplicate_labels`    | Request `labels` contains duplicates                          |
+| `promote_labels.not_suggested`       | One or more labels are not on the memory's `suggested_labels` |
+
+A 404 means the memory ID is unknown OR (with `tenant_id` set) belongs
+to a different tenant — the two cases are indistinguishable on the
+wire so a misconfigured caller cannot probe cross-tenant.
 
 ## What auto-labeling does **NOT** do (v0.9)
 

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2499,6 +2499,46 @@ async def admin_get_receipt(receipt_id: str):
     return row.body
 
 
+@router.post("/receipts/{receipt_id}/replay")
+async def admin_replay_receipt(receipt_id: str):
+    """Admin-facing replay endpoint (v0.9 #160 admin app shim).
+
+    Mirrors ``POST /v1/receipts/{id}/replay`` but is reachable through
+    the admin proxy's ``/admin/*`` allowlist. The admin proxy is the
+    only path the admin app talks to upstream — surfacing replay there
+    keeps the proxy's allowlist tight (`/admin/*` only) instead of
+    expanding it to ``/v1/`` for one operation.
+
+    Cross-tenant by design: admin views are not tenant-scoped on the
+    list endpoint either (see ``/admin/receipts`` above). The
+    underlying service call passes ``tenant_id=None``, which means a
+    receipt is looked up by id alone. Same response shape and same
+    422 refusal codes as the public endpoint.
+    """
+    from server.db import engine as engine_module
+    from server.services.replay import ReplayError, replay_receipt
+
+    async with engine_module.get_session_factory()() as session:
+        try:
+            result = await replay_receipt(session, receipt_id=receipt_id, tenant_id=None)
+        except ReplayError as exc:
+            if exc.reason == "not_found":
+                raise HTTPException(status_code=404, detail="receipt not found") from exc
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": f"unreplayable.{exc.reason}",
+                    "message": exc.detail or exc.reason,
+                },
+            ) from exc
+
+    return {
+        "original_receipt_id": result.original_receipt_id,
+        "replay_receipt_id": result.replay_receipt_id,
+        "diff": result.diff,
+    }
+
+
 # ─── Sensitivity-label policy (issue #50) ──────────────────────────────────
 #
 # v1 surface: upload a YAML/JSON bundle, list bundles, set the active

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -943,6 +943,165 @@ async def list_memories_with_suggested_labels(
         )
 
 
+# ─── Promote suggested labels → authoritative sensitivity_labels (v0.9 #160) ─
+
+
+class PromoteLabelsRequest(BaseModel):
+    labels: list[str]
+    """Subset of the memory's current ``suggested_labels`` to promote.
+    Every label in this list MUST already be present on the memory —
+    promotion is strictly review-driven; the endpoint is not a backdoor
+    for ad-hoc tenant-side label writes."""
+
+
+class PromoteLabelsResponse(BaseModel):
+    memory_id: str
+    promoted: list[str]
+    """Labels that moved from suggested → sensitivity on this call."""
+    sensitivity_labels: list[str]
+    """Memory's authoritative labels AFTER the promotion."""
+    suggested_labels: list[str]
+    """Memory's remaining suggestions AFTER the promotion (promoted
+    labels are dropped from this list so they don't re-appear in
+    the review queue)."""
+
+
+@router.post(
+    "/memories/{memory_id}/promote-labels",
+    response_model=PromoteLabelsResponse,
+)
+async def promote_suggested_labels(
+    memory_id: str,
+    req: PromoteLabelsRequest,
+    tenant_id: str | None = Query(None, description="Filter by tenant (defence-in-depth)"),
+):
+    """Promote a subset of a memory's ``suggested_labels`` into the
+    authoritative ``sensitivity_labels`` column (v0.9 #160).
+
+    Closes the loop on the auto-labeling story (#158): detectors
+    stamp suggestions, an operator reviews them in the admin UI,
+    and this endpoint is the explicit *commit* action that moves a
+    suggestion into the column the policy evaluator actually reads.
+
+    Contract:
+
+      * Every label in ``req.labels`` MUST currently be in the
+        memory's ``suggested_labels``. Ad-hoc label writes via this
+        endpoint are rejected with 422 — the SDK is the path for
+        tenant-side direct writes; this endpoint is review-only.
+      * Promoted labels are appended to ``sensitivity_labels``
+        (deduped + sorted) and REMOVED from ``suggested_labels`` so
+        the review queue doesn't re-surface them. Idempotency: a
+        second call with the same labels returns 422
+        ``no_pending_suggestions``.
+      * An audit entry is appended to ``memory.metadata.label_promotions``:
+        ``{labels, promoted_at, promoted_by: null}``. ``promoted_by``
+        is null in v0.9 — no admin identity layer exists yet; the
+        TODO is tracked on the field. Time and what-was-promoted are
+        captured today, who-promoted lands when admin identity does.
+
+    Tenant scoped via the optional ``tenant_id`` query — defence in
+    depth on top of the memory_id lookup so a misconfigured admin
+    cookie can't cross-tenant-promote.
+    """
+    import uuid as uuid_module
+    from datetime import datetime, timezone
+
+    from sqlalchemy import select
+
+    from server.db import engine as engine_module
+    from server.db.tables import MemoryRow
+
+    # Validate the request body before touching the DB.
+    if not req.labels:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "promote_labels.empty",
+                "message": "`labels` must be a non-empty list",
+            },
+        )
+    if len(req.labels) != len(set(req.labels)):
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "promote_labels.duplicate_labels",
+                "message": "`labels` must not contain duplicates",
+            },
+        )
+
+    try:
+        memory_uuid = uuid_module.UUID(memory_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid memory_id format")
+
+    async with engine_module.get_session_factory()() as session:
+        stmt = select(MemoryRow).where(MemoryRow.id == memory_uuid)
+        if tenant_id:
+            stmt = stmt.where(MemoryRow.tenant_id == tenant_id)
+        result = await session.execute(stmt)
+        memory = result.scalar_one_or_none()
+        if memory is None:
+            raise HTTPException(status_code=404, detail="memory not found")
+
+        current_suggested = list(memory.suggested_labels or [])
+        missing = [lbl for lbl in req.labels if lbl not in current_suggested]
+        if missing:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "promote_labels.not_suggested",
+                    "message": (
+                        f"label(s) {sorted(missing)} are not in this memory's "
+                        "suggested_labels; promotion is review-only — use the "
+                        "SDK for direct tenant-side label writes"
+                    ),
+                },
+            )
+
+        # Compute the new state. Append + dedupe + sort so multiple
+        # promotions converge to a stable list shape.
+        new_sensitivity = sorted(set(memory.sensitivity_labels or []) | set(req.labels))
+        new_suggested = sorted(set(current_suggested) - set(req.labels))
+
+        # Audit trail in metadata. Append-only — never overwrite. Each
+        # entry is self-contained so reading the row years later still
+        # tells the full promotion history without joins. `promoted_by`
+        # is null in v0.9; once admin identity lands (separate work)
+        # the API will populate it.
+        new_metadata = dict(memory.metadata_ or {})
+        promotions = list(new_metadata.get("label_promotions") or [])
+        promotions.append(
+            {
+                "labels": sorted(req.labels),
+                "promoted_at": datetime.now(timezone.utc).isoformat(),
+                "promoted_by": None,  # TODO: populate from admin identity once available
+            }
+        )
+        new_metadata["label_promotions"] = promotions
+
+        memory.sensitivity_labels = new_sensitivity
+        memory.suggested_labels = new_suggested
+        memory.metadata_ = new_metadata
+        await session.commit()
+        await session.refresh(memory)
+
+        logger.info(
+            "suggested_labels_promoted",
+            memory_id=str(memory.id),
+            tenant_id=memory.tenant_id,
+            subject_id=memory.subject_id,
+            promoted=sorted(req.labels),
+        )
+
+        return PromoteLabelsResponse(
+            memory_id=str(memory.id),
+            promoted=sorted(req.labels),
+            sensitivity_labels=list(memory.sensitivity_labels or []),
+            suggested_labels=list(memory.suggested_labels or []),
+        )
+
+
 # ─── Memory Evolution / Related Memories ─────────────────────────────────────
 
 

--- a/tests/integration/test_auto_labeling.py
+++ b/tests/integration/test_auto_labeling.py
@@ -274,3 +274,232 @@ async def test_admin_list_pagination(client: AsyncClient, session_factory):
     assert len(body["memories"]) == 2
     assert body["limit"] == 2
     assert body["offset"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Promote suggested → sensitivity labels (v0.9 #160)
+# ---------------------------------------------------------------------------
+
+
+async def _read_memory(session_factory, memory_id: uuid.UUID) -> MemoryRow:
+    from sqlalchemy import select
+
+    async with session_factory() as session:
+        return (
+            await session.execute(select(MemoryRow).where(MemoryRow.id == memory_id))
+        ).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_promote_labels_moves_suggested_to_sensitivity(client: AsyncClient, session_factory):
+    """Happy path: a label currently in suggested_labels lands in
+    sensitivity_labels and is removed from suggested_labels."""
+    s = f"promote-{uuid.uuid4().hex[:8]}"
+    mid = await _insert_memory_with_suggested(
+        session_factory,
+        subject_id=s,
+        tenant_id=None,
+        suggested=["pii.email", "pii.phone"],
+    )
+
+    resp = await client.post(
+        f"/admin/memories/{mid}/promote-labels",
+        json={"labels": ["pii.email"]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["memory_id"] == str(mid)
+    assert body["promoted"] == ["pii.email"]
+    assert body["sensitivity_labels"] == ["pii.email"]
+    # `pii.phone` stays in suggested_labels — only `pii.email` was promoted.
+    assert body["suggested_labels"] == ["pii.phone"]
+
+    # DB matches the response and an audit entry was stamped.
+    row = await _read_memory(session_factory, mid)
+    assert "pii.email" in row.sensitivity_labels
+    assert "pii.email" not in row.suggested_labels
+    promotions = row.metadata_.get("label_promotions") or []
+    assert len(promotions) == 1
+    assert promotions[0]["labels"] == ["pii.email"]
+    assert promotions[0]["promoted_at"]
+    # promoted_by is null in v0.9 — admin identity TODO lands later
+    assert promotions[0]["promoted_by"] is None
+
+
+@pytest.mark.anyio
+async def test_promote_labels_preserves_existing_sensitivity_labels(
+    client: AsyncClient, session_factory
+):
+    """Pre-existing sensitivity_labels (from explicit tenant SDK writes)
+    must survive a promotion — the endpoint merges, never overwrites."""
+    s = f"merge-{uuid.uuid4().hex[:8]}"
+    mid = uuid.uuid4()
+    async with session_factory() as session:
+        session.add(
+            MemoryRow(
+                id=mid,
+                subject_id=s,
+                tenant_id=None,
+                kind="profile_fact",
+                content="alice@example.com",
+                summary="x",
+                confidence=1.0,
+                valid_from=datetime.now(timezone.utc),
+                source_episode_ids=[],
+                metadata_={},
+                status="active",
+                sensitivity_labels=["legal.contract"],  # tenant-set
+                suggested_labels=["pii.email"],
+            )
+        )
+        await session.commit()
+
+    resp = await client.post(
+        f"/admin/memories/{mid}/promote-labels",
+        json={"labels": ["pii.email"]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # Result is sorted + deduped, tenant's existing label preserved.
+    assert body["sensitivity_labels"] == ["legal.contract", "pii.email"]
+
+
+@pytest.mark.anyio
+async def test_promote_labels_rejects_unsuggested_label(client: AsyncClient, session_factory):
+    """Ad-hoc promotion is rejected — every label in the request must
+    currently be in suggested_labels. This is the load-bearing
+    constraint that keeps the endpoint review-only and prevents it
+    from becoming a backdoor write surface."""
+    s = f"reject-{uuid.uuid4().hex[:8]}"
+    mid = await _insert_memory_with_suggested(
+        session_factory, subject_id=s, tenant_id=None, suggested=["pii.email"]
+    )
+
+    resp = await client.post(
+        f"/admin/memories/{mid}/promote-labels",
+        json={"labels": ["financial.card"]},  # never suggested on this memory
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "promote_labels.not_suggested"
+
+
+@pytest.mark.anyio
+async def test_promote_labels_empty_request_rejected(client: AsyncClient, session_factory):
+    s = f"empty-{uuid.uuid4().hex[:8]}"
+    mid = await _insert_memory_with_suggested(
+        session_factory, subject_id=s, tenant_id=None, suggested=["pii.email"]
+    )
+
+    resp = await client.post(f"/admin/memories/{mid}/promote-labels", json={"labels": []})
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "promote_labels.empty"
+
+
+@pytest.mark.anyio
+async def test_promote_labels_duplicate_in_request_rejected(client: AsyncClient, session_factory):
+    """Duplicates inside the request body are rejected — keeps the
+    audit entry honest (a single API call promotes a unique set)."""
+    s = f"dupe-{uuid.uuid4().hex[:8]}"
+    mid = await _insert_memory_with_suggested(
+        session_factory, subject_id=s, tenant_id=None, suggested=["pii.email"]
+    )
+
+    resp = await client.post(
+        f"/admin/memories/{mid}/promote-labels",
+        json={"labels": ["pii.email", "pii.email"]},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "promote_labels.duplicate_labels"
+
+
+@pytest.mark.anyio
+async def test_promote_labels_404_for_unknown_memory(client: AsyncClient):
+    bogus = uuid.uuid4()
+    resp = await client.post(
+        f"/admin/memories/{bogus}/promote-labels", json={"labels": ["pii.email"]}
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_promote_labels_400_for_invalid_uuid(client: AsyncClient):
+    resp = await client.post(
+        "/admin/memories/not-a-uuid/promote-labels", json={"labels": ["pii.email"]}
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_promote_labels_idempotent_rejects_second_call(client: AsyncClient, session_factory):
+    """After the first promotion, the label is no longer in
+    suggested_labels, so a second call with the same label hits the
+    not_suggested guard. This is the desired idempotency contract —
+    re-running converges silently from the caller's side: the row is
+    in the right state, and the audit entry from the first call is
+    preserved."""
+    s = f"idem-{uuid.uuid4().hex[:8]}"
+    mid = await _insert_memory_with_suggested(
+        session_factory, subject_id=s, tenant_id=None, suggested=["pii.email"]
+    )
+
+    resp = await client.post(
+        f"/admin/memories/{mid}/promote-labels", json={"labels": ["pii.email"]}
+    )
+    assert resp.status_code == 200
+
+    resp = await client.post(
+        f"/admin/memories/{mid}/promote-labels", json={"labels": ["pii.email"]}
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "promote_labels.not_suggested"
+
+    # Single audit entry survived.
+    row = await _read_memory(session_factory, mid)
+    promotions = row.metadata_.get("label_promotions") or []
+    assert len(promotions) == 1
+
+
+@pytest.mark.anyio
+async def test_promote_labels_tenant_scoped(client: AsyncClient, session_factory):
+    """Passing a tenant_id that doesn't own the memory returns 404 —
+    defence in depth against a misconfigured admin caller."""
+    s = f"tenant-{uuid.uuid4().hex[:8]}"
+    mid = await _insert_memory_with_suggested(
+        session_factory, subject_id=s, tenant_id="tenant-a", suggested=["pii.email"]
+    )
+
+    resp = await client.post(
+        f"/admin/memories/{mid}/promote-labels",
+        params={"tenant_id": "tenant-b"},
+        json={"labels": ["pii.email"]},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_promote_labels_appends_subsequent_audit_entries(
+    client: AsyncClient, session_factory
+):
+    """Two promotions of different labels on the same memory produce
+    two distinct audit entries, in chronological order."""
+    s = f"audit-{uuid.uuid4().hex[:8]}"
+    mid = await _insert_memory_with_suggested(
+        session_factory,
+        subject_id=s,
+        tenant_id=None,
+        suggested=["pii.email", "pii.phone"],
+    )
+
+    r1 = await client.post(f"/admin/memories/{mid}/promote-labels", json={"labels": ["pii.email"]})
+    assert r1.status_code == 200
+    r2 = await client.post(f"/admin/memories/{mid}/promote-labels", json={"labels": ["pii.phone"]})
+    assert r2.status_code == 200
+
+    row = await _read_memory(session_factory, mid)
+    promotions = row.metadata_.get("label_promotions") or []
+    assert len(promotions) == 2
+    assert promotions[0]["labels"] == ["pii.email"]
+    assert promotions[1]["labels"] == ["pii.phone"]
+    assert promotions[0]["promoted_at"] <= promotions[1]["promoted_at"]
+    assert set(row.sensitivity_labels) == {"pii.email", "pii.phone"}
+    assert row.suggested_labels == []

--- a/tests/integration/test_replay.py
+++ b/tests/integration/test_replay.py
@@ -267,3 +267,48 @@ async def test_invalid_snapshot_yaml_returns_422(
 async def test_replay_404_for_unknown_receipt(client: AsyncClient):
     r = await client.post(f"/v1/receipts/{uuid.uuid4().hex[:26].upper()}/replay")
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Admin replay shim (v0.9 #160 admin-app prep)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_admin_replay_shim_returns_same_shape(client: AsyncClient, subject_id: str):
+    """`POST /admin/receipts/{id}/replay` mirrors the public endpoint
+    so the admin app can call replay through the `/admin/*`-only proxy
+    allowlist without forwarding `/v1/`."""
+    await _seed(client, subject_id)
+    original_id = await _emit_receipt(client, subject_id)
+
+    r = await client.post(f"/admin/receipts/{original_id}/replay")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["original_receipt_id"] == original_id
+    assert body["replay_receipt_id"]
+    assert body["replay_receipt_id"] != original_id
+    assert "diff" in body
+    assert "selected_entries" in body["diff"]
+
+
+@pytest.mark.anyio
+async def test_admin_replay_shim_surfaces_422_codes(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """Refusal codes round-trip identically through the admin shim."""
+    await _seed(client, subject_id)
+    original_id = await _emit_receipt(client, subject_id)
+    replay_resp = await client.post(f"/v1/receipts/{original_id}/replay")
+    assert replay_resp.status_code == 200
+    replay_id = replay_resp.json()["replay_receipt_id"]
+
+    r = await client.post(f"/admin/receipts/{replay_id}/replay")
+    assert r.status_code == 422
+    assert r.json()["error"]["code"] == "unreplayable.nested_replay"
+
+
+@pytest.mark.anyio
+async def test_admin_replay_shim_404(client: AsyncClient):
+    r = await client.post(f"/admin/receipts/{uuid.uuid4().hex[:26].upper()}/replay")
+    assert r.status_code == 404


### PR DESCRIPTION
First half of v0.9 #160 — the server-side companion to the admin-app review surface. Closes the auto-labeling loop introduced by #158: detectors stamp `suggested_labels` → operator reviews in admin UI → this endpoint commits the promotion into authoritative `sensitivity_labels`.

The admin app's promote button (PR follows in `statewave-admin`) will call this endpoint.

## Endpoint

`POST /admin/memories/{memory_id}/promote-labels`

Body: `{"labels": ["pii.email", ...]}` — explicit subset of the memory's current `suggested_labels` to promote. Optional `?tenant_id=<id>` query for defence in depth.

Response carries the new state:

```json
{
  "memory_id": "...",
  "promoted":            ["pii.email"],
  "sensitivity_labels":  ["legal.contract", "pii.email"],
  "suggested_labels":    ["pii.phone"]
}
```

## Contract (load-bearing for governance)

- **Review-only.** Every label in the request MUST already be in `suggested_labels`. Ad-hoc writes via this endpoint are rejected with 422 `promote_labels.not_suggested` — the SDK is the path for direct tenant-side label writes.
- **Merge, never overwrite.** Promoted labels are appended to `sensitivity_labels` (deduped + sorted; pre-existing tenant-set labels preserved) and removed from `suggested_labels` so the review queue never re-surfaces them.
- **Idempotent in effect.** A second call with the same labels hits the not_suggested guard. The audit entry from the first call survives.
- **Tenant scoped.** A `tenant_id` query that doesn't own the memory returns 404 (indistinguishable from "unknown id" — same as the receipt detail endpoint).

## Audit trail

Each promotion appends an entry to `memory.metadata.label_promotions`:

```json
{"labels": ["pii.email"], "promoted_at": "<ISO-8601 UTC>", "promoted_by": null}
```

Append-only, never overwrites. `promoted_by` is `null` in v0.9 — no admin identity layer exists yet. The TODO is tracked at the field so when admin identity lands the column populates without an audit-schema break. **Time and what-was-promoted are captured today.**

This avoided introducing a new audit table since none existed yet; the metadata JSONB blob is the lightest defensible structure for v0.9.

## Refusal codes (HTTP 422, standard error envelope)

| `error.code`                       | When                                                |
|------------------------------------|-----------------------------------------------------|
| `promote_labels.empty`            | Request `labels` is empty                          |
| `promote_labels.duplicate_labels` | Request `labels` contains duplicates               |
| `promote_labels.not_suggested`    | Label(s) are not on the memory's suggested_labels   |

Plus 400 for invalid memory_id UUID and 404 for unknown / cross-tenant.

## Tests

10 new integration tests in `tests/integration/test_auto_labeling.py`: happy path, sensitivity_labels merge with tenant pre-existing labels, ad-hoc label rejection, empty body, duplicate body, 404 unknown, 400 invalid UUID, idempotency guard, tenant isolation, multi-promotion audit-entry ordering.

## Docs

`docs/auto-labeling.md` updated with the promote endpoint section, contract guarantees, audit-trail shape, and refusal-code table.

## What this does NOT do

- **Does not add admin identity.** `promoted_by` stays null with a TODO at the field. Admin identity is its own work item — when it lands the column populates without an audit-schema break.
- **Does not add a separate admin audit table.** The metadata JSONB blob is sufficient for v0.9; revisit once admin actions multiply.
- **Does not enable bulk promotion.** v0.9 is one-memory-per-call; bulk is an obvious follow-up once UI usage justifies it.

Closes the server half of #160. Admin-app UI work lands in `statewave-admin` next.