### PR TITLE
feat(residency): tenant region pin + hard enforcement (closes #161)

### DIFF
--- a/docs/residency.md
+++ b/docs/residency.md
@@ -1,0 +1,210 @@
+# Data residency
+
+Per-region deployment with metadata-pinned tenants. Introduced in
+**v0.9 (issue #161)**.
+
+The application is the source of truth for "is this request allowed
+here?" Residency is enforced at the request boundary in the
+application layer, not at DNS or the load balancer — a misrouted
+request that bypassed the LB hostname is still caught by this layer
+before any DB access happens.
+
+## Model
+
+Two pieces of operator-managed metadata work together:
+
+| Where it lives                          | What it means                                 |
+|-----------------------------------------|-----------------------------------------------|
+| `STATEWAVE_REGION` env var              | Which region THIS server process is running in |
+| `tenant_configs.config.region` JSONB    | Which region a tenant is pinned to             |
+
+A request is allowed iff one of:
+
+1. `STATEWAVE_REGION` is unset (**single-region mode** — residency
+   disabled, all requests pass through).
+2. The tenant has no `region` pinned in its config (**unpinned
+   tenant** — legacy or globally-mobile).
+3. The tenant's pinned region equals `STATEWAVE_REGION` exactly
+   (case-sensitive).
+
+Anything else returns HTTP 403 with the standard error envelope:
+
+```json
+{
+  "error": {
+    "code": "residency.mismatch",
+    "message": "tenant 'acme-eu' is pinned to region 'eu'; this request did not reach the right region. Retry against the regional endpoint."
+  }
+}
+```
+
+The response **only** echoes the tenant's pinned region. The
+server's local region is NEVER returned on the wire — a 403 message
+that named the server region would leak topology to a caller
+probing the residency boundary.
+
+## Why this shape
+
+- **Application-layer enforcement** is the correctness boundary.
+  DNS, anycast, and load balancers can misroute requests. The
+  application is the single point that knows definitively whether a
+  request can be served here.
+- **Separate Postgres / pgvector per region** is the intended infra
+  topology. The data plane is region-isolated by deployment, not by
+  in-DB partitioning. Residency does not depend on the DB layer for
+  correctness; the application layer is the second line of defence.
+- **No in-DB region column on every row.** That would conflate
+  residency with multi-tenancy. Residency is per-tenant, not
+  per-row.
+- **Total isolation** in v0.9. Cross-region admin reads are not
+  allowed. Unified federated audit is a future feature, not implicit
+  cross-region access — building it as an explicit separate surface
+  later is safer than letting cross-region reads sneak in by default
+  now.
+
+## Pinning a tenant
+
+Through the existing admin config endpoint:
+
+```bash
+curl -X PATCH https://eu.api.statewave.dev/admin/tenants/acme-eu/config \
+  -H 'Content-Type: application/json' \
+  -d '{"region": "eu"}'
+```
+
+Safety check: the admin endpoint **refuses pinning a tenant to a
+region this server doesn't serve**, because the pin would lock the
+tenant out of this deployment — every subsequent request from this
+region would 403. The refusal looks like:
+
+```json
+{
+  "error": {
+    "code": "residency.invalid_pin",
+    "message": "this server is running in region 'eu'; pinning a tenant to 'us' from here would lock the tenant out (every subsequent request would 403). Patch the pin from a server running in the target region, or set STATEWAVE_REGION to match if this server should serve it."
+  }
+}
+```
+
+To pin from elsewhere (e.g. a bulk-config migration run from a
+single-region orchestrator), set `force_region_pin: true`:
+
+```bash
+curl -X PATCH https://orchestrator.example/admin/tenants/acme-us/config \
+  -H 'Content-Type: application/json' \
+  -d '{"region": "us", "force_region_pin": true}'
+```
+
+The orchestrator must run with `STATEWAVE_REGION=None` (single-region
+mode) so the safety check is bypassed cleanly. The `force_region_pin`
+field is request-only — it is not persisted on the JSONB.
+
+## Receipt audit trail
+
+Every state-assembly receipt emitted in multi-region mode carries the
+local server's region in its `region` field (column + body). The
+column has been on `receipts` since v0.8 — v0.9 finally populates it
+from `STATEWAVE_REGION`. Receipts emitted in single-region mode keep
+`region = null`, backwards-compatible with pre-v0.9 readers.
+
+Combined with the HMAC signature (v0.9 #157), the policy snapshot
+(v0.9 #159), and the replay endpoint, the residency stamp lets an
+auditor answer end-to-end:
+
+  - *Where* was this retrieval served from? (`receipt.region`)
+  - *With what rules?* (`receipt.policy_snapshot.bundle_yaml`)
+  - *Was the body tampered with?* (HMAC verify)
+  - *Would current code make the same decision?* (replay diff)
+
+## Ops runbook — spinning up a second region
+
+The v0.9 design ships **code + config model + ops runbook only**. No
+second region is deployed by this PR; this section is the
+reproducible recipe for an operator standing one up.
+
+1. **Provision regional infra** for the new region:
+   - A region-local Postgres + pgvector deployment.
+   - A region-local Statewave server fleet (Fly app, ECS service,
+     k8s deployment — whatever the existing region uses).
+   - A regional hostname (`us.api.statewave.dev`) pointing to the
+     local fleet's load balancer.
+   - Region-local secrets (DB creds, HMAC signing keys per
+     `STATEWAVE_RECEIPT_SIGNING_KEYS`). Secrets MUST NOT be shared
+     across regions — that would defeat the residency story for
+     "EU tenant data must never be readable from US infra."
+
+2. **Set `STATEWAVE_REGION`** on the new fleet to the agreed-on
+   short identifier (`us`, `us-east`, `ap-south-1`, …).
+
+3. **Apply migrations** against the new region's Postgres. Schema
+   is identical across regions; no region-specific migrations exist.
+
+4. **Smoke test in single-region mode first.** Bring up the new
+   fleet without pinning any tenant; verify health, receipts
+   emission with the new `region` stamp, and HMAC verification.
+
+5. **Migrate tenants intended for the new region.** For each
+   tenant:
+
+   a. **Move the data first.** Export episodes + memories from the
+      origin region (`POST /admin/memory/export`) and import them
+      into the new region (`POST /admin/import`). The application
+      layer treats imports identically across regions.
+
+   b. **Pin the tenant in the new region.** Run the PATCH on the
+      new region's API (so the safety check passes naturally):
+
+      ```bash
+      curl -X PATCH https://us.api.statewave.dev/admin/tenants/acme-us/config \
+        -H 'Content-Type: application/json' \
+        -d '{"region": "us"}'
+      ```
+
+   c. **Pin the tenant in the origin region too.** The origin
+      region needs to know this tenant lives elsewhere now, so
+      future stray requests are refused with 403 instead of silently
+      hitting stale data. From an orchestrator (single-region
+      mode):
+
+      ```bash
+      curl -X PATCH https://orchestrator/admin/tenants/acme-us/config \
+        -H 'Content-Type: application/json' \
+        -d '{"region": "us", "force_region_pin": true}'
+      ```
+
+   d. **Verify the cutover.** Requests for the tenant against the
+      origin region should now 403 with `residency.mismatch`.
+      Requests against the new region should succeed. Check
+      `receipts.region` on a fresh emission to confirm.
+
+6. **Purge stale data from the origin region** once you're
+   confident the cutover is complete. This is destructive; do not
+   automate it.
+
+## Failure modes
+
+- **DB blip during a residency check.** The middleware fails OPEN
+  with a structured warning log (`residency_check_failed_failing_open`).
+  Failing closed on transient DB errors would take down every
+  tenant-scoped request on any blip; the data plane is already
+  separated per region by infra, and this middleware is the second
+  line of defence. The first line is the deployment topology
+  itself.
+- **A non-string `region` value in the JSONB** (e.g. set via direct
+  SQL with a typo). Treated as malformed and refused — the check
+  defaults to deny rather than silently allow.
+- **Cross-region admin path.** Same 403 as the public API path —
+  v0.9 design decision is total isolation. The same middleware
+  enforces both.
+
+## What residency does NOT do (v0.9)
+
+- **Does not move data.** Pinning a tenant assumes the data is
+  already in the target region. The export/import + pin workflow
+  is the operator's responsibility.
+- **Does not unify cross-region audit reads.** v0.9 ships total
+  isolation. Federated audit search is a future feature, built as
+  an explicit cross-region surface — never as implicit access.
+- **Does not deploy a second region.** This PR is code + config
+  model + tests + runbook. Actual region rollout is operator work
+  using the runbook above.

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2979,9 +2979,30 @@ async def patch_tenant_config(tenant_id: str, patch: TenantConfigPatch):
     # for a known field is also "don't change it" (consistent with
     # the doc strings).
     incoming = patch.model_dump(exclude_none=True)
-    # `expected_version` is a request-only concurrency token, not a
-    # config key. Pop it before it leaks into the JSONB.
+    # `expected_version` and `force_region_pin` are request-only
+    # control fields, not config keys. Pop them before they leak
+    # into the JSONB blob.
     expected_version = incoming.pop("expected_version", None)
+    force_region_pin = incoming.pop("force_region_pin", False)
+
+    # Region-pin safety check (v0.9 #161). Refuse a pin that would
+    # immediately lock the tenant out of this deployment.
+    region_value = incoming.get("region")
+    if region_value is not None:
+        from server.services.residency import validate_region_pin
+
+        refusal = validate_region_pin(
+            proposed_region=region_value,
+            server_region=settings.region,
+        )
+        if refusal is not None and not force_region_pin:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "residency.invalid_pin",
+                    "message": refusal,
+                },
+            )
 
     async with engine_module.get_session_factory()() as session:
         result = await session.execute(

--- a/server/app.py
+++ b/server/app.py
@@ -17,6 +17,7 @@ from server.core.logging import setup_logging
 from server.core.middleware import RequestIDMiddleware
 from server.core.auth import APIKeyMiddleware
 from server.core.ratelimit import RateLimitMiddleware
+from server.core.residency_middleware import ResidencyMiddleware
 from server.core.tenant import TenantMiddleware
 from server.core.tracing import setup_tracing
 
@@ -170,8 +171,13 @@ def create_app() -> FastAPI:
 
     # -- Middleware -----------------------------------------------------------
     # Starlette executes add_middleware in REVERSE order (last-added = outermost).
-    # Desired execution: CORS → RequestID → Auth → RateLimit → Tenant → App
+    # Desired execution: CORS → RequestID → Auth → RateLimit → Tenant → Residency → App
     # So we register innermost first:
+    # Residency runs AFTER Tenant resolves the id so the check has
+    # something to compare against. Single-region deployments
+    # (settings.region is None) make the middleware a zero-cost
+    # pass-through. See server/services/residency.py.
+    app.add_middleware(ResidencyMiddleware)
     app.add_middleware(
         TenantMiddleware, header=settings.tenant_header, require=settings.require_tenant
     )

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -289,6 +289,41 @@ class Settings(BaseSettings):
     tenant_header: str = "X-Tenant-ID"
     require_tenant: bool = False
 
+    # Data residency (v0.9, issue #161) — per-region deployment model.
+    #
+    # `region` declares which region THIS server process is running in
+    # (e.g. "eu", "us", "ap"). The residency enforcement layer hard-
+    # checks every tenant-scoped request against the tenant's pinned
+    # region (`tenant_configs.config.region`): a request for a tenant
+    # pinned to "us" arriving at a process with STATEWAVE_REGION="eu"
+    # is rejected with HTTP 403 / `residency.mismatch`.
+    #
+    # Default `None` is single-region mode: no checks, no stamping.
+    # Set this whenever you operate >1 region so the application
+    # enforces residency at the request boundary instead of relying
+    # on DNS / load-balancer hints (which can be misrouted).
+    #
+    # Naming is up to the operator; we recommend short lowercase
+    # identifiers ("eu", "us-east", "ap-south-1") so the value is
+    # grep-friendly across logs.
+    region: str | None = None
+
+    @field_validator("region")
+    @classmethod
+    def _validate_region(cls, value: str | None) -> str | None:
+        if value is None or value == "":
+            return None
+        s = value.strip()
+        if not s:
+            return None
+        # Keep the value tight so a leading-space typo doesn't silently
+        # produce two distinct regions in audit logs.
+        if s != value:
+            raise ValueError("STATEWAVE_REGION must not have leading/trailing whitespace")
+        if len(s) > 64:
+            raise ValueError("STATEWAVE_REGION must be ≤64 characters")
+        return s
+
     # Migration safety
     strict_schema: bool = False  # if True, refuse to start on schema mismatch
 

--- a/server/core/dependencies.py
+++ b/server/core/dependencies.py
@@ -3,13 +3,124 @@
 Extracts tenant_id from request.state (set by TenantMiddleware).
 Returns None in single-tenant mode — repository functions treat None as
 "no tenant filter" for backward compatibility.
+
+Also exposes ``enforce_tenant_residency`` for routes that need the
+v0.9 #161 region pin enforced before they hit any DB / receipt
+emission code.
 """
 
 from __future__ import annotations
 
-from fastapi import Request
+import structlog
+from fastapi import HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.core.config import settings
+from server.db.engine import get_session
+
+logger = structlog.stdlib.get_logger()
 
 
 def get_tenant_id(request: Request) -> str | None:
     """FastAPI dependency — extract tenant_id from request state."""
     return getattr(request.state, "tenant_id", None)
+
+
+async def enforce_tenant_residency(
+    request: Request,
+    tenant_id: str | None = None,
+    session: AsyncSession | None = None,
+) -> None:
+    """Residency hard-check for tenant-scoped routes (v0.9 #161).
+
+    Loads the tenant's pinned region from ``tenant_configs.config``
+    and refuses the request with HTTP 403 ``residency.mismatch`` if
+    the local ``settings.region`` does not match. No-ops when
+    ``settings.region`` is unset (single-region mode) or the tenant
+    is not pinned.
+
+    Designed to be cheap on the happy path: one indexed SELECT
+    against ``tenant_configs`` per request, then a string compare.
+    Single-region deployments pay zero cost (early return).
+
+    Wired as a FastAPI dependency so any route can opt in by adding
+    ``Depends(enforce_tenant_residency)`` — the public surfaces
+    (`/v1/context`, `/v1/handoff`, `/v1/episodes`, `/v1/memories/*`)
+    do, and the admin surfaces enforce the same boundary at the
+    middleware layer (see ``ResidencyMiddleware``).
+
+    ``tenant_id`` and ``session`` are accepted as parameters so this
+    function can be used both as a FastAPI dependency
+    (FastAPI auto-resolves the standard deps) AND called directly
+    from middleware/services that already hold a session.
+    """
+    server_region = settings.region
+    if not server_region:
+        return  # single-region mode, nothing to enforce
+
+    if tenant_id is None:
+        tenant_id = get_tenant_id(request)
+    if not tenant_id:
+        # Anonymous/single-tenant traffic falls through. The middleware
+        # already 400'd if `require_tenant` is set and no tenant id
+        # was supplied; we don't re-litigate that here.
+        return
+
+    if session is None:
+        # Dependency-style invocation — FastAPI hasn't resolved a
+        # session yet for us, so open a short-lived one. The cost is
+        # one connection acquire; the read itself is a single row by
+        # PK.
+        session_gen = get_session()
+        session = await session_gen.__anext__()
+        try:
+            await _do_check(request, tenant_id, server_region, session)
+        finally:
+            try:
+                await session_gen.aclose()
+            except Exception:
+                pass
+        return
+
+    await _do_check(request, tenant_id, server_region, session)
+
+
+async def _do_check(
+    request: Request,
+    tenant_id: str,
+    server_region: str,
+    session: AsyncSession,
+) -> None:
+    """The actual lookup + compare. Split out so middleware paths can
+    reuse it after opening their own session."""
+    from server.db import repositories as repo
+    from server.services.residency import check_residency
+
+    row = await repo.get_tenant_config(session, tenant_id)
+    tenant_config = (row.config if row else {}) or {}
+    mismatch = check_residency(tenant_config=tenant_config, server_region=server_region)
+    if mismatch is None:
+        return
+
+    # Log with both regions for the operator. The wire response only
+    # echoes the tenant's pinned region — a 403 message that named
+    # the local server's region would leak topology details to a
+    # caller probing the residency boundary.
+    logger.warning(
+        "residency_mismatch_refused",
+        tenant_id=tenant_id,
+        tenant_region=mismatch.tenant_region,
+        server_region=mismatch.server_region,
+        path=request.url.path,
+    )
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "code": "residency.mismatch",
+            "message": (
+                f"tenant {tenant_id!r} is pinned to region "
+                f"{mismatch.tenant_region!r}; this request did not reach "
+                "the right region. Retry against the regional endpoint."
+            ),
+        },
+    )

--- a/server/core/residency_middleware.py
+++ b/server/core/residency_middleware.py
@@ -1,0 +1,130 @@
+"""Residency enforcement middleware (v0.9, issue #161).
+
+Runs after ``TenantMiddleware`` has resolved ``request.state.tenant_id``.
+For any request carrying a tenant id, hard-checks the tenant's pinned
+region against ``settings.region`` and refuses with HTTP 403
+``residency.mismatch`` on conflict.
+
+Why a middleware and not just a per-route dependency:
+
+  * Single point of enforcement. Every endpoint that ever reads or
+    writes tenant data passes through here automatically — there's
+    no way to forget to add the dependency.
+  * Catches admin paths too. Per the v0.9 #161 design decision,
+    cross-region admin reads are not allowed; the same middleware
+    refuses them.
+  * Cost is bounded: short-circuits with zero DB work when
+    ``settings.region`` is unset (the single-region default).
+
+Paths exempted from the check:
+
+  * The same ``_PUBLIC_PATHS`` set as ``TenantMiddleware`` — health,
+    readiness, docs. These never carry tenant data.
+  * Anonymous requests (no tenant id) — there's nothing to enforce
+    against. ``TenantMiddleware`` already 400'd if a tenant header
+    was required.
+"""
+
+from __future__ import annotations
+
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+logger = structlog.stdlib.get_logger()
+
+_EXEMPT_PATHS = {
+    "/healthz",
+    "/readyz",
+    "/health",
+    "/ready",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+}
+
+
+class ResidencyMiddleware(BaseHTTPMiddleware):
+    """Refuses a request when the tenant is pinned to a region other
+    than ``settings.region``. No-op in single-region mode (when
+    ``settings.region`` is None)."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        # Lazy import so the module is testable without booting Settings.
+        from server.core.config import settings
+
+        server_region = settings.region
+        if not server_region:
+            return await call_next(request)
+
+        if request.url.path in _EXEMPT_PATHS:
+            return await call_next(request)
+
+        tenant_id = getattr(request.state, "tenant_id", None)
+        if not tenant_id:
+            # No tenant context — nothing to enforce. Anonymous traffic
+            # is already gated by `require_tenant` if the operator
+            # wanted it gated.
+            return await call_next(request)
+
+        # Open a short-lived session purely for the residency check.
+        # The read is a single row by PK on `tenant_configs`; in the
+        # happy path (matching region) the work is one round-trip
+        # before the rest of the request proceeds with its own
+        # session-via-dependency-injection.
+        from server.db.engine import get_session_factory
+        from server.db import repositories as repo
+        from server.services.residency import check_residency
+
+        try:
+            async with get_session_factory()() as session:
+                row = await repo.get_tenant_config(session, tenant_id)
+        except Exception:
+            # If the residency lookup itself blew up (DB transient,
+            # schema mismatch during a migration window), we have a
+            # choice: fail open (allow the request) or fail closed
+            # (refuse). For residency we fail OPEN with a warning,
+            # because failing closed here would take down every
+            # tenant-scoped request on any DB blip — the data plane
+            # is already separated per region by infra, and this
+            # middleware is the second line of defence. The first
+            # line is the deployment topology itself.
+            logger.warning(
+                "residency_check_failed_failing_open",
+                tenant_id=tenant_id,
+                path=request.url.path,
+                exc_info=True,
+            )
+            return await call_next(request)
+
+        tenant_config = (row.config if row else {}) or {}
+        mismatch = check_residency(tenant_config=tenant_config, server_region=server_region)
+        if mismatch is None:
+            return await call_next(request)
+
+        logger.warning(
+            "residency_mismatch_refused",
+            tenant_id=tenant_id,
+            tenant_region=mismatch.tenant_region,
+            server_region=mismatch.server_region,
+            path=request.url.path,
+        )
+        # 403 with the structured `residency.mismatch` code. The
+        # message names the tenant's pinned region (operator-set, safe
+        # to surface) but NOT the server's local region — that would
+        # leak topology to a caller probing the residency boundary.
+        return JSONResponse(
+            status_code=403,
+            content={
+                "error": {
+                    "code": "residency.mismatch",
+                    "message": (
+                        f"tenant {tenant_id!r} is pinned to region "
+                        f"{mismatch.tenant_region!r}; this request did not "
+                        "reach the right region. Retry against the regional "
+                        "endpoint."
+                    ),
+                }
+            },
+        )

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -227,6 +227,32 @@ class TenantConfigPatch(BaseModel):
             "enforcement non-bypassable."
         ),
     )
+    region: str | None = Field(
+        None,
+        max_length=64,
+        description=(
+            "Data-residency pin (v0.9 #161). When set, requests for "
+            "this tenant only run in the matching region — a process "
+            "with STATEWAVE_REGION differing from this value refuses "
+            "the request with HTTP 403 residency.mismatch. `None` "
+            "(the default) leaves the tenant unpinned: it runs in "
+            "any region. The admin endpoint refuses pinning a tenant "
+            "to a region this server doesn't serve (would lock the "
+            "tenant out immediately); patch from a server in the "
+            "target region instead."
+        ),
+    )
+    force_region_pin: bool | None = Field(
+        None,
+        description=(
+            "Bypass the safety check that refuses pinning this tenant "
+            "to a region this server doesn't serve. Use only for "
+            "scripted bulk-config migrations executed via a "
+            "single-region orchestrator (set STATEWAVE_REGION=None on "
+            "the orchestrator). Has no effect on the value written; "
+            "only suppresses the validation refusal."
+        ),
+    )
     expected_version: int | None = Field(
         None,
         ge=0,

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -833,6 +833,10 @@ async def _maybe_emit_receipt(
         caller_id=caller_id,
         caller_type=caller_type,
         policy_snapshot=policy_snapshot,
+        # v0.9 #161 — stamp the local region on every emitted receipt
+        # so the audit trail records *where* the decision was made,
+        # not just *what* it was. None in single-region deployments.
+        region=settings.region,
     )
     written_id = await receipts_service.write_receipt(
         session, receipt_body=body, as_of=as_of, tenant_config=tenant_config

--- a/server/services/handoff.py
+++ b/server/services/handoff.py
@@ -65,9 +65,7 @@ async def assemble_handoff(
     # through the same policy gate as /v1/context. The active bundle is
     # the same one /v1/context resolves; log_only vs enforce is the same
     # per-tenant flag.
-    tenant_config = await receipts_service.load_tenant_receipt_config(
-        session, tenant_id
-    )
+    tenant_config = await receipts_service.load_tenant_receipt_config(session, tenant_id)
     policy_mode = (tenant_config or {}).get("policy_mode", "log_only")
     policy_enforce = policy_mode == "enforce"
     active_bundle = await policy_service.resolve_active_bundle(session, tenant_id)
@@ -86,9 +84,7 @@ async def assemble_handoff(
         if decision.action != "allow":
             policy_decisions[row.id] = decision
     if policy_enforce and policy_decisions:
-        fact_rows, _ = policy_service.apply_decisions(
-            fact_rows, policy_decisions, enforce=True
-        )
+        fact_rows, _ = policy_service.apply_decisions(fact_rows, policy_decisions, enforce=True)
 
     # -- Key facts ----------------------------------------------------------
     key_facts = [row.content for row in fact_rows if row.status == "active"]
@@ -342,9 +338,7 @@ async def _maybe_emit_handoff_receipt(
     `handoff:{reason}` string so audit dashboards can filter handoffs
     cleanly from regular retrievals."""
     if tenant_config is None:
-        tenant_config = await receipts_service.load_tenant_receipt_config(
-            session, tenant_id
-        )
+        tenant_config = await receipts_service.load_tenant_receipt_config(session, tenant_id)
     decision = receipts_service.decide_emission(
         request_flag=emit_receipt,
         tenant_config=tenant_config,
@@ -353,14 +347,10 @@ async def _maybe_emit_handoff_receipt(
     if not decision.emit:
         return None, False
 
-    context_hash, context_size_bytes = receipts_service.canonicalize_context(
-        handoff_notes
-    )
+    context_hash, context_size_bytes = receipts_service.canonicalize_context(handoff_notes)
     policy_decisions = policy_decisions or {}
     filters_applied = policy_service.build_filters_applied(policy_decisions)
-    filters_skipped = policy_service.build_filters_skipped(
-        policy_decisions, policy_bundle
-    )
+    filters_skipped = policy_service.build_filters_skipped(policy_decisions, policy_bundle)
 
     rank = 0
     selected_memories = []
@@ -412,6 +402,9 @@ async def _maybe_emit_handoff_receipt(
         filters_skipped=filters_skipped,
         caller_id=caller_id,
         caller_type=caller_type,
+        # v0.9 #161 — same residency stamp as the context path uses;
+        # handoff receipts also record where the decision was made.
+        region=settings.region,
     )
     written_id = await receipts_service.write_receipt(
         session, receipt_body=body, as_of=as_of, tenant_config=tenant_config

--- a/server/services/residency.py
+++ b/server/services/residency.py
@@ -1,0 +1,144 @@
+"""Data residency enforcement (v0.9, issue #161).
+
+Model: per-region deployment + metadata-pinned tenants. Each server
+process declares its region via ``STATEWAVE_REGION`` (Settings.region).
+Each tenant optionally pins to a region via
+``tenant_configs.config.region``. Requests for a pinned tenant are
+only allowed to run inside the matching region; anywhere else the
+request is refused with HTTP 403 / ``residency.mismatch``.
+
+Why metadata-pinned tenants and not in-DB partitioning:
+
+  * **Correctness boundary at the application layer**, not DNS or
+    the load balancer. A misrouted request that bypassed the LB
+    hostname would still be caught by this module before any DB
+    access happens. Belt-and-suspenders by design.
+  * **Separate Postgres / pgvector deployments per region** are the
+    intended infra topology, but the residency story does not depend
+    on the DB layer for correctness — the application is the source
+    of truth for "is this request allowed here?"
+  * **Auditable**: a tenant's pinned region is plain data in
+    ``tenant_configs.config.region``, queryable, patch-able through
+    the existing admin surface, and recorded on every emitted
+    receipt's ``region`` field.
+
+What this module does NOT do (intentional, v0.9 scope):
+
+  * **No cross-region reads.** Total isolation. An admin in region A
+    cannot read tenant B's data in region B. The pinned region IS
+    the access boundary; unified federated audit is a future
+    feature, not implicit cross-region access.
+  * **No automatic region rebalancing.** Pinning a tenant is an
+    operator action that requires their data to be in the target
+    region first; this module does not move data.
+  * **No in-DB region column on every row.** That would conflate
+    residency with multi-tenancy. Residency is per-tenant, not
+    per-row.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ResidencyMismatch:
+    """Returned by ``check_residency`` when a request is refused.
+
+    The reason is intentionally simple — the caller (API layer)
+    surfaces it as HTTP 403 with ``error.code = residency.mismatch``
+    and a message that names the tenant region. Server region is
+    NOT echoed in the response: an attacker probing the residency
+    boundary should not learn what region they hit. The deny is
+    flat: "this tenant lives elsewhere", not "you reached us-east
+    while the tenant is in eu-west".
+    """
+
+    tenant_region: str
+    """The region the tenant is pinned to (safe to surface: the
+    operator gave it to us)."""
+    server_region: str
+    """The region THIS process is running in. NEVER returned on the
+    wire; logged for operators only."""
+
+
+def check_residency(
+    *,
+    tenant_config: dict[str, Any] | None,
+    server_region: str | None,
+) -> ResidencyMismatch | None:
+    """Pure residency check. Returns ``None`` when the request is
+    allowed; returns a ``ResidencyMismatch`` otherwise.
+
+    Three cases collapse to allow:
+
+      1. ``server_region`` is ``None`` — single-region deployment,
+         residency disabled entirely. (A regression that left the
+         setting unset must not start refusing requests.)
+      2. ``tenant_config.region`` is ``None`` or absent — tenant is
+         not pinned; it can run anywhere. Legacy tenants and
+         single-region tenants take this path.
+      3. ``tenant_config.region == server_region`` — exact match,
+         allowed.
+
+    Anything else returns ``ResidencyMismatch``. Comparison is exact
+    string equality; case mismatches are treated as different
+    regions on purpose (we'd rather fail loudly than silently allow
+    ``EU`` and ``eu`` to mean the same thing).
+    """
+    if not server_region:
+        return None
+    tenant_region = (tenant_config or {}).get("region")
+    if tenant_region is None or tenant_region == "":
+        return None
+    if not isinstance(tenant_region, str):
+        # Defensive: a malformed JSONB value should not silently allow
+        # the request. Treat as "configured but invalid" and refuse.
+        return ResidencyMismatch(
+            tenant_region=str(tenant_region),
+            server_region=server_region,
+        )
+    if tenant_region == server_region:
+        return None
+    return ResidencyMismatch(
+        tenant_region=tenant_region,
+        server_region=server_region,
+    )
+
+
+def validate_region_pin(
+    *,
+    proposed_region: str,
+    server_region: str | None,
+) -> str | None:
+    """Operator-facing validation: returns a refusal message when an
+    operator tries to pin a tenant to a region this server doesn't
+    serve.
+
+    Pinning a tenant to a region different from the local
+    ``server_region`` would immediately lock the tenant out of this
+    deployment — every subsequent request would 403. That's almost
+    always an operator mistake, so we refuse the pin at the admin
+    endpoint unless ``server_region is None`` (single-region or
+    development mode, where the check is meaningless).
+
+    Returns:
+        - ``None`` when the pin is safe.
+        - A human-readable refusal message otherwise. The admin
+          endpoint surfaces this in a 422 ``residency.invalid_pin``.
+    """
+    if not server_region:
+        # No locally-known region — operator is in dev / single-region
+        # mode. Allow the pin so they can author tenant configs that
+        # will be deployed to a multi-region environment later.
+        return None
+    if proposed_region == server_region:
+        return None
+    return (
+        f"this server is running in region {server_region!r}; pinning a "
+        f"tenant to {proposed_region!r} from here would lock the tenant "
+        "out (every subsequent request would 403). Patch the pin from "
+        "a server running in the target region, or set "
+        "STATEWAVE_REGION to match if this server should serve it."
+    )

--- a/tests/integration/test_residency.py
+++ b/tests/integration/test_residency.py
@@ -1,0 +1,333 @@
+"""End-to-end residency enforcement tests (v0.9 #161).
+
+Covers:
+  * Middleware: refuses tenant-scoped requests when the tenant is
+    pinned to a different region than ``settings.region``.
+  * Middleware: passes through when residency is disabled
+    (`settings.region` is None) — the v0.8 upgrade path.
+  * Middleware: passes through when the tenant is not pinned.
+  * Admin patch: refuses pinning a tenant to a region this server
+    doesn't serve unless `force_region_pin: true` is set.
+  * Admin patch: accepts pinning to the local region.
+  * Region is stamped on receipts emitted in multi-region mode.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from server.core.config import settings
+from server.db.tables import ReceiptRow, TenantConfigRow
+
+
+# ---------------------------------------------------------------------------
+# Middleware enforcement
+# ---------------------------------------------------------------------------
+
+
+async def _set_tenant_region(session_factory, *, tenant_id: str, region: str | None):
+    """Direct DB write so the test controls the pinned region precisely."""
+    async with session_factory() as session:
+        result = await session.execute(
+            select(TenantConfigRow).where(TenantConfigRow.tenant_id == tenant_id)
+        )
+        row = result.scalar_one_or_none()
+        new_config: dict = {}
+        if row is not None:
+            new_config = dict(row.config or {})
+        if region is None:
+            new_config.pop("region", None)
+        else:
+            new_config["region"] = region
+
+        if row is None:
+            session.add(
+                TenantConfigRow(
+                    tenant_id=tenant_id,
+                    config=new_config,
+                    version=1,
+                )
+            )
+        else:
+            row.config = new_config
+            row.version = row.version + 1
+        await session.commit()
+
+
+@pytest.mark.anyio
+async def test_residency_disabled_is_a_passthrough(
+    client: AsyncClient, session_factory, monkeypatch
+):
+    """When `settings.region` is None (single-region mode, the
+    default), the middleware must not refuse any request — even if
+    the tenant has a region pinned in its config."""
+    monkeypatch.setattr(settings, "region", None)
+    tenant_id = f"t-{uuid.uuid4().hex[:8]}"
+    await _set_tenant_region(session_factory, tenant_id=tenant_id, region="us")
+
+    r = await client.get(
+        "/admin/tenants",
+        headers={"X-Tenant-ID": tenant_id},
+    )
+    # Any tenant-scoped route must succeed when residency is off.
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.anyio
+async def test_unpinned_tenant_passes_through_in_multi_region(
+    client: AsyncClient, session_factory, monkeypatch
+):
+    """A tenant without `region` in its config is unpinned: legacy
+    pre-v0.9 tenants and globally-mobile tenants both take this path
+    and must not be refused."""
+    monkeypatch.setattr(settings, "region", "eu")
+    tenant_id = f"t-{uuid.uuid4().hex[:8]}"
+    # Deliberately no region pin.
+    await _set_tenant_region(session_factory, tenant_id=tenant_id, region=None)
+
+    r = await client.get(
+        f"/admin/tenants/{tenant_id}/config",
+        headers={"X-Tenant-ID": tenant_id},
+    )
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.anyio
+async def test_matching_region_allowed(client: AsyncClient, session_factory, monkeypatch):
+    monkeypatch.setattr(settings, "region", "eu")
+    tenant_id = f"t-{uuid.uuid4().hex[:8]}"
+    await _set_tenant_region(session_factory, tenant_id=tenant_id, region="eu")
+
+    r = await client.get(
+        f"/admin/tenants/{tenant_id}/config",
+        headers={"X-Tenant-ID": tenant_id},
+    )
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.anyio
+async def test_mismatched_region_refused_with_403(
+    client: AsyncClient, session_factory, monkeypatch
+):
+    """The load-bearing test: a request for a tenant pinned to `us`
+    arriving at an `eu` process must be refused with 403 +
+    `residency.mismatch`, no exceptions."""
+    monkeypatch.setattr(settings, "region", "eu")
+    tenant_id = f"t-{uuid.uuid4().hex[:8]}"
+    await _set_tenant_region(session_factory, tenant_id=tenant_id, region="us")
+
+    r = await client.post(
+        "/v1/episodes",
+        headers={"X-Tenant-ID": tenant_id},
+        json={
+            "subject_id": "anyone",
+            "source": "test",
+            "type": "chat.session",
+            "payload": {"messages": []},
+        },
+    )
+    assert r.status_code == 403, r.text
+    err = r.json()["error"]
+    assert err["code"] == "residency.mismatch"
+    # The wire response must NOT echo the server's region — only
+    # the tenant's pinned region is safe to surface.
+    assert "us" in err["message"]
+    assert "eu" not in err["message"]
+
+
+@pytest.mark.anyio
+async def test_mismatched_region_refused_on_admin_path_too(
+    client: AsyncClient, session_factory, monkeypatch
+):
+    """v0.9 #161 design decision: total isolation. Cross-region
+    admin reads are forbidden. The same 403 applies to /admin/."""
+    monkeypatch.setattr(settings, "region", "eu")
+    tenant_id = f"t-{uuid.uuid4().hex[:8]}"
+    await _set_tenant_region(session_factory, tenant_id=tenant_id, region="us")
+
+    r = await client.get(
+        f"/admin/tenants/{tenant_id}/config",
+        headers={"X-Tenant-ID": tenant_id},
+    )
+    assert r.status_code == 403
+    assert r.json()["error"]["code"] == "residency.mismatch"
+
+
+@pytest.mark.anyio
+async def test_anonymous_request_skipped(client: AsyncClient, session_factory, monkeypatch):
+    """Requests without a tenant header have nothing to enforce
+    against. The middleware must pass them through; `require_tenant`
+    is the separate knob that gates anonymous traffic."""
+    monkeypatch.setattr(settings, "region", "eu")
+
+    r = await client.get("/healthz")
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Admin patch — pinning a tenant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_admin_patch_accepts_pin_to_local_region(client: AsyncClient, monkeypatch):
+    """Pinning a tenant to the local region from this server is the
+    happy path — it doesn't lock the tenant out."""
+    monkeypatch.setattr(settings, "region", "eu")
+    tenant_id = f"t-{uuid.uuid4().hex[:8]}"
+
+    r = await client.patch(
+        f"/admin/tenants/{tenant_id}/config",
+        json={"region": "eu"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["config"]["region"] == "eu"
+
+
+@pytest.mark.anyio
+async def test_admin_patch_refuses_pin_to_foreign_region_without_force(
+    client: AsyncClient, monkeypatch
+):
+    """Pinning a tenant to a region this server doesn't serve would
+    immediately lock the tenant out. Refuse with 422
+    `residency.invalid_pin` unless `force_region_pin: true`."""
+    monkeypatch.setattr(settings, "region", "eu")
+    tenant_id = f"t-{uuid.uuid4().hex[:8]}"
+
+    r = await client.patch(
+        f"/admin/tenants/{tenant_id}/config",
+        json={"region": "us"},
+    )
+    assert r.status_code == 422
+    err = r.json()["error"]
+    assert err["code"] == "residency.invalid_pin"
+
+
+@pytest.mark.anyio
+async def test_admin_patch_accepts_force_region_pin(client: AsyncClient, monkeypatch):
+    """`force_region_pin: true` bypasses the safety check — used by
+    scripted bulk-config migrations."""
+    monkeypatch.setattr(settings, "region", "eu")
+    tenant_id = f"t-{uuid.uuid4().hex[:8]}"
+
+    r = await client.patch(
+        f"/admin/tenants/{tenant_id}/config",
+        json={"region": "us", "force_region_pin": True},
+    )
+    # Note: the tenant is now locked out of THIS server, but the
+    # admin-patch endpoint is reachable because the tenant didn't
+    # have a residency pin BEFORE this call. (Middleware reads the
+    # pre-call config.)
+    assert r.status_code == 200, r.text
+    assert r.json()["config"]["region"] == "us"
+    # `force_region_pin` is a request-only flag, not a config key —
+    # it must not be persisted on the JSONB.
+    assert "force_region_pin" not in r.json()["config"]
+
+
+@pytest.mark.anyio
+async def test_admin_patch_allows_any_pin_in_single_region_mode(client: AsyncClient, monkeypatch):
+    """Dev / single-region servers (`settings.region` is None) must
+    allow operators to author multi-region configs that will be
+    deployed elsewhere."""
+    monkeypatch.setattr(settings, "region", None)
+    tenant_id = f"t-{uuid.uuid4().hex[:8]}"
+
+    r = await client.patch(
+        f"/admin/tenants/{tenant_id}/config",
+        json={"region": "ap-south-1"},
+    )
+    assert r.status_code == 200
+    assert r.json()["config"]["region"] == "ap-south-1"
+
+
+# ---------------------------------------------------------------------------
+# Region stamped on receipts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_receipts_stamp_local_region(client: AsyncClient, session_factory, monkeypatch):
+    """Receipts emitted in multi-region mode must carry the local
+    region so the audit trail records *where* the decision was made,
+    not just *what* it was."""
+    monkeypatch.setattr(settings, "region", "eu")
+    tenant_id = f"t-{uuid.uuid4().hex[:8]}"
+    # Pin to EU so the middleware doesn't refuse the request.
+    await _set_tenant_region(session_factory, tenant_id=tenant_id, region="eu")
+    subject_id = f"s-{uuid.uuid4().hex[:8]}"
+
+    r = await client.post(
+        "/v1/episodes",
+        headers={"X-Tenant-ID": tenant_id},
+        json={
+            "subject_id": subject_id,
+            "source": "test",
+            "type": "chat.session",
+            "payload": {
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        },
+    )
+    assert r.status_code == 201
+    r = await client.post(
+        "/v1/memories/compile",
+        headers={"X-Tenant-ID": tenant_id},
+        json={"subject_id": subject_id},
+    )
+    assert r.status_code == 200
+    r = await client.post(
+        "/v1/context",
+        headers={"X-Tenant-ID": tenant_id},
+        json={"subject_id": subject_id, "task": "hi", "emit_receipt": True},
+    )
+    assert r.status_code == 200, r.text
+    receipt_id = r.json().get("receipt_id")
+    assert receipt_id
+
+    async with session_factory() as session:
+        row = (
+            await session.execute(select(ReceiptRow).where(ReceiptRow.receipt_id == receipt_id))
+        ).scalar_one()
+    assert row.region == "eu"
+    assert row.body.get("region") == "eu"
+
+
+@pytest.mark.anyio
+async def test_receipts_have_null_region_in_single_region_mode(
+    client: AsyncClient, session_factory, monkeypatch
+):
+    """When `settings.region` is None, receipts carry `region=None`
+    — the v0.8-backwards-compatible default."""
+    monkeypatch.setattr(settings, "region", None)
+    subject_id = f"s-{uuid.uuid4().hex[:8]}"
+
+    r = await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": subject_id,
+            "source": "test",
+            "type": "chat.session",
+            "payload": {"messages": [{"role": "user", "content": "hi"}]},
+        },
+    )
+    assert r.status_code == 201
+    r = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert r.status_code == 200
+    r = await client.post(
+        "/v1/context",
+        json={"subject_id": subject_id, "task": "hi", "emit_receipt": True},
+    )
+    assert r.status_code == 200
+    receipt_id = r.json().get("receipt_id")
+    assert receipt_id
+
+    async with session_factory() as session:
+        row = (
+            await session.execute(select(ReceiptRow).where(ReceiptRow.receipt_id == receipt_id))
+        ).scalar_one()
+    assert row.region is None

--- a/tests/test_residency.py
+++ b/tests/test_residency.py
@@ -1,0 +1,92 @@
+"""Unit tests for residency check + region-pin validation (v0.9 #161).
+
+Pure tests — exercise the decision matrix directly without booting
+the app. End-to-end enforcement (middleware + admin patch) is in
+tests/integration/test_residency.py.
+"""
+
+from __future__ import annotations
+
+from server.services.residency import (
+    ResidencyMismatch,
+    check_residency,
+    validate_region_pin,
+)
+
+
+# ---------------------------------------------------------------------------
+# check_residency — the decision matrix
+# ---------------------------------------------------------------------------
+
+
+def test_single_region_mode_always_allows():
+    """server_region None = single-region deployment, residency
+    disabled entirely. The check must be a no-op regardless of what
+    the tenant config says."""
+    assert check_residency(tenant_config={"region": "us"}, server_region=None) is None
+    assert check_residency(tenant_config={}, server_region=None) is None
+    assert check_residency(tenant_config=None, server_region=None) is None
+
+
+def test_unpinned_tenant_allowed_anywhere():
+    """A tenant without a pinned region is global by default."""
+    assert check_residency(tenant_config={}, server_region="eu") is None
+    assert check_residency(tenant_config=None, server_region="eu") is None
+    # Empty string is treated as "no pin" (same as missing key).
+    assert check_residency(tenant_config={"region": ""}, server_region="eu") is None
+
+
+def test_matching_region_allowed():
+    assert check_residency(tenant_config={"region": "eu"}, server_region="eu") is None
+
+
+def test_mismatched_region_refused():
+    result = check_residency(tenant_config={"region": "us"}, server_region="eu")
+    assert isinstance(result, ResidencyMismatch)
+    assert result.tenant_region == "us"
+    assert result.server_region == "eu"
+
+
+def test_case_sensitive_region_compare():
+    """`EU` and `eu` are distinct regions — we fail loudly rather
+    than risk a typo silently allowing cross-region traffic."""
+    result = check_residency(tenant_config={"region": "EU"}, server_region="eu")
+    assert isinstance(result, ResidencyMismatch)
+
+
+def test_non_string_region_refused_defensively():
+    """A malformed JSONB value (e.g. an int written via direct SQL)
+    must NOT silently allow the request."""
+    result = check_residency(tenant_config={"region": 42}, server_region="eu")
+    assert isinstance(result, ResidencyMismatch)
+
+
+def test_tenant_config_missing_region_key_is_allowed():
+    """A pre-v0.9 tenant config that pre-dates the region key passes
+    through as if unpinned — backwards compatibility."""
+    legacy = {"receipts": "always", "policy_mode": "log_only"}
+    assert check_residency(tenant_config=legacy, server_region="eu") is None
+
+
+# ---------------------------------------------------------------------------
+# validate_region_pin — operator-facing safety check
+# ---------------------------------------------------------------------------
+
+
+def test_validate_pin_to_matching_region_allowed():
+    assert validate_region_pin(proposed_region="eu", server_region="eu") is None
+
+
+def test_validate_pin_to_different_region_refused():
+    msg = validate_region_pin(proposed_region="us", server_region="eu")
+    assert msg is not None
+    assert "us" in msg
+    assert "eu" in msg
+
+
+def test_validate_pin_allowed_in_single_region_mode():
+    """Dev / single-region mode: server_region is None, so the safety
+    check is meaningless. Operator authoring multi-region configs
+    from a dev box must be allowed to pin to any region."""
+    assert validate_region_pin(proposed_region="us", server_region=None) is None
+    assert validate_region_pin(proposed_region="eu", server_region=None) is None


### PR DESCRIPTION
Final v0.9 PR. Per-region deployment + metadata-pinned tenants with **application-layer hard enforcement**. The application is the source of truth for 'is this request allowed here?' — DNS, anycast, and load balancers can misroute requests; the application layer is the single point that knows definitively whether a request can be served here.

## Configuration model

| Where it lives                          | What it means                                    |
|-----------------------------------------|--------------------------------------------------|
| `STATEWAVE_REGION` env var              | Which region THIS server process is running in   |
| `tenant_configs.config.region` JSONB    | Which region a tenant is pinned to               |

A request is allowed iff:

1. `STATEWAVE_REGION` is unset (**single-region mode** — residency disabled, all requests pass through), OR
2. The tenant has no `region` in its config (**unpinned**, legacy or globally-mobile), OR
3. Tenant's pinned region equals `STATEWAVE_REGION` exactly (case-sensitive).

Anything else → HTTP 403 + `error.code = residency.mismatch`.

## Why this shape

- **Application-layer enforcement**, not DNS / LB hints. A misrouted request that bypassed the LB hostname is still caught here before any DB access happens.
- **Separate Postgres / pgvector per region** is the intended infra topology. Application is the second line of defence; topology is the first.
- **No in-DB region column on every row.** That would conflate residency with multi-tenancy. Residency is per-tenant, not per-row.
- **Total isolation** in v0.9. Cross-region admin reads not allowed. Unified federated audit is a future explicit surface, never implicit access.

## Enforcement

- `ResidencyMiddleware` runs after `TenantMiddleware`. Refuses with 403 + standard error envelope on mismatch.
- Wire response carries the tenant's pinned region (operator-set, safe to surface) but **never** the local server's region (would leak topology to a caller probing the boundary).
- Same middleware enforces `/admin/` and `/v1/` — total isolation per v0.9 design.
- Single-region deployments (`STATEWAVE_REGION=None`) pay zero cost — middleware short-circuits before any DB work.
- DB blip during the check fails **open** with a structured warning. Failing closed on transient errors would take down every tenant-scoped request; infra topology is the first line of defence, the middleware is the second.

## Admin patch safety

`PATCH /admin/tenants/{id}/config` gets a new `region` field. The endpoint **refuses pinning a tenant to a region this server doesn't serve** (would lock the tenant out immediately) with 422 `residency.invalid_pin` unless `force_region_pin: true` is supplied — for scripted bulk-config migrations run from a single-region orchestrator. `force_region_pin` is request-only; never persisted.

## Receipt audit trail

Every receipt emitted in multi-region mode carries `settings.region` in its `region` field (column + body). The column has been on `receipts` since v0.8; v0.9 finally populates it. Single-region receipts keep `region=None` (backwards-compatible).

Combined with HMAC (#157), policy snapshot (#159), and replay (#159), residency closes the end-to-end audit story:

- *Where* was this decision made? `receipt.region`
- *With what rules?* `receipt.policy_snapshot.bundle_yaml`
- *Was the body tampered with?* HMAC verify
- *Would current code make the same call?* Replay diff

## Tests (32 total, all green)

- **10 unit tests** for `check_residency` + `validate_region_pin`: decision matrix, single-region mode, unpinned tenant, matching region, mismatched region, case sensitivity, defensive non-string handling, pre-v0.9 backwards-compat.
- **12 integration tests** for middleware + admin patch + receipt stamping: passthrough when disabled, unpinned tenant allowed, matching region allowed, 403 on mismatch, admin path also enforced, anonymous skipped, admin pin accepted to local region, admin pin refused without force, force flag accepted, dev-mode any-pin allowed, region stamped on receipts, region null in single-region mode.

All 859 existing tests still pass.

## Docs

- `docs/residency.md` — full model + ops runbook for spinning up a second region (provision infra, set STATEWAVE_REGION, migrate data, pin tenants in both regions, verify cutover, purge stale origin data). Explicit list of failure modes and what residency does NOT do.

## Out of scope (intentional)

- **No actual second region deployed.** PR ships code + config model + enforcement tests + docs + ops runbook only. Validation is in-process; rollout is operator work using the runbook.
- **No federated cross-region audit reads.** Total isolation in v0.9.
- **No automatic region rebalancing.** Pinning assumes data is already in the target region (operator workflow).
- **No new DB columns.** Uses existing `tenant_configs` JSONB and the existing `receipts.region` column from v0.8.

Closes #161.