### PR TITLE
fix: don't expose raw exception text in compile/LLM error responses

### DIFF
--- a/server/api/llm.py
+++ b/server/api/llm.py
@@ -58,9 +58,11 @@ async def complete_chat(body: LLMCompleteRequest) -> LLMCompleteResponse:
             temperature=body.temperature,
         )
     except LLMTimeoutError as exc:
+        # Same reason as the provider-error handler below — don't echo the raw
+        # exception text, which can carry the configured endpoint/model detail.
         raise HTTPException(
             status_code=504,
-            detail={"code": "upstream_llm_timeout", "message": str(exc)},
+            detail={"code": "upstream_llm_timeout", "message": "Upstream LLM call timed out."},
         ) from exc
     except (LLMProviderError, LLMResponseError, StatewaveLLMError) as exc:
         # Don't echo the raw provider message back — it can include URLs,

--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -31,6 +31,21 @@ logger = structlog.stdlib.get_logger()
 
 router = APIRouter(prefix="/v1/memories", tags=["memories"])
 
+# Client-facing error text for compile failures. Deliberately static and
+# free of any exception detail: the underlying exception can carry provider
+# internals (URLs, config, partial keys, stack traces) that must not reach an
+# external caller (CWE-209). The full `str(exc)` is logged server-side at every
+# raise site; the client only needs the actionable next step. `CompilationError`
+# is an expected, recoverable misconfiguration, so its message points the caller
+# at the fix; the catch-all path stays vague because the cause is unknown.
+_COMPILE_FAILED_MESSAGE = (
+    "Memory compilation could not run because the configured compiler or "
+    "provider is unavailable or misconfigured. The affected episodes were left "
+    "uncompiled — fix the provider configuration and retry. See server logs for "
+    "the underlying error."
+)
+_COMPILE_INTERNAL_ERROR_MESSAGE = "An internal error occurred during compilation."
+
 
 async def _compile_one_batch(
     session: AsyncSession, subject_id: str, tenant_id: str | None, batch_size: int
@@ -182,12 +197,15 @@ async def _run_compile(
         # the reason instead of a clean zero-memory completion.
         logger.warning("compile_unavailable", subject_id=subject_id, error=str(exc))
         if job_id:
-            await compile_jobs.mark_failed_durable(job_id, str(exc))
+            # `job.error` is returned to the polling client by
+            # `get_compile_status`, so store the static message — never the raw
+            # exception (CWE-209). The detail is in the log line above.
+            await compile_jobs.mark_failed_durable(job_id, _COMPILE_FAILED_MESSAGE)
         raise
-    except Exception as exc:
+    except Exception:
         logger.error("compile_failed", subject_id=subject_id, exc_info=True)
         if job_id:
-            await compile_jobs.mark_failed_durable(job_id, str(exc))
+            await compile_jobs.mark_failed_durable(job_id, _COMPILE_INTERNAL_ERROR_MESSAGE)
         raise
 
 
@@ -244,7 +262,7 @@ async def compile_memories(
                 content={
                     "error": {
                         "code": "compilation_failed",
-                        "message": str(exc),
+                        "message": _COMPILE_FAILED_MESSAGE,
                     }
                 },
             )

--- a/tests/test_api_llm.py
+++ b/tests/test_api_llm.py
@@ -113,7 +113,7 @@ async def test_complete_chat_timeout_returns_504(monkeypatch):
     with patch(
         "server.api.llm.acomplete",
         new_callable=AsyncMock,
-        side_effect=LLMTimeoutError("timed out after 60s"),
+        side_effect=LLMTimeoutError("timed out talking to https://internal-config after 60s"),
     ):
         async with await _client_with() as c:
             r = await c.post(
@@ -122,6 +122,8 @@ async def test_complete_chat_timeout_returns_504(monkeypatch):
             )
     assert r.status_code == 504
     assert r.json()["error"]["code"] == "upstream_llm_timeout"
+    # Don't echo upstream details (endpoint URLs, internal model identifiers).
+    assert "internal-config" not in r.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_compile_error_handling.py
+++ b/tests/test_compile_error_handling.py
@@ -173,14 +173,19 @@ async def test_legitimate_empty_extraction_still_marks_compiled(monkeypatch):
 @pytest.mark.asyncio
 async def test_sync_route_returns_502_on_compilation_error(monkeypatch):
     """Sync `/v1/memories/compile` surfaces a 502 with a clear error envelope
-    rather than a misleading `memories_created: 0`."""
+    rather than a misleading `memories_created: 0`.
+
+    The envelope carries a static, actionable message — NOT the raw exception
+    text, which can leak provider internals to an external caller (CWE-209,
+    CodeQL py/stack-trace-exposure). The detail goes to the server log only."""
     import json
 
     from server.api import memories as api_memories
     from server.schemas.requests import CompileMemoriesRequest
 
+    # A message that would expose internals if echoed verbatim.
     async def raising_batch(*_a, **_k):
-        raise CompilationError("LLM compiler has no reachable key")
+        raise CompilationError("connect to http://10.0.0.5:11434 failed: secret-key-abc123")
 
     monkeypatch.setattr(api_memories, "_compile_one_batch", raising_batch)
 
@@ -190,7 +195,10 @@ async def test_sync_route_returns_502_on_compilation_error(monkeypatch):
     assert resp.status_code == 502
     payload = json.loads(bytes(resp.body))
     assert payload["error"]["code"] == "compilation_failed"
-    assert "no reachable key" in payload["error"]["message"]
+    assert payload["error"]["message"] == api_memories._COMPILE_FAILED_MESSAGE
+    # The exception detail must not reach the client.
+    assert "secret-key-abc123" not in payload["error"]["message"]
+    assert "10.0.0.5" not in payload["error"]["message"]
 
 
 @pytest.mark.asyncio
@@ -202,7 +210,7 @@ async def test_async_job_marked_failed_on_compilation_error(monkeypatch):
     failed: list = []
 
     async def raising_batch(*_a, **_k):
-        raise CompilationError("LLM compiler has no reachable key")
+        raise CompilationError("connect to http://10.0.0.5:11434 failed: secret-key-abc123")
 
     async def fake_mark_running(_job_id):
         pass
@@ -234,4 +242,7 @@ async def test_async_job_marked_failed_on_compilation_error(monkeypatch):
 
     assert len(failed) == 1
     assert failed[0][0] == "job-1"
-    assert "no reachable key" in failed[0][1]
+    # `job.error` is returned to polling clients, so it carries the static
+    # message — never the raw exception text (CWE-209).
+    assert failed[0][1] == api_memories._COMPILE_FAILED_MESSAGE
+    assert "secret-key-abc123" not in failed[0][1]


### PR DESCRIPTION
## What

Fixes CodeQL alert [#2](https://github.com/smaramwbc/statewave/security/code-scanning/2) — `py/stack-trace-exposure` (CWE-209, medium).

The sync compile route returned `str(exc)` to the caller, and the wrapped `CompilationError` embeds the raw provider exception (`f"...: {exc}"` in `compilers/llm.py`), so endpoint URLs, model identifiers, or partial keys could reach an external client.

## Fix

Log the detail server-side, return a static message — CodeQL's recommended pattern (the full `str(exc)` was already logged at every raise site):

- **compile sync route** (the flagged sink): static `compilation_failed` message
- **compile async path**: `job.error` is echoed to pollers by `get_compile_status` — the same leak, unflagged because the DB round-trip breaks taint tracking. Both `mark_failed_durable` calls now store static messages (actionable on the `CompilationError` path, vague on the catch-all since the cause is unknown)
- **`/v1/llm/complete` timeout handler**: stopped echoing `str(exc)`, matching the adjacent provider-error handler that already sanitizes

## Tests

Updated the three assertions that pinned the leaky behavior into regression tests: each feeds an exception containing a fake secret/URL and asserts it does **not** appear in the response. The issue #201 contract (502 / failed job rather than a misleading `memories_created: 0`) is preserved. `tests/test_compile_error_handling.py` + `tests/test_api_llm.py` → 13 passed.
