### PR TITLE
feat(admin): surface sensitivity_labels + suggested_labels on subject-scoped memory listing

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -84,6 +84,13 @@ class MemoryListItem(BaseModel):
     valid_from: str
     valid_to: str | None
     created_at: str
+    # Governance fields (v0.9): exposed on subject-scoped listings so the
+    # admin "open subject → view memories" flow can show labels in one
+    # place — both already-authoritative and detector-suggested.
+    # Empty list is the documented default; the policy evaluator reads
+    # only ``sensitivity_labels`` so surfacing them here is non-destructive.
+    sensitivity_labels: list[str]
+    suggested_labels: list[str]
 
 
 class MemoryListResponse(BaseModel):
@@ -706,6 +713,8 @@ async def list_subject_memories(
                 valid_from=m.valid_from.isoformat(),
                 valid_to=m.valid_to.isoformat() if m.valid_to else None,
                 created_at=m.created_at.isoformat(),
+                sensitivity_labels=list(m.sensitivity_labels or []),
+                suggested_labels=list(m.suggested_labels or []),
             )
             for m in rows
         ]

--- a/tests/integration/test_auto_labeling.py
+++ b/tests/integration/test_auto_labeling.py
@@ -503,3 +503,70 @@ async def test_promote_labels_appends_subsequent_audit_entries(
     assert promotions[0]["promoted_at"] <= promotions[1]["promoted_at"]
     assert set(row.sensitivity_labels) == {"pii.email", "pii.phone"}
     assert row.suggested_labels == []
+
+
+# ---------------------------------------------------------------------------
+# Subject-scoped memory listing — labels exposed alongside the rest of the
+# memory shape so the "open subject -> view memories" admin flow can show
+# both authoritative and suggested labels in one place (v0.9.4 #B / smoke
+# finding: the listing previously omitted both fields, fragmenting the
+# admin governance review path).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_subject_memory_listing_includes_label_fields_after_suggestion(
+    client: AsyncClient, session_factory
+):
+    """A memory carrying suggested_labels must surface both label arrays
+    on GET /admin/subjects/{id}/memories — not only on the dedicated
+    /admin/memories/with-suggested-labels review endpoint."""
+    s = f"labels-list-{uuid.uuid4().hex[:8]}"
+    await _insert_memory_with_suggested(
+        session_factory,
+        subject_id=s,
+        tenant_id=None,
+        suggested=["pii.email", "pii.phone"],
+    )
+
+    resp = await client.get(f"/admin/subjects/{s}/memories")
+    assert resp.status_code == 200
+    items = resp.json()["memories"]
+    assert len(items) == 1
+    item = items[0]
+    # Both fields are present in the response shape (regression guard
+    # against an omission that broke the admin demo path in v0.9.4 smoke).
+    assert "suggested_labels" in item
+    assert "sensitivity_labels" in item
+    assert set(item["suggested_labels"]) == {"pii.email", "pii.phone"}
+    assert item["sensitivity_labels"] == []
+
+
+@pytest.mark.anyio
+async def test_subject_memory_listing_reflects_promoted_labels(
+    client: AsyncClient, session_factory
+):
+    """After promote-labels moves entries from suggested into authoritative,
+    the subject-scoped listing must reflect the new sensitivity_labels and
+    the now-emptied suggested_labels — closing the loop on the review-and-
+    promote flow without the operator having to bounce through two
+    different admin endpoints."""
+    s = f"labels-promote-{uuid.uuid4().hex[:8]}"
+    mid = await _insert_memory_with_suggested(
+        session_factory,
+        subject_id=s,
+        tenant_id=None,
+        suggested=["pii.email"],
+    )
+
+    promote = await client.post(
+        f"/admin/memories/{mid}/promote-labels",
+        json={"labels": ["pii.email"]},
+    )
+    assert promote.status_code == 200
+
+    resp = await client.get(f"/admin/subjects/{s}/memories")
+    assert resp.status_code == 200
+    item = resp.json()["memories"][0]
+    assert item["sensitivity_labels"] == ["pii.email"]
+    assert item["suggested_labels"] == []


### PR DESCRIPTION
## Why

v0.9.4 launch-readiness smoke caught the only real governance UX gap remaining before v1.0:

`GET /admin/subjects/{id}/memories` returns 10 fields per memory but omits both label arrays. Operators reviewing a subject's memories cannot see what is authoritative or what the detectors suggested without bouncing through `/admin/memories/with-suggested-labels` — and that endpoint only shows memories with **un-promoted** suggestions, so once an admin promotes the labels they vanish from view entirely.

This change closes that loop in one place: surface both `sensitivity_labels` and `suggested_labels` directly on the subject-scoped listing.

## Reproducer (against the v0.9.4 smoke server)

```
# Before this PR — labels missing entirely
curl -s :8101/admin/subjects/smoke-pii/memories | jq '.memories[0] | keys'
# ["confidence","content","created_at","id","kind","source_episode_ids","status","summary","valid_from","valid_to"]

# After this PR
curl -s :8101/admin/subjects/smoke-pii/memories | jq '.memories[0] | keys'
# adds: "sensitivity_labels", "suggested_labels"
```

## Properties

- **Purely additive.** Two new fields on `MemoryListItem`. No migration, no breaking change, no behaviour change on any existing field.
- **Cannot affect policy.** The policy evaluator reads only `sensitivity_labels`; surfacing the field on a read-only listing route is non-destructive by construction.
- **Empty list is the documented default** and matches `MemoryRow`'s column default — same shape as `/admin/memories/with-suggested-labels` already uses.
- **No admin UI changes required.** The admin console either already consumes the fields if present (forward-compatible) or will pick them up on its next iteration.

## Tests

Two new integration tests in `tests/integration/test_auto_labeling.py` (the canonical home for the suggested→sensitivity flow):

- `test_subject_memory_listing_includes_label_fields_after_suggestion` — proves both arrays are present and populated with detector hints immediately after compile stamps suggestions.
- `test_subject_memory_listing_reflects_promoted_labels` — proves the listing reflects the move from suggested → authoritative after a `promote-labels` call.

`test_list_subject_memories` in `tests/test_admin_subjects.py` continues to pass (the keys-present assertions are still satisfied; the new fields are additive).

Local run:
```
$ pytest tests/test_admin_subjects.py::test_list_subject_memories \
         tests/integration/test_auto_labeling.py \
         tests/test_admin_dashboard.py -v
============================== 26 passed in 2.12s ==============================
```

## Scope check against the v0.9.4 guardrails

- ✅ Not a new feature — completes the admin governance visibility path that v0.9 already shipped.
- ✅ Keeps it additive.
- ✅ No migration.
- ✅ No new endpoint.
- ✅ No admin UI expansion.
- ✅ Integration test proves listing returns label fields after suggestion AND after promotion.
- ✅ Smoke scenario 6 + 9 will be re-run against the post-merge image and the smoke report updated to reflect post-fix state in one place.