### PR TITLE
fix(subjects): return unpaginated total

### DIFF
--- a/server/api/subjects.py
+++ b/server/api/subjects.py
@@ -23,9 +23,10 @@ async def list_subjects(
 ):
     """List all known subject IDs with episode and memory counts."""
     rows = await repo.list_subjects(session, tenant_id=tenant_id, limit=limit, offset=offset)
+    total = await repo.count_subjects(session, tenant_id=tenant_id)
     return ListSubjectsResponse(
         subjects=rows,
-        total=len(rows),
+        total=total,
     )
 
 

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -385,6 +385,29 @@ async def list_subjects(
     ]
 
 
+async def count_subjects(
+    session: AsyncSession,
+    *,
+    tenant_id: str | None = None,
+) -> int:
+    """Return the unpaginated count of public subject IDs."""
+    ep_subjects = select(EpisodeRow.subject_id)
+    mem_subjects = select(MemoryRow.subject_id)
+    if tenant_id is not None:
+        ep_subjects = ep_subjects.where(EpisodeRow.tenant_id == tenant_id)
+        mem_subjects = mem_subjects.where(MemoryRow.tenant_id == tenant_id)
+    all_subjects = ep_subjects.union(mem_subjects).subquery()
+
+    stmt = (
+        select(func.count())
+        .select_from(all_subjects)
+        .where(all_subjects.c.subject_id.not_like("_snapshot/%"))
+        .where(all_subjects.c.subject_id.not_like("_bootstrap_tmp/%"))
+    )
+    total = await session.scalar(stmt)
+    return int(total or 0)
+
+
 # ---------------------------------------------------------------------------
 # Resolutions
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_edge_cases.py
+++ b/tests/integration/test_edge_cases.py
@@ -358,9 +358,15 @@ async def test_list_subjects(client: AsyncClient, subject_id: str):
 
 @pytest.mark.anyio
 async def test_list_subjects_empty(client: AsyncClient):
-    """GET /v1/subjects with pagination returns valid shape."""
+    """An out-of-range page returns an empty `subjects` list, while `total`
+    still reports the full matching count (it must not collapse to the page
+    length). `total` is therefore independent of `limit`/`offset`."""
+    baseline = await client.get("/v1/subjects")
+    assert baseline.status_code == 200
+    total_all = baseline.json()["total"]
+
     resp = await client.get("/v1/subjects", params={"limit": 1, "offset": 99999})
     assert resp.status_code == 200
     data = resp.json()
     assert data["subjects"] == []
-    assert data["total"] == 0
+    assert data["total"] == total_all

--- a/tests/test_subjects.py
+++ b/tests/test_subjects.py
@@ -1,0 +1,45 @@
+"""Tests for public subject management routes."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_list_subjects_returns_unpaginated_total(monkeypatch):
+    from server.api import subjects as api_subjects
+
+    session = AsyncMock()
+
+    async def fake_list_subjects(_session, *, tenant_id, limit, offset):
+        assert _session is session
+        assert tenant_id == "tenant-a"
+        assert limit == 1
+        assert offset == 1
+        return [
+            {
+                "subject_id": "user-b",
+                "episode_count": 2,
+                "memory_count": 1,
+            }
+        ]
+
+    async def fake_count_subjects(_session, *, tenant_id):
+        assert _session is session
+        assert tenant_id == "tenant-a"
+        return 3
+
+    monkeypatch.setattr(api_subjects.repo, "list_subjects", fake_list_subjects)
+    monkeypatch.setattr(api_subjects.repo, "count_subjects", fake_count_subjects, raising=False)
+
+    response = await api_subjects.list_subjects(
+        limit=1,
+        offset=1,
+        session=session,
+        tenant_id="tenant-a",
+    )
+
+    assert response.total == 3
+    assert len(response.subjects) == 1


### PR DESCRIPTION
## Summary

- Add an unpaginated subject count helper in the repository layer.
- Return that count from `GET /v1/subjects` instead of the current page length.
- Add route-level regression coverage for paginated responses.

## Root Cause

`GET /v1/subjects` returned `total=len(rows)` after applying `limit` and `offset`. That made `total` describe the page size rather than the number of matching subjects, so clients could not reliably calculate pagination state.

## Impact

The endpoint now returns a stable total count for the full result set while keeping `subjects` paginated. Existing subject filtering for tenant scope and hidden system subjects is preserved in the count query.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests/test_subjects.py -q`
- `.\.venv\Scripts\python.exe -m ruff check server/api/subjects.py server/db/repositories.py tests/test_subjects.py`

## Notes

The focused test run passes on Windows with the existing pytest cache write warning in this workspace; no new warning category was introduced by this change.