### PR TITLE
fix(config): validate enum-like settings fields at startup

### DIFF
--- a/server/core/config.py
+++ b/server/core/config.py
@@ -34,7 +34,17 @@ class Settings(BaseSettings):
     default_max_context_tokens: int = 4000
 
     # Compiler
-    compiler_type: str = "heuristic"
+    compiler_type: str = "heuristic"  # "heuristic" | "llm"
+
+    @field_validator("compiler_type")
+    @classmethod
+    def _validate_compiler_type(cls, value: str) -> str:
+        allowed = {"heuristic", "llm"}
+        if value not in allowed:
+            raise ValueError(
+                f"STATEWAVE_COMPILER_TYPE must be one of {sorted(allowed)}, got {value!r}"
+            )
+        return value
 
     # Embeddings.
     #
@@ -46,6 +56,16 @@ class Settings(BaseSettings):
     # `none` disables embeddings entirely (no vector column writes).
     embedding_provider: str = "stub"  # "stub" | "litellm" | "none"
     embedding_dimensions: int = 1536
+
+    @field_validator("embedding_provider")
+    @classmethod
+    def _validate_embedding_provider(cls, value: str) -> str:
+        allowed = {"stub", "litellm", "none"}
+        if value not in allowed:
+            raise ValueError(
+                f"STATEWAVE_EMBEDDING_PROVIDER must be one of {sorted(allowed)}, got {value!r}"
+            )
+        return value
 
     # LiteLLM — single provider abstraction. See server/services/llm.py for
     # the provider-neutral env-var contract. LiteLLM dispatches to the
@@ -65,6 +85,16 @@ class Settings(BaseSettings):
     # Rate limiting (0 = disabled)
     rate_limit_rpm: int = 0
     rate_limit_strategy: str = "memory"  # "memory" (default) | "distributed"
+
+    @field_validator("rate_limit_strategy")
+    @classmethod
+    def _validate_rate_limit_strategy(cls, value: str) -> str:
+        allowed = {"memory", "distributed"}
+        if value not in allowed:
+            raise ValueError(
+                f"STATEWAVE_RATE_LIMIT_STRATEGY must be one of {sorted(allowed)}, got {value!r}"
+            )
+        return value
 
     # Subject Snapshots (advanced bootstrap — disabled by default)
     enable_snapshots: bool = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,61 @@
+"""Tests for Settings enum-like field validators (startup config validation)."""
+
+from __future__ import annotations
+
+import pytest
+
+from server.core.config import Settings
+
+
+# ── rate_limit_strategy ─────────────────────────────────────────────────────
+
+
+def test_rate_limit_strategy_accepts_valid_values():
+    for value in ("memory", "distributed"):
+        assert Settings(_env_file=None, rate_limit_strategy=value).rate_limit_strategy == value
+
+
+def test_rate_limit_strategy_default_is_valid():
+    assert Settings(_env_file=None).rate_limit_strategy == "memory"
+
+
+def test_rate_limit_strategy_rejects_typo():
+    # A typo here silently degrades to per-process in-memory limiting
+    # (effective global limit becomes rpm*workers) and skips distributed
+    # cleanup, so it must fail at startup rather than be accepted.
+    with pytest.raises(ValueError, match="STATEWAVE_RATE_LIMIT_STRATEGY must be one of"):
+        Settings(_env_file=None, rate_limit_strategy="distrubuted")
+
+
+# ── compiler_type ───────────────────────────────────────────────────────────
+
+
+def test_compiler_type_accepts_valid_values():
+    for value in ("heuristic", "llm"):
+        assert Settings(_env_file=None, compiler_type=value).compiler_type == value
+
+
+def test_compiler_type_default_is_valid():
+    assert Settings(_env_file=None).compiler_type == "heuristic"
+
+
+def test_compiler_type_rejects_typo():
+    with pytest.raises(ValueError, match="STATEWAVE_COMPILER_TYPE must be one of"):
+        Settings(_env_file=None, compiler_type="heruistic")
+
+
+# ── embedding_provider ──────────────────────────────────────────────────────
+
+
+def test_embedding_provider_accepts_valid_values():
+    for value in ("stub", "litellm", "none"):
+        assert Settings(_env_file=None, embedding_provider=value).embedding_provider == value
+
+
+def test_embedding_provider_default_is_valid():
+    assert Settings(_env_file=None).embedding_provider == "stub"
+
+
+def test_embedding_provider_rejects_typo():
+    with pytest.raises(ValueError, match="STATEWAVE_EMBEDDING_PROVIDER must be one of"):
+        Settings(_env_file=None, embedding_provider="littelm")


### PR DESCRIPTION
## Summary
- Add Pydantic `field_validator`s for the three enum-like `Settings` fields — `rate_limit_strategy`, `compiler_type`, `embedding_provider` — so an invalid value fails fast at startup instead of silently degrading or failing late.
- Mirror the existing `_validate_auto_labeling_provider` / `_validate_region` pattern (after-mode classmethod validator, set-membership check, `ValueError` naming the env var, the sorted allowed set, and the supplied value).
- Add `tests/test_config.py` with 9 tests covering the valid values, the default, and a typo for each field.

## Before
The enum-like `Settings` fields had no validation:
- A typo in `rate_limit_strategy` (anything other than `distributed`) silently routed to the per-process in-memory limiter, weakening the global limit to per-worker (`rpm * workers`) and skipping the distributed `cleanup_expired_windows()` loop.
- A typo in `compiler_type` or `embedding_provider` failed late at first use (the service factories raise only when the bad branch is reached), not at boot.

## After
Invalid values for any of the three fields fail fast at startup with a clear message naming the env var, the allowed set, and the supplied value — consistent with the existing `auto_labeling_provider` / `region` validators. Valid configs are unaffected: the current defaults (`heuristic` / `stub` / `memory`) are all within their allowed sets.

## Impact
- Files: `server/core/config.py`, `tests/test_config.py`
- Breaking changes: no — only values that were already invalid/non-functional (and previously degraded silently or failed late) are now rejected at boot.
- Performance: none (startup-only set-membership checks; no regex/parsing/I/O).

## Test Plan
- [x] `tests/test_config.py` — 9/9 passed (the suite that exercises this change)
- [x] No regression: full `tests/test_*.py` minus the 3 DB-backed files (which require a running Postgres and are unrelated to this change) — 612 passed, 0 failed, 23 skipped
- [x] `ruff check` clean on the changed files
- [x] `ruff format --check` clean on the changed files
- [x] Verified no secret leakage — validators echo only the offending non-secret enum value via `{value!r}`
