### PR TITLE
fix(handoff): scope active session and order recent context

### DIFF
--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -81,6 +81,31 @@ async def list_episodes_by_subject(
     return result.scalars().all()
 
 
+async def list_episodes_by_session(
+    session: AsyncSession,
+    subject_id: str,
+    session_id: str,
+    *,
+    tenant_id: str | None = None,
+    limit: int = 100,
+) -> Sequence[EpisodeRow]:
+    # Scoped to a single session so callers (e.g. handoff) always see the
+    # active session's episodes regardless of how many lifetime episodes the
+    # subject has. Same chronological ordering contract as
+    # `list_episodes_by_subject`: `occurred_at` first so backfilled events
+    # land in their real position, `created_at` as the ingest-order tiebreak.
+    stmt = (
+        select(EpisodeRow)
+        .where(EpisodeRow.subject_id == subject_id)
+        .where(EpisodeRow.session_id == session_id)
+        .order_by(EpisodeRow.occurred_at.asc(), EpisodeRow.created_at.asc())
+        .limit(limit)
+    )
+    stmt = _tenant_filter(stmt, EpisodeRow.tenant_id, tenant_id)
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
 async def list_uncompiled_episodes(
     session: AsyncSession,
     subject_id: str,

--- a/server/services/handoff.py
+++ b/server/services/handoff.py
@@ -56,6 +56,9 @@ async def assemble_handoff(
     episode_rows = await repo.list_episodes_by_subject(
         session, subject_id, tenant_id=tenant_id, limit=30
     )
+    session_episode_rows = await repo.list_episodes_by_session(
+        session, subject_id, session_id, tenant_id=tenant_id, limit=30
+    )
     resolution_rows = await repo.list_resolutions(
         session, subject_id, tenant_id=tenant_id, limit=20
     )
@@ -90,9 +93,12 @@ async def assemble_handoff(
     key_facts = [row.content for row in fact_rows if row.status == "active"]
 
     # -- Active issue (current session episodes) ----------------------------
-    current_session_eps = [
-        row for row in episode_rows if getattr(row, "session_id", None) == session_id
-    ]
+    # Sourced from a session-scoped query, not the subject-wide list: for
+    # subjects with >30 lifetime episodes the active session falls outside
+    # the subject window, which would silently empty the active issue and
+    # attempted steps. `episode_rows` is still used for cross-session
+    # "recent context" below.
+    current_session_eps = list(session_episode_rows)
     other_eps = [row for row in episode_rows if getattr(row, "session_id", None) != session_id]
 
     # Build active issue description from current session
@@ -138,8 +144,13 @@ async def assemble_handoff(
         )
 
     # -- Recent context (non-current session, most recent first) ------------
+    # `other_eps` is occurred_at ASC (oldest first); take the newest 5 and
+    # reverse so the most-recent cross-session episode leads, matching the
+    # heading. Computed once and reused for provenance + the receipt's
+    # carry-forward set so all three agree on which episodes are surfaced.
+    recent_eps = list(reversed(other_eps[-5:]))
     recent_context: list[str] = []
-    for ep in other_eps[:5]:
+    for ep in recent_eps:
         text = extract_payload_text(ep.payload)
         if text:
             sid_label = f" [{ep.session_id}]" if getattr(ep, "session_id", None) else ""
@@ -250,7 +261,7 @@ async def assemble_handoff(
         "fact_ids": [str(row.id) for row in fact_rows if row.status == "active"],
         "episode_ids": [str(ep.id) for ep in current_session_eps[:10]],
         "resolution_ids": [str(r.id) for r in resolution_rows],
-        "context_episode_ids": [str(ep.id) for ep in other_eps[:5]],
+        "context_episode_ids": [str(ep.id) for ep in recent_eps],
     }
 
     # -- Receipt emission ---------------------------------------------------
@@ -270,7 +281,7 @@ async def assemble_handoff(
         token_estimate=token_estimate,
         active_fact_rows=[row for row in fact_rows if row.status == "active"],
         session_episode_rows=current_session_eps[:10],
-        carry_forward_episode_rows=other_eps[:5],
+        carry_forward_episode_rows=recent_eps,
         emit_receipt=emit_receipt,
         query_id=query_id,
         task_id=task_id,

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -77,11 +77,21 @@ def _make_resolution_row(
 
 
 @contextmanager
-def _mock_repos(*, episodes=None, facts=None, resolutions=None, health=None, sla=None):
+def _mock_repos(
+    *, episodes=None, session_episodes=None, facts=None, resolutions=None, health=None, sla=None
+):
     if health is None:
         health = HealthResult(subject_id="user-1", score=100, state="healthy", factors=[])
     if sla is None:
         sla = SLASummary(subject_id="user-1")
+    # By default the session-scoped fetch returns the "sess-1" subset of the
+    # subject-wide list, so existing tests (which all hand off "sess-1") keep
+    # exercising the same episodes. Tests that need the active session to live
+    # outside the subject window pass `session_episodes` explicitly.
+    if session_episodes is None:
+        session_episodes = [
+            ep for ep in (episodes or []) if getattr(ep, "session_id", None) == "sess-1"
+        ]
     with (
         patch(
             "server.services.handoff.repo.search_memories",
@@ -92,6 +102,11 @@ def _mock_repos(*, episodes=None, facts=None, resolutions=None, health=None, sla
             "server.services.handoff.repo.list_episodes_by_subject",
             new_callable=AsyncMock,
             return_value=episodes or [],
+        ),
+        patch(
+            "server.services.handoff.repo.list_episodes_by_session",
+            new_callable=AsyncMock,
+            return_value=session_episodes,
         ),
         patch(
             "server.services.handoff.repo.list_resolutions",
@@ -231,6 +246,60 @@ async def test_recent_context_from_other_sessions():
         result = await assemble_handoff(AsyncMock(), "user-1", "sess-1")
 
     assert any("Previous conversation" in c for c in result.recent_context)
+
+
+@pytest.mark.asyncio
+async def test_active_session_episodes_present_outside_subject_window():
+    """Active session episodes must surface even when the subject-wide window
+    (occurred_at ASC, capped at 30) contains only older, other-session
+    episodes — the active session would otherwise fall outside it."""
+    # Subject-wide window: 30 episodes, all from a different, older session.
+    subject_window = [
+        _make_episode_row(session_id="sess-old", text=f"old message {i}", minutes_ago=1000 - i)
+        for i in range(30)
+    ]
+    # The active session's episodes live outside that window.
+    active_eps = [
+        _make_episode_row(session_id="sess-1", source="user", text="My billing is wrong"),
+        _make_episode_row(
+            session_id="sess-1", source="assistant", text="I checked your account status"
+        ),
+    ]
+
+    with _mock_repos(episodes=subject_window, session_episodes=active_eps):
+        result = await assemble_handoff(AsyncMock(), "user-1", "sess-1")
+
+    assert "billing" in result.active_issue.lower()
+    assert any("checked your account" in s for s in result.attempted_steps)
+    assert len(result.provenance["episode_ids"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_recent_context_shows_newest_other_sessions():
+    """Recent context should surface the newest cross-session episodes, not the
+    oldest, lead with the most recent, and stay consistent with provenance."""
+    current_ep = _make_episode_row(session_id="sess-1", text="Current issue")
+    # Other-session episodes in occurred_at ASC order (oldest first), as the
+    # subject-wide query returns them.
+    other_eps = [
+        _make_episode_row(session_id=f"sess-{i}", text=f"other message {i}") for i in range(7)
+    ]
+    episodes = other_eps + [current_ep]
+
+    with _mock_repos(episodes=episodes):
+        result = await assemble_handoff(AsyncMock(), "user-1", "sess-1")
+
+    joined = "\n".join(result.recent_context)
+    # Newest (index 6) is present; oldest (index 0/1) are dropped.
+    assert "other message 6" in joined
+    assert "other message 0" not in joined
+    assert "other message 1" not in joined
+    # Most-recent leads the section.
+    assert "other message 6" in result.recent_context[0]
+    assert len(result.recent_context) == 5
+    # Provenance attests the SAME newest-5 episodes (reversed) the brief shows.
+    expected_ids = [str(ep.id) for ep in reversed(other_eps[-5:])]
+    assert result.provenance["context_episode_ids"] == expected_ids
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add a session-scoped episode query for handoff assembly.
- Use that query for active-session issue and attempted-step extraction.
- Render recent cross-session context newest-first and reuse the same selected episodes for provenance and receipt carry-forward data.

## Root Cause

`assemble_handoff` built the active-session section by filtering the subject-wide episode window. That window is capped and ordered chronologically, so subjects with more than 30 lifetime episodes could exclude the active session entirely. The result was an empty active issue and missing attempted steps even when the current session had relevant episodes.

The recent-context section also iterated the oldest cross-session episodes while its heading described most-recent context.

## Impact

Handoff packs now consistently include current-session context regardless of long subject history. The rendered brief, provenance, and receipt-selected carry-forward episodes also agree on which recent cross-session episodes were surfaced.

## Validation

- `STATEWAVE_EMBEDDING_PROVIDER=stub STATEWAVE_COMPILER_TYPE=heuristic .\.venv\Scripts\python.exe -m pytest tests/test_handoff.py`
- `.\.venv\Scripts\python.exe -m ruff check server/db/repositories.py server/services/handoff.py tests/test_handoff.py`

## Notes

The test run passes on Windows with existing warnings from mocked policy resolution and pytest cache write permissions; no new warning category was introduced by this change.