### PR TITLE
chore: update README v0.9.0 → v0.9.2 mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _If Statewave is useful to you, a ⭐ on the repo helps others discover it._
 
 <!-- QUICKSTART GIF: docs/img/quickstart.gif landing in follow-up PR (issue #4) -->
 
-> **v0.9.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
+> **v0.9.2** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
 
 ## 🎯 Try it
 
@@ -281,7 +281,7 @@ pytest tests/ -v
 
 ## Current limitations
 
-Statewave is in active development (v0.9.0). Honest status:
+Statewave is in active development (v0.9.2). Honest status:
 
 - **Rate limiting is per-IP** — distributed (Postgres-backed), but keyed by IP only, not per-tenant or per-API-key yet
 - **Multi-tenant is app-layer** — query-scoped data isolation (v0.5) + per-tenant config / policy bundles / receipts (v0.8) + HMAC-signed audit + tenant region pin (v0.9), but no Postgres RLS yet


### PR DESCRIPTION
Closes the mechanical-drift caught by the v0.9.2 Release workflow's [`Verify server/contract version self-consistency`](https://github.com/smaramwbc/statewave/actions/runs/26477504347) gate.

The workspace tooling at `statewave-docs/tools/check-versions.py` treats `statewave/pyproject.toml` as truth and audits two mechanical mirror surfaces in this README. PR [#171](https://github.com/smaramwbc/statewave/pull/171) only touched pyproject; this PR closes the drift on the two README mirrors:

```
- line 17:  > **v0.9.0** — actively developed
+ line 17:  > **v0.9.2** — actively developed

- line 284: Statewave is in active development (v0.9.0).
+ line 284: Statewave is in active development (v0.9.2).
```

Both produced by the canonical fix the audit recommends: `python statewave-docs/tools/bump-version.py 0.9.2 --apply`.

## Why this wasn't in PR 171

PR 171 was scoped to "bump pyproject/version metadata to 0.9.2" per user direction. I read "metadata" narrowly. The repo's tooling-enforced broader meaning (the truth + two mechanical mirrors must stay in lockstep) surfaced when the Release workflow ran on the `v0.9.2` tag.

## Companion PR

[`statewave-docs#…`](https://github.com/smaramwbc/statewave-docs) — same audit also flagged `architecture/repo-map.md` "Test counts (as of v0.9.0)" header. Tracked as a parallel single-line fix.

## After merge

Once **both** this PR and the statewave-docs companion merge, I'll re-run the failed Release workflow:

```
gh run rerun 26477504347 --repo smaramwbc/statewave
```

## Out of scope

No content or behaviour changes. No new tests needed (this is a string-mirror fix; the audit tooling already enforces the invariant). Strict adherence to v0.9.2 scope — no new features, no API changes.