### PR TITLE
docs(readme): add Jira + database preview connectors to the install sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Connectors live in their own repository so this core stays focused on the runtim
 ```bash
 # Pick what you need — every package is independent
 npm install @statewavedev/connectors-github
+npm install @statewavedev/connectors-jira          # preview
+npm install @statewavedev/connectors-database      # preview — postgres/mysql/mariadb/mssql
 npm install @statewavedev/connectors-markdown
 npm install @statewavedev/connectors-slack
 npm install @statewavedev/connectors-n8n


### PR DESCRIPTION
Docs-only README update so the core repo's Connectors section reflects the now-published preview connectors (connectors-jira, connectors-database). No code/version/tag changes; does not touch the v1.0 freeze text.