### PR TITLE
fix(conflicts): scope resolution by tenant

### DIFF
--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -91,7 +91,7 @@ async def _compile_one_batch(
         session.add(row)
     await repo.mark_episodes_compiled(session, [ep.id for ep in episodes])
 
-    superseded_ids = await resolve_conflicts(session, subject_id)
+    superseded_ids = await resolve_conflicts(session, subject_id, tenant_id=tenant_id)
     if superseded_ids:
         logger.info("conflicts_resolved", superseded=len(superseded_ids))
 

--- a/server/services/conflicts.py
+++ b/server/services/conflicts.py
@@ -47,9 +47,13 @@ def _tokenize(content: str) -> set[str]:
 async def resolve_conflicts(
     session: AsyncSession,
     subject_id: str,
+    *,
+    tenant_id: str | None = None,
 ) -> list[uuid.UUID]:
     """Detect and resolve conflicting memories. Returns IDs of superseded memories."""
-    memories = await repo.list_active_memories_by_subject(session, subject_id)
+    memories = await repo.list_active_memories_by_subject(
+        session, subject_id, tenant_id=tenant_id
+    )
     if len(memories) < 2:
         return []
 

--- a/tests/test_compile_error_handling.py
+++ b/tests/test_compile_error_handling.py
@@ -126,6 +126,7 @@ async def test_legitimate_empty_extraction_still_marks_compiled(monkeypatch):
 
     episodes = [_FakeEpisode()]
     marked: list = []
+    resolved: list[tuple[str, str | None]] = []
 
     async def fake_list(_session, _subject_id, *, tenant_id, limit):
         return episodes
@@ -136,7 +137,8 @@ async def test_legitimate_empty_extraction_still_marks_compiled(monkeypatch):
     async def fake_count(_session, _subject_id, *, tenant_id):
         return 0
 
-    async def fake_resolve(_session, _subject_id):
+    async def fake_resolve(_session, _subject_id, *, tenant_id):
+        resolved.append((_subject_id, tenant_id))
         return []
 
     async def fake_fire(*_a, **_k):
@@ -156,12 +158,13 @@ async def test_legitimate_empty_extraction_still_marks_compiled(monkeypatch):
 
     session = _FakeSession()
     responses, created, remaining = await api_memories._compile_one_batch(
-        session, "user-1", None, 10
+        session, "user-1", "tenant-a", 10
     )
 
     assert created == 0
     assert responses == []
     assert marked == [[episodes[0].id]], "empty-but-successful run marks episodes compiled"
+    assert resolved == [("user-1", "tenant-a")]
     assert session.commits == 1
 
 

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -100,6 +100,21 @@ async def test_resolve_conflicts_supersedes_despite_punctuation():
     mock_repo.mark_memories_superseded.assert_called_once()
 
 
+async def test_resolve_conflicts_scopes_memory_lookup_by_tenant():
+    with patch("server.services.conflicts.repo") as mock_repo:
+        mock_repo.list_active_memories_by_subject = AsyncMock(return_value=[])
+        mock_repo.mark_memories_superseded = AsyncMock()
+
+        session = AsyncMock()
+        result = await resolve_conflicts(session, "user-1", tenant_id="tenant-a")
+
+    assert result == []
+    mock_repo.list_active_memories_by_subject.assert_awaited_once_with(
+        session, "user-1", tenant_id="tenant-a"
+    )
+    mock_repo.mark_memories_superseded.assert_not_called()
+
+
 async def test_resolve_conflicts_marks_older_superseded():
     now = datetime.now(timezone.utc)
     older = _make_memory("my name is Alice", created_at=now - timedelta(days=5))


### PR DESCRIPTION
## Summary

- Thread `tenant_id` through memory conflict resolution.
- Ensure compile batches resolve conflicts only within the active tenant scope.
- Add regression coverage for tenant-scoped lookup and compile-path propagation.

## Root Cause

New compiled memories are assigned the request tenant before conflict resolution runs, and the repository already supports filtering active memories by tenant. The conflict resolver did not accept or pass that tenant value, so compilation for one tenant could compare against active memories from another tenant that used the same `subject_id`.

## Impact

Conflict supersession now respects tenant isolation. Tenants that reuse the same subject identifier no longer risk cross-tenant memory supersession during compile.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests/test_conflicts.py tests/test_compile_error_handling.py -q`
- `.\.venv\Scripts\python.exe -m ruff check server/services/conflicts.py server/api/memories.py tests/test_conflicts.py tests/test_compile_error_handling.py`

## Notes

The test run passes on Windows with the existing pytest cache write warning in this workspace; no new warning category was introduced by this change.