### PR TITLE
Don't mark episodes compiled when a compile batch errors (#201)

### DIFF
--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -18,7 +18,7 @@ from server.db.engine import get_session
 from server.db.tables import MemoryRow
 from server.schemas.requests import CompileMemoriesRequest, SetMemoryLabelsRequest
 from server.schemas.responses import CompileMemoriesResponse, MemoryResponse, SearchMemoriesResponse
-from server.services.compilers import get_compiler
+from server.services.compilers import CompilationError, get_compiler
 from server.services.embeddings import get_provider as get_embedding_provider
 from server.services.embeddings.backfill import schedule_embedding_backfill
 from server.services.conflicts import resolve_conflicts
@@ -44,6 +44,15 @@ async def _compile_one_batch(
 
     Does its own commit so each batch is durable independently — if the
     process dies mid-drain, no episode is lost or double-counted.
+
+    Raises `CompilationError` (propagated from the compiler) when extraction
+    could not run — e.g. the LLM compiler has no reachable provider key. In
+    that case the episodes are deliberately left UNCOMPILED: we return before
+    `mark_episodes_compiled`/`commit`, so a later, correctly configured
+    recompile reprocesses them instead of the failure silently consuming them
+    (issue #201). An empty `new_rows` from a *successful* run is the opposite
+    case — a legitimate "extracted nothing" — and does mark the episodes
+    compiled.
     """
     episodes = await repo.list_uncompiled_episodes(
         session, subject_id, tenant_id=tenant_id, limit=batch_size
@@ -52,6 +61,8 @@ async def _compile_one_batch(
         return [], 0, 0
 
     compiler = get_compiler()
+    # A CompilationError here propagates intentionally: nothing below this
+    # point runs, so the episodes are never marked compiled or committed.
     if hasattr(compiler, "compile_async"):
         new_rows = await compiler.compile_async(list(episodes))
     else:
@@ -162,6 +173,17 @@ async def _run_compile(
 
         return result
 
+    except CompilationError as exc:
+        # Extraction could not run (e.g. provider misconfig / no key). This is
+        # an expected, recoverable failure mode, not a code bug — log it
+        # without a stacktrace. Episodes from the failed batch were left
+        # uncompiled (issue #201); any batches that already succeeded in this
+        # drain are committed. Mark the job failed so the polling client sees
+        # the reason instead of a clean zero-memory completion.
+        logger.warning("compile_unavailable", subject_id=subject_id, error=str(exc))
+        if job_id:
+            await compile_jobs.mark_failed_durable(job_id, str(exc))
+        raise
     except Exception as exc:
         logger.error("compile_failed", subject_id=subject_id, exc_info=True)
         if job_id:
@@ -205,9 +227,27 @@ async def compile_memories(
         # report `has_more` so the caller knows whether to loop. Bounded
         # latency is the trade-off for not surprising long-standing
         # sync clients with multi-minute compile calls.
-        memory_responses, created, remaining = await _compile_one_batch(
-            session, body.subject_id, tenant_id, settings.compile_batch_size
-        )
+        try:
+            memory_responses, created, remaining = await _compile_one_batch(
+                session, body.subject_id, tenant_id, settings.compile_batch_size
+            )
+        except CompilationError as exc:
+            # Extraction could not run (e.g. LLM compiler with no reachable
+            # key). The episodes were left uncompiled (issue #201); surface
+            # the failure as a 5xx instead of a misleading
+            # `memories_created: 0` so the caller knows to fix the provider
+            # config and retry rather than assuming there was nothing to
+            # compile.
+            logger.warning("compile_unavailable", subject_id=body.subject_id, error=str(exc))
+            return JSONResponse(
+                status_code=502,
+                content={
+                    "error": {
+                        "code": "compilation_failed",
+                        "message": str(exc),
+                    }
+                },
+            )
         return CompileMemoriesResponse(
             subject_id=body.subject_id,
             memories_created=created,

--- a/server/services/compilers/__init__.py
+++ b/server/services/compilers/__init__.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 from typing import Protocol, Sequence
 
 from server.db.tables import EpisodeRow, MemoryRow
+from server.services.compilers.errors import CompilationError
+
+__all__ = ["BaseCompiler", "CompilationError", "get_compiler"]
 
 
 class BaseCompiler(Protocol):
@@ -21,7 +24,13 @@ class BaseCompiler(Protocol):
         - Must be deterministic for the same input.
         - Must set source_episode_ids on every produced memory.
         - Must not mutate the input episodes.
-        - May return an empty list.
+        - May return an empty list when the input legitimately yields no
+          memories. An empty list means "extracted nothing", which lets the
+          caller mark the episodes compiled.
+        - Must raise `CompilationError` when extraction could NOT run (config
+          or provider failure). Never swallow such a failure into an empty
+          list — that would let the caller consume episodes for a run that
+          produced nothing. See `errors.CompilationError`.
         """
         ...
 

--- a/server/services/compilers/errors.py
+++ b/server/services/compilers/errors.py
@@ -1,0 +1,30 @@
+"""Compiler error types.
+
+Kept in their own module so both the compilers and the API layer can import
+them without pulling in a concrete compiler (and the heavy, optional LLM
+dependency that comes with it).
+"""
+
+from __future__ import annotations
+
+
+class CompilationError(Exception):
+    """A compiler could not RUN extraction (config or provider failure).
+
+    This is deliberately distinct from a compiler legitimately returning an
+    empty list — "extracted zero memories" and "could not extract" are
+    different outcomes and must be handled differently.
+
+    Contract for callers (see server/api/memories.py):
+    - When this is raised, the episodes were NOT processed. Callers MUST NOT
+      mark them compiled — they must stay uncompiled so a later, correctly
+      configured recompile can reprocess them. Marking them compiled would
+      silently consume the source episode for a run that produced nothing.
+    - The failure must be surfaced to the client (a 5xx / failed job), not
+      reported as a clean ``memories_created: 0``.
+
+    The canonical trigger is selecting the LLM compiler with no reachable
+    provider credential: every provider round-trip fails, and the old
+    behaviour swallowed that into an empty result that still advanced the
+    episodes' compiled state.
+    """

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -8,10 +8,12 @@ adapter owns provider selection, timeout, retries, and error mapping.
 Optimized for speed:
 - Batches small episodes into a single LLM call
 - Runs multiple batches in parallel with concurrency control
-- Per-batch errors are logged at WARNING and contribute zero memories
-  to the final result. (The previous "Falls back gracefully" wording
-  obscured this — partial failures still log loudly so they can be
-  investigated.)
+- A failed provider round-trip (auth, timeout, 5xx, missing key) is logged
+  at WARNING and re-raised as `CompilationError` — extraction could not RUN,
+  which is distinct from a batch that legitimately extracted nothing. The
+  caller (server/api/memories.py) leaves the affected episodes uncompiled
+  and surfaces the failure rather than consuming the episodes for a run that
+  produced no memories (issue #201).
 
 Requires:
 - STATEWAVE_COMPILER_TYPE=llm
@@ -31,6 +33,7 @@ from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
 from server.services import llm as llm_adapter
 from server.services.auto_labeling import apply_suggestions
+from server.services.compilers.errors import CompilationError
 from server.services.compilers.heuristic import episode_valid_from, extract_payload_text
 from server.services.memory_ttl import compute_valid_to
 
@@ -135,7 +138,13 @@ class LLMCompiler:
         )
 
     async def compile_async(self, episodes: Sequence[EpisodeRow]) -> list[MemoryRow]:
-        """Async compile — batches episodes and processes in parallel."""
+        """Async compile — batches episodes and processes in parallel.
+
+        Returns the extracted memories (possibly empty when the episodes
+        legitimately yield nothing). Raises `CompilationError` if any batch's
+        provider round-trip fails, so the caller does not mistake a provider
+        outage for an empty extraction and consume the episodes (issue #201).
+        """
         # Extract text from each episode, skip empties
         episode_texts: list[tuple[EpisodeRow, str]] = []
         for ep in episodes:
@@ -225,9 +234,18 @@ class LLMCompiler:
 
             try:
                 raw_memories = await self._call_llm_async(combined_text, len(batch))
-            except Exception:
+            except Exception as exc:
+                # A failed provider round-trip (auth, timeout, 5xx, no key)
+                # means extraction could not RUN — it is NOT a legitimate
+                # "zero memories" result. Raise so the caller leaves these
+                # episodes uncompiled and surfaces the failure, instead of
+                # silently consuming them (issue #201). Previously this
+                # returned `[]`, which the compile route could not tell apart
+                # from a real empty extraction.
                 logger.warning("llm_batch_failed", episode_count=len(batch), exc_info=True)
-                return []
+                raise CompilationError(
+                    f"LLM compilation failed for a batch of {len(batch)} episode(s): {exc}"
+                ) from exc
 
             # Map memories back to their source episodes
             results: list[MemoryRow] = []

--- a/tests/test_compile_error_handling.py
+++ b/tests/test_compile_error_handling.py
@@ -1,0 +1,237 @@
+"""Regression tests for issue #201.
+
+A compile batch that fails for a configuration/provider reason (e.g. the LLM
+compiler with no reachable key) used to be indistinguishable from a batch
+that legitimately extracted nothing: `LLMCompiler._process_batch` swallowed
+the error into an empty list, and `_compile_one_batch` marked the episodes
+compiled regardless. The episodes were then permanently consumed — a later,
+correctly configured recompile could not recover them.
+
+The fix:
+  * Provider/config failures raise `CompilationError` instead of returning [].
+  * `_compile_one_batch` returns before `mark_episodes_compiled`/`commit` when
+    that error propagates, so the episodes stay uncompiled and recoverable.
+  * The `/v1/memories/compile` sync route surfaces a 502 (not a misleading
+    `memories_created: 0`); async mode marks the durable job failed.
+  * A legitimate empty extraction still marks the episodes compiled.
+
+These are unit-level tests that exercise the control flow without a real
+database, mirroring tests/test_issue_134_compile_drain.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.services.compilers.errors import CompilationError
+
+
+class _FakeEpisode:
+    def __init__(self) -> None:
+        self.id = uuid.uuid4()
+        self.subject_id = "user-1"
+        self.payload = {"text": "My name is Alice and I work at Globex."}
+        self.created_at = datetime(2026, 5, 29, tzinfo=timezone.utc)
+
+
+class _FakeSession:
+    """Minimal async-session stand-in — records commits, no DB."""
+
+    def __init__(self) -> None:
+        self.added: list = []
+        self.commits = 0
+
+    def add(self, row) -> None:
+        self.added.append(row)
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+    async def refresh(self, row) -> None:  # pragma: no cover - no rows in these tests
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Compiler layer: a provider failure raises rather than returning [].
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_raises_compilation_error():
+    """The canonical no-key case: the provider round-trip fails, so
+    `compile_async` raises `CompilationError` (not an empty list)."""
+    from server.services.compilers.llm import LLMCompiler
+    from server.services import llm as llm_adapter
+
+    compiler = LLMCompiler.__new__(LLMCompiler)
+    compiler._model = "gpt-4o-mini"
+
+    ep = _FakeEpisode()
+
+    with patch.object(
+        compiler,
+        "_call_llm_async",
+        new_callable=AsyncMock,
+        side_effect=llm_adapter.LLMProviderError("401 missing key"),
+    ):
+        with pytest.raises(CompilationError, match="missing key"):
+            await compiler.compile_async([ep])
+
+
+# ---------------------------------------------------------------------------
+# _compile_one_batch: failed batch must NOT mark episodes compiled.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_batch_does_not_consume_episodes(monkeypatch):
+    """When the compiler raises, `mark_episodes_compiled` must never run —
+    the episodes stay uncompiled and recoverable (issue #201)."""
+    from server.api import memories as api_memories
+
+    episodes = [_FakeEpisode()]
+    marked: list = []
+
+    async def fake_list(_session, _subject_id, *, tenant_id, limit):
+        return episodes
+
+    async def fake_mark(_session, ids):
+        marked.append(ids)
+
+    class _RaisingCompiler:
+        async def compile_async(self, _eps):
+            raise CompilationError("LLM compilation failed: no reachable key")
+
+    monkeypatch.setattr(api_memories.repo, "list_uncompiled_episodes", fake_list)
+    monkeypatch.setattr(api_memories.repo, "mark_episodes_compiled", fake_mark)
+    monkeypatch.setattr(api_memories, "get_compiler", lambda: _RaisingCompiler())
+
+    session = _FakeSession()
+    with pytest.raises(CompilationError):
+        await api_memories._compile_one_batch(session, "user-1", None, 10)
+
+    assert marked == [], "failed batch must not mark episodes compiled"
+    assert session.commits == 0, "failed batch must not commit"
+
+
+@pytest.mark.asyncio
+async def test_legitimate_empty_extraction_still_marks_compiled(monkeypatch):
+    """A *successful* run that extracts nothing is the opposite case — the
+    episodes ARE marked compiled so we don't reprocess them forever."""
+    from server.api import memories as api_memories
+
+    episodes = [_FakeEpisode()]
+    marked: list = []
+
+    async def fake_list(_session, _subject_id, *, tenant_id, limit):
+        return episodes
+
+    async def fake_mark(_session, ids):
+        marked.append(ids)
+
+    async def fake_count(_session, _subject_id, *, tenant_id):
+        return 0
+
+    async def fake_resolve(_session, _subject_id):
+        return []
+
+    async def fake_fire(*_a, **_k):
+        return None
+
+    class _EmptyCompiler:
+        async def compile_async(self, _eps):
+            return []  # legitimate "extracted nothing"
+
+    monkeypatch.setattr(api_memories.repo, "list_uncompiled_episodes", fake_list)
+    monkeypatch.setattr(api_memories.repo, "mark_episodes_compiled", fake_mark)
+    monkeypatch.setattr(api_memories.repo, "count_uncompiled_episodes", fake_count)
+    monkeypatch.setattr(api_memories, "get_compiler", lambda: _EmptyCompiler())
+    monkeypatch.setattr(api_memories, "resolve_conflicts", fake_resolve)
+    monkeypatch.setattr(api_memories, "schedule_embedding_backfill", lambda *_a, **_k: None)
+    monkeypatch.setattr(api_memories.webhooks, "fire", fake_fire)
+
+    session = _FakeSession()
+    responses, created, remaining = await api_memories._compile_one_batch(
+        session, "user-1", None, 10
+    )
+
+    assert created == 0
+    assert responses == []
+    assert marked == [[episodes[0].id]], "empty-but-successful run marks episodes compiled"
+    assert session.commits == 1
+
+
+# ---------------------------------------------------------------------------
+# Route layer: sync 502, async job failed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_route_returns_502_on_compilation_error(monkeypatch):
+    """Sync `/v1/memories/compile` surfaces a 502 with a clear error envelope
+    rather than a misleading `memories_created: 0`."""
+    import json
+
+    from server.api import memories as api_memories
+    from server.schemas.requests import CompileMemoriesRequest
+
+    async def raising_batch(*_a, **_k):
+        raise CompilationError("LLM compiler has no reachable key")
+
+    monkeypatch.setattr(api_memories, "_compile_one_batch", raising_batch)
+
+    body = CompileMemoriesRequest(subject_id="user-1")
+    resp = await api_memories.compile_memories(body, session=_FakeSession(), tenant_id=None)
+
+    assert resp.status_code == 502
+    payload = json.loads(bytes(resp.body))
+    assert payload["error"]["code"] == "compilation_failed"
+    assert "no reachable key" in payload["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_async_job_marked_failed_on_compilation_error(monkeypatch):
+    """Async drain marks the durable job failed (with the reason) when a
+    batch raises `CompilationError`, instead of completing as zero-memory."""
+    from server.api import memories as api_memories
+
+    failed: list = []
+
+    async def raising_batch(*_a, **_k):
+        raise CompilationError("LLM compiler has no reachable key")
+
+    async def fake_mark_running(_job_id):
+        pass
+
+    async def fake_mark_failed(job_id, error):
+        failed.append((job_id, error))
+
+    monkeypatch.setattr(api_memories, "_compile_one_batch", raising_batch)
+    monkeypatch.setattr(api_memories.compile_jobs, "mark_running_durable", fake_mark_running)
+    monkeypatch.setattr(api_memories.compile_jobs, "mark_failed_durable", fake_mark_failed)
+
+    import server.db.engine as engine_module
+
+    class _FakeFactory:
+        def __call__(self_inner):
+            class _Ctx:
+                async def __aenter__(self_):
+                    return _FakeSession()
+
+                async def __aexit__(self_, *a):
+                    return None
+
+            return _Ctx()
+
+    monkeypatch.setattr(engine_module, "get_session_factory", lambda: _FakeFactory())
+
+    with pytest.raises(CompilationError):
+        await api_memories._run_compile("user-1", job_id="job-1", tenant_id=None)
+
+    assert len(failed) == 1
+    assert failed[0][0] == "job-1"
+    assert "no reachable key" in failed[0][1]

--- a/tests/test_llm_compiler.py
+++ b/tests/test_llm_compiler.py
@@ -90,15 +90,25 @@ async def test_llm_compile_empty_payload():
 
 
 @pytest.mark.asyncio
-async def test_llm_compile_api_failure_returns_empty():
+async def test_llm_compile_api_failure_raises_compilation_error():
+    """A failed provider round-trip must raise `CompilationError`, NOT return
+    an empty list.
+
+    Returning `[]` was indistinguishable from a legitimate "extracted
+    nothing" result, so the compile route marked the episodes compiled and
+    silently consumed them (issue #201). The error now propagates so the
+    caller leaves the episodes uncompiled and surfaces the failure.
+    """
+    from server.services.compilers.errors import CompilationError
+
     compiler = _make_compiler()
 
     with patch.object(
         compiler, "_call_llm_async", new_callable=AsyncMock, side_effect=RuntimeError("API down")
     ):
         ep = _make_episode()
-        memories = await compiler.compile_async([ep])
-        assert memories == []
+        with pytest.raises(CompilationError, match="API down"):
+            await compiler.compile_async([ep])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #201.

## Problem

A compile batch that failed for a config/provider reason (e.g. the LLM compiler with no reachable key) was indistinguishable from a batch that legitimately extracted nothing: `LLMCompiler._process_batch` swallowed the provider error into an empty list, and `_compile_one_batch` marked the episodes compiled regardless. The episodes were then permanently consumed — adding a key and recompiling could not recover them. This is a memory-lifecycle correctness bug: a failed extraction must not destroy the source episode.

## Fix

Distinguish "could not run extraction" from "extracted nothing":

- Add `CompilationError` (`server/services/compilers/errors.py`). The compiler protocol now contracts: return `[]` for a legitimate empty result, raise `CompilationError` when extraction could not run.
- `LLMCompiler._process_batch` re-raises provider failures as `CompilationError` instead of returning `[]`.
- `_compile_one_batch` lets it propagate **before** `mark_episodes_compiled`/`commit`, so failed-batch episodes stay uncompiled and recoverable. A successful empty extraction still marks episodes compiled, as before.
- Sync `/v1/memories/compile` returns `502 compilation_failed` instead of a misleading `memories_created: 0`; async mode marks the durable job failed with the reason.

## Tests

New regression suite `tests/test_compile_error_handling.py`, including **"missing LLM key does not consume the episode"** (`test_failed_batch_does_not_consume_episodes`) and its counterpart that a legitimate empty extraction still marks episodes compiled. Updated the existing `test_llm_compiler` test that asserted the old return-empty behaviour.

## Notes

- One stable error path: `502 compilation_failed` for all provider/compiler failures (no 502/503 split).
- Partial-batch semantics in async drain: batches that already succeeded stay committed; only the failing batch's episodes are preserved. Safe — no data loss.
- A pre-existing Postgres integration test (`test_admin_subjects.py::test_memory_related_basic`) fails locally without a live DB; it reproduces on clean `main` and is unrelated to this change.
