### PR TITLE
fix(compile-jobs): scope status polling by tenant

### DIFF
--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -276,9 +276,12 @@ async def compile_memories(
 
 
 @router.get("/compile/{job_id}", summary="Check compile job status")
-async def get_compile_status(job_id: str):
+async def get_compile_status(
+    job_id: str,
+    tenant_id: str | None = Depends(get_tenant_id),
+):
     """Poll for the status of an async compile job (durable — survives restarts)."""
-    job = await compile_jobs.get_job_durable(job_id)
+    job = await compile_jobs.get_job_durable(job_id, tenant_id=tenant_id)
     if not job:
         return JSONResponse(status_code=404, content={"error": "Job not found or expired"})
 

--- a/server/services/compile_jobs.py
+++ b/server/services/compile_jobs.py
@@ -44,6 +44,7 @@ class JobStatus(str, Enum):
 class CompileJob:
     id: str
     subject_id: str
+    tenant_id: str | None = None
     status: JobStatus = JobStatus.pending
     memories_created: int = 0
     memories: list[dict[str, Any]] = field(default_factory=list)
@@ -83,7 +84,7 @@ async def submit_job_durable(subject_id: str, tenant_id: str | None = None) -> C
     return job
 
 
-async def get_job_durable(job_id: str) -> CompileJob | None:
+async def get_job_durable(job_id: str, tenant_id: str | None = None) -> CompileJob | None:
     """Get a job by id. Process-local cache first, then Postgres.
 
     Cache hits skip the DB round-trip; cache misses fall through to
@@ -91,10 +92,13 @@ async def get_job_durable(job_id: str) -> CompileJob | None:
     as "job not found".
     """
     if job_id in _jobs:
-        return _jobs[job_id]
+        job = _jobs[job_id]
+        if job.tenant_id == tenant_id:
+            return job
+        return None
     from server.services.compile_jobs_durable import get_job as _durable_get
 
-    return await _durable_get(job_id)
+    return await _durable_get(job_id, tenant_id=tenant_id)
 
 
 async def mark_running_durable(job_id: str) -> None:
@@ -152,10 +156,10 @@ async def update_progress_durable(job_id: str, memories_created: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-def submit_job(subject_id: str) -> CompileJob:
+def submit_job(subject_id: str, tenant_id: str | None = None) -> CompileJob:
     """Create a new compile job and return it. Caller must start the task."""
     job_id = str(uuid.uuid4())[:8]
-    job = CompileJob(id=job_id, subject_id=subject_id)
+    job = CompileJob(id=job_id, subject_id=subject_id, tenant_id=tenant_id)
     _jobs[job_id] = job
     _cleanup_old_jobs()
     return job

--- a/server/services/compile_jobs_durable.py
+++ b/server/services/compile_jobs_durable.py
@@ -45,6 +45,7 @@ class JobStatus(str, Enum):
 class CompileJob:
     id: str
     subject_id: str
+    tenant_id: str | None = None
     status: JobStatus = JobStatus.pending
     memories_created: int = 0
     memories: list[dict[str, Any]] = field(default_factory=list)
@@ -57,6 +58,7 @@ def _row_to_job(row: CompileJobRow) -> CompileJob:
     return CompileJob(
         id=row.id,
         subject_id=row.subject_id,
+        tenant_id=row.tenant_id,
         status=JobStatus(row.status),
         memories_created=row.memories_created,
         memories=[],  # Not stored in DB to keep table lean
@@ -86,17 +88,27 @@ async def submit_job(subject_id: str, tenant_id: str | None = None) -> CompileJo
         )
         session.add(row)
         await session.commit()
-    return CompileJob(id=job_id, subject_id=subject_id, created_at=now.timestamp())
+    return CompileJob(
+        id=job_id,
+        subject_id=subject_id,
+        tenant_id=tenant_id,
+        created_at=now.timestamp(),
+    )
 
 
-async def get_job(job_id: str) -> CompileJob | None:
+async def get_job(job_id: str, tenant_id: str | None = None) -> CompileJob | None:
     """Retrieve a job by ID from Postgres.
 
     Returns None only when the job genuinely does not exist. DB errors
     propagate so a transient outage doesn't masquerade as "not found".
     """
     async with get_session_factory()() as session:
-        result = await session.execute(select(CompileJobRow).where(CompileJobRow.id == job_id))
+        stmt = select(CompileJobRow).where(CompileJobRow.id == job_id)
+        if tenant_id is None:
+            stmt = stmt.where(CompileJobRow.tenant_id.is_(None))
+        else:
+            stmt = stmt.where(CompileJobRow.tenant_id == tenant_id)
+        result = await session.execute(stmt)
         row = result.scalar_one_or_none()
         if row is None:
             return None

--- a/tests/test_compile_error_handling.py
+++ b/tests/test_compile_error_handling.py
@@ -171,6 +171,25 @@ async def test_legitimate_empty_extraction_still_marks_compiled(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_compile_status_scopes_job_lookup_by_tenant(monkeypatch):
+    """Polling an async compile job should only look up jobs in the caller tenant."""
+    from server.api import memories as api_memories
+
+    looked_up: list[tuple[str, str | None]] = []
+
+    async def fake_get_job(job_id: str, *, tenant_id: str | None):
+        looked_up.append((job_id, tenant_id))
+        return None
+
+    monkeypatch.setattr(api_memories.compile_jobs, "get_job_durable", fake_get_job)
+
+    response = await api_memories.get_compile_status("job-1", tenant_id="tenant-a")
+
+    assert response.status_code == 404
+    assert looked_up == [("job-1", "tenant-a")]
+
+
+@pytest.mark.asyncio
 async def test_sync_route_returns_502_on_compilation_error(monkeypatch):
     """Sync `/v1/memories/compile` surfaces a 502 with a clear error envelope
     rather than a misleading `memories_created: 0`.

--- a/tests/test_compile_jobs_durable.py
+++ b/tests/test_compile_jobs_durable.py
@@ -105,6 +105,25 @@ class TestDurableJobs:
         assert job.id in _jobs
 
     @pytest.mark.anyio
+    async def test_submit_job_durable_preserves_tenant_in_cache(self):
+        """Durable submit keeps tenant ownership available for cache reads."""
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        def mock_factory():
+            return mock_session
+
+        with patch(
+            "server.services.compile_jobs_durable.get_session_factory",
+            return_value=mock_factory,
+        ):
+            job = await submit_job_durable("test-subject", tenant_id="tenant-a")
+
+        assert job.tenant_id == "tenant-a"
+        assert _jobs[job.id].tenant_id == "tenant-a"
+
+    @pytest.mark.anyio
     async def test_submit_job_durable_propagates_db_error(self):
         """A DB failure surfaces to the caller — no silent in-memory fallback.
 
@@ -136,6 +155,15 @@ class TestDurableJobs:
         job = submit_job("sub")
         result = await get_job_durable(job.id)
         assert result is job
+
+    @pytest.mark.anyio
+    async def test_get_job_durable_rejects_cache_hit_for_wrong_tenant(self):
+        """A cached job for another tenant must not be visible to this caller."""
+        job = submit_job("sub", tenant_id="tenant-a")
+
+        result = await get_job_durable(job.id, tenant_id="tenant-b")
+
+        assert result is None
 
     @pytest.mark.anyio
     async def test_get_job_durable_queries_db_on_miss(self):


### PR DESCRIPTION
## Summary

- Preserve `tenant_id` on durable compile job objects and the process-local job cache.
- Scope async compile status polling by the caller tenant.
- Add tests for tenant ownership in the cache and for the polling route lookup.

## Root Cause

Async compile jobs are created with a tenant id, but the polling path looked jobs up only by `job_id`. The process-local cache also did not retain tenant ownership, so a cache hit could not enforce the same tenant boundary as the durable row.

## Impact

A caller can now poll only jobs that belong to the same tenant context. Jobs from another tenant with the same visible job id are treated as not found, matching tenant isolation expectations for the rest of the API.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests/test_compile_jobs_durable.py tests/test_compile_error_handling.py -q`
- `.\.venv\Scripts\python.exe -m ruff check server/api/memories.py server/services/compile_jobs.py server/services/compile_jobs_durable.py tests/test_compile_jobs_durable.py tests/test_compile_error_handling.py`

## Notes

The focused test run passes on Windows with existing warnings from mocked async session `add()` calls and pytest cache write permissions; no new warning category was introduced by this change.