### PR TITLE
fix(context): strip punctuation in issue-keyword extraction

### DIFF
--- a/server/services/context.py
+++ b/server/services/context.py
@@ -876,11 +876,17 @@ _STOPWORDS = frozenset(
 
 
 def _extract_issue_keywords(text: str) -> set[str]:
-    """Extract meaningful issue keywords from text (lowercase, stopwords removed)."""
+    """Extract meaningful issue keywords (lowercase, punctuation-stripped,
+    stopwords removed).
+
+    Shares `_tokenize_for_relevance`'s punctuation handling so a
+    sentence-final keyword like "outage!" still matches a clean "outage"
+    during repeat-issue overlap detection — without it the trailing
+    punctuation silently zeros the overlap (same failure that helper's
+    docstring documents for the lexical signal)."""
     if not text:
         return set()
-    words = set(text.lower().split())
-    return words - _STOPWORDS
+    return _tokenize_for_relevance(text) - _STOPWORDS
 
 
 def _session_keyword_overlap(current_keywords: set[str], prior_keywords: set[str]) -> float:

--- a/tests/test_repeat_issue.py
+++ b/tests/test_repeat_issue.py
@@ -123,6 +123,25 @@ class TestExtractIssueKeywords:
         assert "ok" not in kw
         assert "no" not in kw
 
+    def test_strips_trailing_punctuation(self):
+        # A sentence-final keyword must not keep its punctuation, or
+        # "outage!" silently fails to match "outage" elsewhere. The sibling
+        # tokenizer _tokenize_for_relevance strips for exactly this reason.
+        kw = _extract_issue_keywords("We have a production outage!")
+        assert "outage" in kw
+        assert "outage!" not in kw
+        # Stripping unmasks punctuation-wrapped stopwords ("(no)" -> "no"),
+        # which must then still be filtered out as stopwords.
+        assert "no" not in _extract_issue_keywords("(no)")
+
+    def test_punctuation_does_not_break_repeat_overlap(self):
+        # The repeat-issue boost depends on a current issue (often phrased
+        # with sentence punctuation) overlapping a prior session's clean
+        # keywords. A trailing "!" must not zero the overlap.
+        current = _extract_issue_keywords("Production outage!")
+        prior = _extract_issue_keywords("we had an outage last week")
+        assert _session_keyword_overlap(current, prior) > 0.0
+
 
 class TestSessionKeywordOverlap:
     def test_identical_sets(self):


### PR DESCRIPTION
## Summary
- `_extract_issue_keywords` tokenized with `text.lower().split()`, leaving punctuation welded to tokens.
- A sentence-final keyword like `outage!` never matched a clean `outage` during repeat-issue overlap detection, silently zeroing the recurring-issue boost whenever the issue was phrased with terminal punctuation.
- Fix reuses the existing punctuation-aware `_tokenize_for_relevance` before removing stopwords; adds focused unit tests.

## Why this is a bug (and the right fix)
`_tokenize_for_relevance` already strips punctuation for exactly this reason — its docstring notes that without stripping, `'npm` won't intersect `npm`, "silently zeroing the lexical signal." The same failure applied to issue-keyword overlap, which feeds the repeat-issue boost in `assemble_context`. Reusing that helper keeps a single tokenization contract instead of two divergent ones.

## Before
```python
_extract_issue_keywords("Production outage!")              # {"production", "outage!"}
_session_keyword_overlap({"production", "outage!"},
                         {"outage", "last", "week"})        # 0.0  -> repeat-issue boost lost
```

## After
```python
_extract_issue_keywords("Production outage!")              # {"production", "outage"}
# overlap -> 0.5  -> repeat-issue boost fires as intended
```

## Impact
- File: `server/services/context.py` (`_extract_issue_keywords`)
- Improves recall of the repeat-issue boost; no API or schema change.
- Breaking changes: none.

## Test plan
- [x] New unit tests fail before / pass after (red -> green)
- [x] `pytest tests/test_*.py` — no new failures
- [x] Full integration suite against Postgres + pgvector — no new failures
- [x] `ruff check` and `ruff format --check` clean

Signed off per DCO.
