### PR TITLE
chore: bump version to 0.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "statewave"
-version = "0.9.0"
+version = "0.9.2"
 description = "Open-source memory runtime for AI agents — durable, structured context with provenance."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
First PR of the v0.9.2 stabilization patch. Closes the pyproject/tag drift introduced when `0.9.0` was bumped ahead of the actual v0.9 work.

## What changes

One line in `pyproject.toml`: `version = "0.9.0"` → `version = "0.9.2"`.

## Why

Published tags `v0.9.0` (at `e51a553`, superseded) and `v0.9.1` (at `4036f4f`, canonical v0.9 governance release) both report version `0.9.0` from `pip show statewave`. Honest version reporting is table-stakes for a launch; this aligns pyproject with the next published tag.

## Why v0.9.2 and not v0.9.1

The v0.9.1 tag is already published and immutable per workspace convention. Cutting an additive v0.9.2 keeps the principle intact and gives us the version-consistency release.

## Out of scope

- **No server feature work.** No new code, no API, no schema, no behaviour change.
- **Helm chart `appVersion` (0.7.0) deliberately untouched.** Chart release cadence is independent; updating `appVersion` changes what `helm install` picks by default, which is out of scope for a version-consistency patch. Flagging separately as a Helm chart release candidate.

## Sequence

This is **PR 1 of 6** in the v0.9.2 stabilization patch:

1. **statewave** — this PR: pyproject bump
2. statewave-docs — v0.9.2 stabilization changelog
3. statewave-py — v0.10.1: receipt verify/replay (closes #169)
4. statewave-ts — v0.10.1: verifyReceipt/replayReceipt + Receipt type completion (closes #170)
5. statewave-examples — fix `pip install statewave-py` → `pip install statewave`
6. statewave-web — stale v0.9 string sweep

The `v0.9.2` tag + GitHub release will be cut after this PR merges with CI green.