### PR TITLE
fix(memories): reject non-positive search limit

### DIFF
--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -302,7 +302,7 @@ async def search_memories(
     kind: str | None = Query(None),
     query: str | None = Query(None, alias="q"),
     semantic: bool = Query(False, description="Use semantic similarity search when available"),
-    limit: int = Query(20, le=100),
+    limit: int = Query(20, ge=1, le=100),
     session: AsyncSession = Depends(get_session),
     tenant_id: str | None = Depends(get_tenant_id),
 ):

--- a/tests/test_memories_search_validation.py
+++ b/tests/test_memories_search_validation.py
@@ -1,0 +1,17 @@
+"""Validation tests for memory search parameters."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [0, -1])
+async def test_search_memories_rejects_non_positive_limit(client: AsyncClient, limit: int):
+    response = await client.get(
+        "/v1/memories/search",
+        params={"subject_id": "user-1", "limit": limit},
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

- Add a lower bound to the `limit` query parameter for `GET /v1/memories/search`.
- Add HTTP-level validation coverage for zero and negative limits.

## Root Cause

The route constrained `limit` with `le=100` but did not set `ge=1`. Requests with `limit=0` or negative values passed FastAPI validation and reached the repository layer, where they could produce confusing behavior or database errors instead of a clear 422 response.

## Impact

Invalid non-positive search limits are rejected at the API boundary before any database work is attempted. This matches the existing request schema contract and the validation style used by other paginated endpoints.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests/test_memories_search_validation.py -q`
- `.\.venv\Scripts\python.exe -m ruff check server/api/memories.py tests/test_memories_search_validation.py`

## Notes

The focused test run passes on Windows with the existing pytest cache write warning in this workspace; no new warning category was introduced by this change.