### PR TITLE
Fix quickstart: default .env.example to demo mode, LLM opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,23 +3,33 @@
 #
 # Quickstart:
 #   1. cp .env.example .env
-#   2. Set STATEWAVE_LITELLM_API_KEY below (recommended).
-#   3. docker compose up -d
+#   2. docker compose up -d
+#
+# That's it — no API key required. The defaults below run Statewave in
+# demo mode, and every step of getting-started.md works as written.
+# To turn on real LLM extraction + semantic search, see the opt-in
+# LiteLLM block further down.
 #
 # All variables are prefixed STATEWAVE_. Values left commented use the
 # defaults baked into server/core/config.py.
 # ──────────────────────────────────────────────────
 
-# ── Recommended setup: LLM compiler + LiteLLM embeddings ─────
-# Uncomment these three for real semantic search and LLM-driven memory
-# extraction. Without them, Statewave runs in "demo mode" with a regex
-# compiler and hash-based embeddings (no semantic similarity).
+# ── Default: demo mode (no API key required) ─────────────────
+# Heuristic regex compiler + hash-based embeddings. Zero external calls,
+# nothing to configure. Memories are extracted locally; retrieval is
+# keyword/text only (no semantic similarity). Good for first-touch local
+# exploration and for finishing the getting-started.md quickstart.
 
-STATEWAVE_COMPILER_TYPE=llm
-STATEWAVE_EMBEDDING_PROVIDER=litellm
-STATEWAVE_LITELLM_API_KEY=
+STATEWAVE_COMPILER_TYPE=heuristic
+STATEWAVE_EMBEDDING_PROVIDER=stub
 
-# ── LiteLLM (single provider abstraction) ────────────────────
+# ── Opt-in: real LLM compiler + LiteLLM embeddings ───────────
+# For LLM-driven memory extraction and real semantic search, comment out
+# the two demo-mode lines above, then uncomment the block below and set a
+# provider. Note: with the LLM compiler selected but no key reachable,
+# compilation produces zero memories — it does NOT fall back to the regex
+# compiler. Use demo mode above for a keyless setup.
+#
 # LiteLLM dispatches to whichever provider you select via the model
 # identifier. https://docs.litellm.ai/docs/providers
 #
@@ -30,6 +40,8 @@ STATEWAVE_LITELLM_API_KEY=
 #   bedrock/anthropic.claude-3-haiku-...     → AWS Bedrock
 #   cohere/command-r                         → Cohere       (set co-...)
 #
+# STATEWAVE_COMPILER_TYPE=llm
+# STATEWAVE_EMBEDDING_PROVIDER=litellm
 # STATEWAVE_LITELLM_API_KEY=sk-...
 # STATEWAVE_LITELLM_MODEL=gpt-4o-mini
 # STATEWAVE_LITELLM_EMBEDDING_MODEL=text-embedding-3-small
@@ -37,13 +49,6 @@ STATEWAVE_LITELLM_API_KEY=
 # STATEWAVE_LITELLM_TIMEOUT_SECONDS=60
 # STATEWAVE_LITELLM_MAX_RETRIES=2
 # STATEWAVE_LITELLM_TEMPERATURE=0.1
-
-# ── Demo mode (no LLM key required) ──────────────────────────
-# Uncomment these and DELETE the LITELLM_ block above to run without
-# any provider credentials. Useful for first-touch local exploration.
-#
-# STATEWAVE_COMPILER_TYPE=heuristic
-# STATEWAVE_EMBEDDING_PROVIDER=stub
 
 # ── Database ─────────────────────────────────────────────────
 # Docker compose overrides this to point at the `db` service. Set this

--- a/server/services/llm.py
+++ b/server/services/llm.py
@@ -94,10 +94,13 @@ def llm_requires_api_key() -> bool:
 def warn_if_llm_compiler_missing_api_key() -> None:
     """Log a one-shot startup warning when LLM compiler is selected without credentials.
 
-    Operators often copy `.env.example` (compiler=llm, empty key) and assume
-    semantic search is live. Without a key, compilation cannot reach a provider
-    and the default hash embedding stub still produces non-semantic vectors —
-    the same degraded "demo mode" described in getting-started.md.
+    Operators sometimes select the LLM compiler (STATEWAVE_COMPILER_TYPE=llm)
+    with an empty key and assume semantic search is live. It is not: without a
+    reachable key, every compile call fails its provider round-trip and yields
+    zero memories — the LLM compiler does NOT fall back to the regex
+    (heuristic) compiler. Embeddings separately degrade to the non-semantic
+    hash stub. For a keyless setup, use STATEWAVE_COMPILER_TYPE=heuristic
+    (the .env.example default), which extracts memories locally.
     """
     if settings.compiler_type != "llm":
         return
@@ -109,13 +112,15 @@ def warn_if_llm_compiler_missing_api_key() -> None:
     logger.warning(
         "llm_compiler_missing_api_key",
         missing_var="STATEWAVE_LITELLM_API_KEY",
-        fallback=(
-            "demo mode: regex-based extraction and hash-based embeddings "
-            "(no real semantic search)"
+        effect=(
+            "compilation will produce zero memories (LLM calls fail with no "
+            "key — there is no regex fallback); embeddings use the "
+            "non-semantic hash stub"
         ),
         advice=(
             "Set STATEWAVE_LITELLM_API_KEY in .env (or deployment secrets) and "
-            "restart the API process."
+            "restart the API process — or, for a keyless setup, set "
+            "STATEWAVE_COMPILER_TYPE=heuristic to extract memories locally."
         ),
         docs=_GETTING_STARTED_TROUBLESHOOTING_URL,
     )


### PR DESCRIPTION
## Problem

The 5-minute quickstart fails at Step 3 on a fresh `cp .env.example .env && docker compose up -d`. `getting-started.md` promises a no-key demo-mode default, but `.env.example` shipped `STATEWAVE_COMPILER_TYPE=llm` with a blank key. With the LLM compiler selected and no key reachable, compile produces `memories_created: 0` — the LLM compiler does not fall back to the regex compiler. So the very first thing a new user does returns nothing.

## Fix

- `.env.example` now defaults to demo mode (`STATEWAVE_COMPILER_TYPE=heuristic` + `STATEWAVE_EMBEDDING_PROVIDER=stub`); the LLM/LiteLLM block is moved to an explicit opt-in section. A fresh copy now makes the quickstart's "no API key, 5 minutes" promise true.
- `warn_if_llm_compiler_missing_api_key` no longer claims a "demo mode: regex-based extraction" fallback that does not exist. It now states that compilation yields zero memories without a key, and points to `STATEWAVE_COMPILER_TYPE=heuristic` for a keyless setup.

## Notes

- The deeper "failed compile should not consume the episode" behaviour is tracked separately in #201 and fixed in its own PR — kept out of this low-risk onboarding change.
- Companion docs change (inline Ollama `extra_hosts` note) is a separate PR in `statewave-docs`.
- A pre-existing Postgres integration test (`test_admin_subjects.py::test_memory_related_basic`) fails locally without a live DB; it reproduces on clean `main` and is unrelated to this change.
