### PR TITLE
fix(handoff): embed policy_snapshot for replay symmetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ The runtime essentials. [Full capability inventory →](docs/capabilities.md)
 - **Provenance** — every memory traces back to its source episodes; receipts are content-hashed
 - **Pluggable compilers** — heuristic (regex, fully local) or LLM (any [LiteLLM](https://github.com/BerriAI/litellm) provider)
 - **Subject-organised** — `user:`, `repo:`, `account:`, or any entity prefix you choose
-- **State-assembly receipts** — immutable, ULID-addressable record of which memories influenced each bundle
-- **Sensitivity labels + policy engine** — declarative YAML policies (`deny` / `redact`) over per-memory tags (`pii`, `financial`, `secret`, …) with `log_only` and `enforce` modes
-- **Multi-tenant** — query-scoped data isolation via `X-Tenant-ID` header, per-tenant config and policies
+- **State-assembly receipts** — immutable, ULID-addressable record of which memories influenced each bundle. HMAC-SHA256 signature (v0.9), embedded policy snapshot (v0.9), and `POST /v1/receipts/{id}/replay` for "what would today's code say with the original rules?"
+- **Sensitivity labels + policy engine** — declarative YAML policies (`deny` / `redact`) over per-memory tags (`pii`, `financial`, `secret`, …) with `log_only` and `enforce` modes. v0.9 adds advisory `suggested_labels` from heuristic detectors (pii.email/phone, financial.card, secret.token) with operator review + explicit promotion via the admin app
+- **Multi-tenant** — query-scoped data isolation via `X-Tenant-ID` header, per-tenant config and policies. v0.9 adds per-tenant **region pinning** for residency: requests for a tenant pinned to `eu` are 403'd at any process running in another region
 - **Self-hosted on Postgres + pgvector** — no vendor lock-in; runs on your infrastructure
 
 ## Why Statewave
@@ -257,6 +257,9 @@ All settings use the `STATEWAVE_` env prefix. Copy `.env.example` to `.env` to g
 | `STATEWAVE_WEBHOOK_TIMEOUT` | `5.0` | Webhook HTTP timeout in seconds |
 | `STATEWAVE_WEBHOOK_EVENTS` | — | Comma-separated event-type allowlist (empty = deliver every event) |
 | `STATEWAVE_RECEIPT_SIGNING_KEYS` | — | JSON `{"<key_id>": "<base64>"}` map of HMAC keys for receipt signing (≥32 bytes each). Never persisted to the DB; per-tenant active key id set via `tenant_configs.config.receipt_signing_key_id`. |
+| `STATEWAVE_AUTO_LABELING_ENABLED` | `false` | Run heuristic detectors at compile time and stamp advisory `suggested_labels` on memories (v0.9). See [`docs/auto-labeling.md`](docs/auto-labeling.md). |
+| `STATEWAVE_AUTO_LABELING_PROVIDER` | `heuristic` | Detector provider. Only `heuristic` is valid in v0.9; the switch is reserved for future LLM-based classifiers. |
+| `STATEWAVE_REGION` | — | Region this server process is running in. When set, requests for tenants pinned to a different region are refused with HTTP 403 `residency.mismatch` (v0.9). Empty = single-region mode, residency disabled. See [`docs/residency.md`](docs/residency.md). |
 | `STATEWAVE_TENANT_HEADER` | `X-Tenant-ID` | Header for multi-tenant isolation |
 | `STATEWAVE_REQUIRE_TENANT` | `false` | Reject requests without tenant header |
 | `STATEWAVE_DEFAULT_MAX_CONTEXT_TOKENS` | `4000` | Default token budget for context assembly |
@@ -281,10 +284,12 @@ pytest tests/ -v
 Statewave is in active development (v0.9.0). Honest status:
 
 - **Rate limiting is per-IP** — distributed (Postgres-backed), but keyed by IP only, not per-tenant or per-API-key yet
-- **Multi-tenant is app-layer** — query-scoped data isolation (v0.5) + per-tenant config / policy bundles / receipts (v0.8) layered on top, but no Postgres RLS yet
-- **PostgreSQL required** — no alternative storage backends
+- **Multi-tenant is app-layer** — query-scoped data isolation (v0.5) + per-tenant config / policy bundles / receipts (v0.8) + HMAC-signed audit + tenant region pin (v0.9), but no Postgres RLS yet
 - **No built-in auth provider** — validates API keys you configure, doesn't issue them
-- **Policy retention purge worker** — `tenant_configs.receipt_retention_days` is read by the config surface but no scheduled worker deletes expired receipts yet; planned for v0.9
+- **No admin-action identity yet** — the v0.9 auto-labeling promote endpoint stamps `promoted_at` + `labels` on every promotion, but `promoted_by` is `null` until an admin-identity layer ships
+- **No visual policy editor** — policy bundles are authored as YAML in git and uploaded through the admin workflow; a no-YAML form-based editor is deferred to a future admin release
+- **No federated cross-region audit** — v0.9 ships strict per-region isolation by design; operators running multiple regions cannot search receipts or memories across regions from a single console yet. Federated audit should be added explicitly later, not through implicit cross-region access
+- **Replay is "current code + original policy"** — v0.9 receipt replay re-runs the original retrieval against today's memories using the original policy bundle (frozen on every v0.9+ receipt). Byte-for-byte historical reproduction needs memory snapshots, which are deferred
 
 See the [roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) for what's being fixed and when.
 
@@ -305,6 +310,10 @@ See the [roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.
 | [Deployment sizing guide](https://github.com/smaramwbc/statewave-docs/blob/main/deployment/sizing.md) | Hardware profiles by tier (local → enterprise) and topology patterns |
 | [Capacity planning checklist](https://github.com/smaramwbc/statewave-docs/blob/main/deployment/capacity-planning.md) | Diagnostic flow + tuning order when load grows |
 | [Deployment guide](https://github.com/smaramwbc/statewave-docs/blob/main/deployment/guide.md) | Production deployment guidance |
+| [State-assembly receipts](docs/state-assembly-receipts.md) | Receipt schema, HMAC signing, verify semantics |
+| [Receipt replay](docs/replay.md) | v0.9 — re-run a historical retrieval against current memories + original policy |
+| [Auto-labeling](docs/auto-labeling.md) | v0.9 — heuristic detectors + review/promote workflow |
+| [Residency](docs/residency.md) | v0.9 — per-region deployment + tenant pinning + ops runbook |
 | [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) | What's next |
 | [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) | Release history |
 

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -36,7 +36,10 @@ extension without a schema break.
 
 1. **Emission** — every v0.9+ receipt carries
    `policy_snapshot`, a JSONB envelope embedded both inside the
-   signed body and into a denormalised column for fast indexing:
+   signed body and into a denormalised column for fast indexing.
+   This applies to both retrieval receipts (`/v1/context`) and
+   handoff receipts (`/v1/handoff`) — both paths are replayable
+   symmetrically.
 
    ```json
    {

--- a/docs/state-assembly-receipts.md
+++ b/docs/state-assembly-receipts.md
@@ -26,14 +26,14 @@ feature ships with the policy fields present but the policy input
 
 Receipts use a **strict-superset** shape — every field is always
 present, optional fields are nullable. A `mode` discriminator
-(`"retrieval"` in v1, future values reserved for `as_of_replay` and
-`eval_run`) means new assembly modes can extend the schema without a
-union break.
+(`"retrieval"` for `/v1/context` + `/v1/handoff`, `"as_of_replay"`
+for v0.9 replay receipts, future values reserved for `eval_run`)
+means new assembly modes can extend the schema without a union break.
 
 ```yaml
 receipt_id:            # ULID — addressable, chainable
-parent_receipt_id:     # nullable ULID — chains multi-step tasks
-mode:                  # "retrieval" (v1) | reserved future values
+parent_receipt_id:     # nullable ULID — chains multi-step tasks (set on replay receipts)
+mode:                  # "retrieval" | "as_of_replay" | reserved future values
 query_id:              # caller-supplied or generated UUID
 task_id:               # optional, for multi-call tasks
 tenant_id:             # tenant the assembly ran under
@@ -228,12 +228,20 @@ assembly internals:
    `output.context_hash` recomputed from `assembled_context` mismatches
    the stored hash.
 
-## Out of scope for v1
+## Shipped after this doc was written
 
-- Sensitivity-label / policy layer ([#50](https://github.com/smaramwbc/statewave/issues/50)) — receipt fields exist, policy input returns "no opinion".
-- Review-time redaction UI.
-- Receipt-driven replay / time-travel debugging tooling.
-- Cross-tenant receipt aggregation / fleet-wide audit views.
+- **Sensitivity-label / policy layer** ([#50](https://github.com/smaramwbc/statewave/issues/50)) — shipped v0.8. `receipt.policy.filters_applied/skipped` populates from the active bundle; `policy_mode` toggles `log_only` vs `enforce` per tenant.
+- **HMAC signing** ([#157](https://github.com/smaramwbc/statewave/issues/157)) — shipped v0.9. See HMAC signing section above.
+- **Scheduled retention worker** ([#156](https://github.com/smaramwbc/statewave/issues/156)) — shipped v0.9. `cleanup_expired_receipts` tombstones rows past `tenant_configs.receipt_retention_days`; partial index keeps it cheap.
+- **Receipt-driven replay** ([#159](https://github.com/smaramwbc/statewave/issues/159)) — shipped v0.9. `mode: "as_of_replay"` receipts emitted by `POST /v1/receipts/{id}/replay`; design + diff envelope in [`docs/replay.md`](replay.md).
+- **Auto-labeling** ([#158](https://github.com/smaramwbc/statewave/issues/158)) — shipped v0.9. Heuristic detectors stamp advisory `suggested_labels` on memories; the policy evaluator never reads them. Operator review + promote via the admin app (#160). See [`docs/auto-labeling.md`](auto-labeling.md).
+- **Per-tenant residency** ([#161](https://github.com/smaramwbc/statewave/issues/161)) — shipped v0.9. `STATEWAVE_REGION` + `tenant_configs.config.region` enforced at the application layer. See [`docs/residency.md`](residency.md).
+
+## Still out of scope (v0.9)
+
+- Review-time redaction UI for receipts.
+- Cross-tenant receipt aggregation / fleet-wide audit views. Single-tenant audit ships; federated cross-region audit is an explicit future surface, not implicit access (see `docs/residency.md`).
 - KMS / Vault-backed signing (architecture is compatible — a future PR swaps the key resolver behind the same `receipt_signing_keys` settings field; v0.9 reads keys from env / secret-manager mount).
 - Asymmetric signatures (the `algorithm` field reserves space for `ed25519-canonical-v1` etc.; v0.9 ships HMAC only).
 - Bulk re-signing of pre-v0.9 receipts (forward-only signing — they verify as `no_signature`).
+- Byte-for-byte historical replay (memory snapshots). v0.9 ships `current code + original policy`; the data model leaves room for memory snapshots without a schema break.

--- a/server/services/handoff.py
+++ b/server/services/handoff.py
@@ -381,6 +381,17 @@ async def _maybe_emit_handoff_receipt(
         )
 
     receipt_id = receipts_service.new_ulid()
+    # v0.9 #159 — stamp the same policy snapshot the /v1/context path
+    # writes so handoff receipts are replayable by /v1/receipts/{id}/replay
+    # without a separate code path. Empty-bundle snapshots (null inner
+    # pair) replay against the no-policy fallback. The fix landed
+    # after #159 shipped — pre-fix handoff receipts will return 422
+    # ``unreplayable.missing_policy_snapshot``, same contract as
+    # pre-v0.9 retrieval receipts.
+    policy_snapshot = receipts_service.build_policy_snapshot(
+        bundle_hash=policy_bundle.bundle_hash if policy_bundle else None,
+        bundle_yaml=policy_bundle.yaml_content if policy_bundle else None,
+    )
     body = receipts_service.build_receipt_body(
         receipt_id=receipt_id,
         mode="retrieval",
@@ -402,6 +413,7 @@ async def _maybe_emit_handoff_receipt(
         filters_skipped=filters_skipped,
         caller_id=caller_id,
         caller_type=caller_type,
+        policy_snapshot=policy_snapshot,
         # v0.9 #161 — same residency stamp as the context path uses;
         # handoff receipts also record where the decision was made.
         region=settings.region,

--- a/tests/integration/test_replay.py
+++ b/tests/integration/test_replay.py
@@ -312,3 +312,106 @@ async def test_admin_replay_shim_surfaces_422_codes(
 async def test_admin_replay_shim_404(client: AsyncClient):
     r = await client.post(f"/admin/receipts/{uuid.uuid4().hex[:26].upper()}/replay")
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Handoff receipts carry the snapshot too (post-fix symmetry with retrieval)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_handoff(client: AsyncClient, subject_id: str, session_id: str) -> str:
+    """Record episodes + emit a handoff receipt. Returns the receipt id."""
+    r = await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": subject_id,
+            "source": "user",
+            "type": "message",
+            "payload": {"text": "system is down, urgent"},
+            "session_id": session_id,
+        },
+    )
+    assert r.status_code == 201, r.text
+    r = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert r.status_code == 200
+    r = await client.post(
+        "/v1/handoff",
+        json={
+            "subject_id": subject_id,
+            "session_id": session_id,
+            "reason": "escalation",
+            "emit_receipt": True,
+        },
+    )
+    assert r.status_code == 200, r.text
+    receipt_id = r.json().get("receipt_id")
+    assert receipt_id, "handoff did not emit a receipt"
+    return receipt_id
+
+
+@pytest.mark.anyio
+async def test_handoff_receipt_carries_policy_snapshot(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    """The handoff receipt path stamps the same policy_snapshot
+    envelope as the /v1/context path so handoff receipts are
+    replayable. Pre-fix handoff receipts had no snapshot — the
+    replay endpoint refused them with 422; post-fix they replay
+    cleanly."""
+    receipt_id = await _seed_handoff(client, subject_id, "sess-1")
+
+    async with session_factory() as session:
+        row = (
+            await session.execute(select(ReceiptRow).where(ReceiptRow.receipt_id == receipt_id))
+        ).scalar_one()
+
+    # The envelope itself is always present in v0.9+ (null inner pair
+    # when no bundle is active, the YAML when one is).
+    assert row.policy_snapshot is not None
+    assert "bundle_hash" in row.policy_snapshot
+    assert "bundle_yaml" in row.policy_snapshot
+    assert "captured_at" in row.policy_snapshot
+    # Body and column agree (body is signed, column is denormalised).
+    assert row.body.get("policy_snapshot") == row.policy_snapshot
+    # And the task is unambiguously a handoff — we're not accidentally
+    # asserting on a retrieval receipt that happened to land first.
+    assert row.body.get("task", "").startswith("handoff:")
+
+
+@pytest.mark.anyio
+async def test_handoff_receipt_is_replayable(client: AsyncClient, subject_id: str):
+    """Confirm the full loop end-to-end: a handoff receipt replays
+    through POST /v1/receipts/{id}/replay and the response carries
+    the diff envelope. This is the load-bearing test for the fix —
+    it would have failed pre-fix with 422 unreplayable."""
+    receipt_id = await _seed_handoff(client, subject_id, "sess-handoff-replay")
+
+    r = await client.post(f"/v1/receipts/{receipt_id}/replay")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["original_receipt_id"] == receipt_id
+    assert body["replay_receipt_id"]
+    assert body["replay_receipt_id"] != receipt_id
+    # Diff envelope shape, not values — replay semantics are tested
+    # elsewhere; here we only assert symmetry with /v1/context receipts.
+    diff = body["diff"]
+    assert "context_hash" in diff
+    assert "selected_entries" in diff
+    assert "filters_applied" in diff
+
+
+@pytest.mark.anyio
+async def test_handoff_replay_verify_still_works(client: AsyncClient, subject_id: str):
+    """The HMAC verify path covers the canonicalised body. Adding the
+    snapshot to the body must not change whether ``verify`` reports a
+    sensible result. With no signing key configured, the receipt
+    emits unsigned and verify returns ``valid: null, reason: no_signature``
+    — same answer pre- and post-fix."""
+    receipt_id = await _seed_handoff(client, subject_id, "sess-handoff-verify")
+
+    r = await client.get(f"/v1/receipts/{receipt_id}/verify")
+    assert r.status_code == 200
+    body = r.json()
+    # Unsigned in the test fixture (no STATEWAVE_RECEIPT_SIGNING_KEYS).
+    assert body["valid"] is None
+    assert body["reason"] == "no_signature"


### PR DESCRIPTION
Closes the gap where `/v1/handoff` receipts were missing the `policy_snapshot` envelope that v0.9 #159 receipt-replay requires. The retrieval path (`services/context.py`) started stamping it when #159 shipped; the handoff path (`services/handoff.py`) was missed in that pass.

## Backwards compatibility — explicit

**Pre-fix handoff receipts remain backwards-compatible** and continue to return HTTP 422 `unreplayable.missing_policy_snapshot` from `POST /v1/receipts/{id}/replay` — exactly the same contract as pre-v0.9 retrieval receipts. No data migration is needed. No behavioral change for callers that aren't using replay. Receipt verification, listing, retention-purge, and the assembly path itself are all unaffected.

Receipts emitted **after** this PR merges carry the snapshot and replay symmetrically with retrieval receipts.

## What changes

**`server/services/handoff.py`** — builds the `policy_snapshot` from the active policy bundle (or null inner pair when no bundle is active) and threads it through `build_receipt_body`. Mirrors `services/context.py` exactly so the two paths cannot drift again.

## Tests (+3)

- `test_handoff_receipt_carries_policy_snapshot` — column + body envelope both populated, task starts with `handoff:` so we're not accidentally asserting on a retrieval receipt that happened to land first.
- `test_handoff_receipt_is_replayable` — end-to-end POST → 200 → diff envelope shape. **Load-bearing** test for the fix; would have failed pre-fix with 422.
- `test_handoff_replay_verify_still_works` — adding the snapshot to the body doesn't change the HMAC verify path. Unsigned receipts still report `valid: null, reason: no_signature`.

Full server suite locally: **862 passed, 1 skipped** (up from 859, no regressions).

## Release-hardening docs in this PR

Bundled because they describe the same v0.9 surfaces this fix completes:

- **`README.md`** — Capabilities section names v0.9 additions (HMAC, snapshot+replay, suggested_labels, region pin); env-var table grows `STATEWAVE_AUTO_LABELING_ENABLED`, `STATEWAVE_AUTO_LABELING_PROVIDER`, `STATEWAVE_REGION`; doc-links table adds the four new v0.9 doc files. **Current limitations** refreshed: `PostgreSQL required` removed (PostgreSQL + pgvector is core architecture, not a limitation — matching positioning pass lives in the companion `statewave-docs` PR), added `No admin-action identity yet`, `No visual policy editor`, `No federated cross-region audit`, `Replay is "current code + original policy"` caveats.
- **`docs/state-assembly-receipts.md`** — schema `mode` discriminator updated to `"retrieval" | "as_of_replay"`; "Out of scope for v1" rewritten as "Shipped after this doc was written" (lists v0.8/v0.9 additions with PR refs) plus "Still out of scope (v0.9)".
- **`docs/replay.md`** — one-line clarification that handoff receipts are replayable symmetrically.

## Companion PRs

This is **PR 1 of 3** in the v0.9 release-hardening sweep. The other two land after this one in sequence:

- **PR 2** — `statewave-docs`: v0.9 changelog, roadmap, audit/replay docs, Postgres positioning.
- **PR 3** — `statewave-admin`: document v0.9 admin surfaces.

## Out of scope (intentional)

- No new replay semantics; no admin-identity work; no bulk promotion; no second-region deploy; no API surface changes.