### PR TITLE
fix(conflicts): strip punctuation when tokenizing overlap

### DIFF
--- a/server/services/conflicts.py
+++ b/server/services/conflicts.py
@@ -27,6 +27,22 @@ logger = structlog.stdlib.get_logger()
 # Similarity threshold for word-overlap conflict detection (0–1)
 _WORD_OVERLAP_THRESHOLD = 0.6
 
+# Punctuation stripped from token edges before the word-overlap comparison,
+# mirroring server.services.context._tokenize_for_relevance. Without it a
+# trailing "." welds onto a word ("Stripe." != "Stripe"), dragging the Jaccard
+# similarity below threshold and silently skipping a valid supersession — the
+# older duplicate then stays active forever and pollutes future bundles.
+_TOKEN_EDGE_PUNCT = "?.,:;()[]{}'\"!"
+
+
+def _tokenize(content: str) -> set[str]:
+    """Lowercase word tokens with surrounding punctuation stripped."""
+    return {
+        stripped
+        for stripped in (t.strip(_TOKEN_EDGE_PUNCT) for t in content.lower().split())
+        if stripped
+    }
+
 
 async def resolve_conflicts(
     session: AsyncSession,
@@ -85,8 +101,8 @@ def _are_conflicting(older: MemoryRow, newer: MemoryRow) -> bool:
     if older.kind != "profile_fact":
         threshold = 0.8  # stricter for non-facts
 
-    older_tokens = set(older.content.lower().split())
-    newer_tokens = set(newer.content.lower().split())
+    older_tokens = _tokenize(older.content)
+    newer_tokens = _tokenize(newer.content)
 
     if not older_tokens or not newer_tokens:
         return False

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -64,6 +64,42 @@ def test_are_conflicting_stricter_for_non_facts():
     assert _are_conflicting(a, b) is True  # still high overlap
 
 
+def test_are_conflicting_ignores_trailing_punctuation():
+    # Same fact, one with a trailing period. Punctuation must not drag the
+    # word-overlap below threshold and silently prevent supersession.
+    a = _make_memory("I use Stripe.")
+    b = _make_memory("I use Stripe")
+    assert _are_conflicting(a, b) is True
+
+
+def test_are_conflicting_distinct_facts_not_over_merged():
+    # Precision guard: edge-stripping must not merge facts that differ by a
+    # real word. "Stripe" vs "PayPal" share only stopwords, so they stay
+    # below threshold and neither wrongly supersedes the other.
+    a = _make_memory("I use Stripe")
+    b = _make_memory("I use PayPal")
+    assert _are_conflicting(a, b) is False
+
+
+async def test_resolve_conflicts_supersedes_despite_punctuation():
+    # Regression: trailing punctuation on the newer memory must not stop the
+    # older duplicate from being superseded — otherwise it stays active and
+    # pollutes every future context bundle.
+    now = datetime.now(timezone.utc)
+    older = _make_memory("I use Stripe", created_at=now - timedelta(days=5))
+    newer = _make_memory("I use Stripe.", created_at=now)
+
+    with patch("server.services.conflicts.repo") as mock_repo:
+        mock_repo.list_active_memories_by_subject = AsyncMock(return_value=[older, newer])
+        mock_repo.mark_memories_superseded = AsyncMock()
+
+        session = AsyncMock()
+        result = await resolve_conflicts(session, "user-1")
+
+    assert older.id in result
+    mock_repo.mark_memories_superseded.assert_called_once()
+
+
 async def test_resolve_conflicts_marks_older_superseded():
     now = datetime.now(timezone.utc)
     older = _make_memory("my name is Alice", created_at=now - timedelta(days=5))


### PR DESCRIPTION
## Summary
- `_are_conflicting` compared memory contents with `content.lower().split()`, leaving punctuation welded to tokens.
- A trailing `.` (`"Stripe."` vs `"Stripe"`) drops the Jaccard similarity below the supersession threshold, so a genuine duplicate is never superseded — the stale memory stays `active` and keeps polluting future context bundles.
- Fix tokenizes through a small punctuation-stripping helper; adds regression + precision-guard tests.

## Why this is a bug
`resolve_conflicts` runs on every `/v1/memories/compile` and persists supersession. Conflict detection uses word-overlap (Jaccard) over memory content; welded punctuation shrinks the intersection and inflates the union, biasing similarity downward. Near-threshold duplicates that differ only by terminal punctuation are then left un-superseded — a persisted, compounding effect, since the stale memory is ranked into every future bundle.

## Before / After
```python
# profile_fact threshold = 0.6
_are_conflicting("I use Stripe.", "I use Stripe")   # before: 0.5 -> False (no supersession)
                                                    # after:  1.0 -> True
```

## Safety (over-supersession)
The change is **strictly supersession-increasing**: edge-stripping can only collapse punctuation variants of the *same* word (or drop pure-punctuation tokens) — it can never make two *distinct* words match. A precision-guard test asserts distinct facts (`Stripe` vs `PayPal`) stay below threshold and are not over-merged. Limitation: only ASCII edge punctuation is stripped (matching `context._tokenize_for_relevance`); smart quotes / em-dash are not, which can only cause missed supersessions (the safe direction).

## Design note
`_tokenize` mirrors `context._tokenize_for_relevance` and is kept local to avoid coupling the conflicts service to `context.py`. This does duplicate the punctuation set; a natural follow-up is to extract a shared `tokenize()` utility used by both — happy to do that in a separate PR/Discussion if you prefer.

## Impact
- File: `server/services/conflicts.py` (`_are_conflicting`, new `_tokenize`)
- Improves recall of memory supersession; no API or schema change.
- Breaking changes: none.

## Test plan
- [x] Predicate + `resolve_conflicts` regression tests fail before / pass after (red -> green)
- [x] Precision-guard test (distinct facts not over-merged)
- [x] `pytest tests/test_*.py` — no new failures
- [x] Full integration suite against Postgres + pgvector — no new failures
- [x] `ruff check` and `ruff format --check` clean

Signed off per DCO.
