### PR TITLE
docs: fix broken deployment-hardening link in receipts doc (#61)

### DIFF
--- a/docs/state-assembly-receipts.md
+++ b/docs/state-assembly-receipts.md
@@ -98,9 +98,8 @@ audit story) and not as JSONB on the assembly response (lost after the
 request). The table is **append-only by convention**: no service-code
 path issues `UPDATE` or `DELETE`. Operators running compliance-grade
 deployments should additionally grant the service role
-`INSERT`-and-`SELECT`-only on `receipts`; this is documented in
-[`docs/deployment-hardening.md`](./deployment-hardening.md) (separate
-from v1 of this feature).
+`INSERT`-and-`SELECT`-only on `receipts` — a deployment-hardening step
+independent of this feature.
 
 Retention is tenant-controlled via
 `tenant_configs.config.receipt_retention_days`. Absent or `null` means


### PR DESCRIPTION
Part of the v1.0 launch-prep cross-repo link check ([statewave#61](https://github.com/smaramwbc/statewave/issues/61)).

`docs/state-assembly-receipts.md` linked to `./deployment-hardening.md`, which exists **nowhere** in the repo — it was deferred ("separate from v1 of this feature") and never written. The actual hardening guidance (grant the service role `INSERT`-and-`SELECT`-only on `receipts`) is already stated inline, so the link was pure dangle.

**Fix:** dropped the dead link, kept the inline guidance. One sentence, docs-only, no product change.

This is the only **real broken public link** the cross-repo pass found on launch surfaces. Full findings reported in the audit; everything else was a build artifact, an intentional fill-in placeholder, a gitignored `.venv` file, or intentional private cross-repo workspace paths.

Freeze-safe: launch-facing doc-quality fix, no core code, no version bump, no tag.
