### PR TITLE
feat(api): public GET /v1/version discovery endpoint (#178)

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -243,6 +243,24 @@ def create_app() -> FastAPI:
         """Returns 200 if the process is alive."""
         return {"status": "ok"}
 
+    @app.get("/v1/version", tags=["ops"], summary="Server version discovery")
+    async def version():
+        """Public, unauthenticated version discovery.
+
+        Returns the running server version and the API contract id — useful
+        for smoke tests, support, and Docker users verifying which image is
+        live. No auth, tenant, or rate-limit applies (see the middleware
+        public-path sets).
+        """
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as pkg_version
+
+        try:
+            ver = pkg_version("statewave")
+        except PackageNotFoundError:
+            ver = "unknown"
+        return {"version": ver, "api_contract": "v1"}
+
     @app.get("/readyz", tags=["ops"], summary="Deep readiness check")
     @app.get("/ready", tags=["ops"], summary="Readiness check (alias)", include_in_schema=False)
     async def readyz():

--- a/server/core/auth.py
+++ b/server/core/auth.py
@@ -17,7 +17,7 @@ from starlette.responses import JSONResponse, Response
 logger = structlog.stdlib.get_logger()
 
 # Paths that never require authentication
-_PUBLIC_PATHS = {"/healthz", "/readyz", "/health", "/ready", "/docs", "/redoc", "/openapi.json"}
+_PUBLIC_PATHS = {"/healthz", "/readyz", "/health", "/ready", "/docs", "/redoc", "/openapi.json", "/v1/version"}
 
 
 class APIKeyMiddleware(BaseHTTPMiddleware):

--- a/server/core/ratelimit.py
+++ b/server/core/ratelimit.py
@@ -18,7 +18,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 # Paths exempt from rate limiting
-_EXEMPT_PATHS = {"/healthz", "/readyz", "/health", "/ready"}
+_EXEMPT_PATHS = {"/healthz", "/readyz", "/health", "/ready", "/v1/version"}
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):

--- a/server/core/residency_middleware.py
+++ b/server/core/residency_middleware.py
@@ -42,6 +42,7 @@ _EXEMPT_PATHS = {
     "/docs",
     "/redoc",
     "/openapi.json",
+    "/v1/version",
 }
 
 

--- a/server/core/tenant.py
+++ b/server/core/tenant.py
@@ -18,7 +18,7 @@ from starlette.responses import JSONResponse, Response
 
 logger = structlog.stdlib.get_logger()
 
-_PUBLIC_PATHS = {"/healthz", "/readyz", "/health", "/ready", "/docs", "/redoc", "/openapi.json"}
+_PUBLIC_PATHS = {"/healthz", "/readyz", "/health", "/ready", "/docs", "/redoc", "/openapi.json", "/v1/version"}
 
 
 class TenantMiddleware(BaseHTTPMiddleware):

--- a/tests/test_version_endpoint.py
+++ b/tests/test_version_endpoint.py
@@ -1,0 +1,32 @@
+"""Tests for the public /v1/version discovery endpoint (#178)."""
+
+from httpx import ASGITransport, AsyncClient
+
+from server.app import create_app
+
+
+async def test_version_endpoint_shape(client):
+    resp = await client.get("/v1/version")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body.get("version"), str) and body["version"]
+    assert body["api_contract"] == "v1"
+
+
+async def test_version_endpoint_is_public_when_api_key_set(monkeypatch):
+    """With an API key configured, /v1/version needs no auth header — while a
+    guarded /v1 path still 401s. Confirms the public-path exemption works."""
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "api_key", "secret-key")
+    app = create_app()
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        public = await ac.get("/v1/version")
+    assert public.status_code == 200
+    assert public.json()["api_contract"] == "v1"
+
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        guarded = await ac.get("/v1/subjects")  # no X-API-Key
+    assert guarded.status_code == 401


### PR DESCRIPTION
Closes #178.

Adds a public, unauthenticated **`GET /v1/version`** returning:

```json
{ "version": "1.0.0", "api_contract": "v1" }
```

- `version` resolves from `importlib.metadata.version("statewave")` (fallback `"unknown"`).
- No auth complexity: exempted in the public-path sets of the auth, tenant, rate-limit, and residency middlewares — **additive only** (a path that isn't listed still requires auth, so this can't weaken other routes).
- +2 tests: response shape, and "public even when an API key is configured" (while a guarded `/v1` path still 401s).
- No release/tag/version-bump. Useful for smoke tests, support, and Docker users verifying the live image.

Endpoint self-documents via its OpenAPI summary/description (`/docs`, `/openapi.json`); the `api/v1-contract.md` reference gets a matching line in a small docs PR.
