### PR TITLE
fix(admin): return required label fields from citing-memories lookup

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -850,10 +850,12 @@ async def list_citing_memories(
                 summary=m.summary,
                 confidence=m.confidence,
                 status=m.status,
-                source_episode_ids=[str(eid) for eid in m.source_episode_ids],
+                source_episode_ids=[str(eid) for eid in (m.source_episode_ids or [])],
                 valid_from=m.valid_from.isoformat(),
                 valid_to=m.valid_to.isoformat() if m.valid_to else None,
                 created_at=m.created_at.isoformat(),
+                sensitivity_labels=list(m.sensitivity_labels or []),
+                suggested_labels=list(m.suggested_labels or []),
             )
             for m in rows
         ]

--- a/tests/integration/test_admin_citing_memories.py
+++ b/tests/integration/test_admin_citing_memories.py
@@ -1,0 +1,53 @@
+"""Regression: the reverse-provenance lookup must not 500 on a hit.
+
+GET /admin/subjects/{subject_id}/episodes/{episode_id}/citing-memories built
+its ``MemoryListItem`` response without the required ``sensitivity_labels`` /
+``suggested_labels`` fields, so it raised a response-model ValidationError
+(HTTP 500) the moment any memory actually cited the episode — i.e. exactly the
+case the endpoint exists to serve. It only "worked" when the result was empty.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.anyio
+async def test_citing_memories_returns_200_when_memories_cite_episode(
+    client: AsyncClient, subject_id: str
+):
+    # Ingest an episode and capture its id.
+    r = await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": subject_id,
+            "source": "test",
+            "type": "conversation",
+            "payload": {
+                "messages": [
+                    {"role": "user", "content": "My name is Alice and I work at Initech."}
+                ]
+            },
+        },
+    )
+    assert r.status_code == 201
+    episode_id = r.json()["id"]
+
+    # Compile → the derived memories carry this episode in source_episode_ids.
+    r = await client.post("/v1/memories/compile", json={"subject_id": subject_id})
+    assert r.status_code == 200
+    assert r.json()["memories_created"] > 0
+
+    # Reverse-provenance lookup must succeed (previously 500).
+    r = await client.get(
+        f"/admin/subjects/{subject_id}/episodes/{episode_id}/citing-memories"
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total"] >= 1
+    assert len(body["memories"]) >= 1
+    first = body["memories"][0]
+    # The governance fields that were previously omitted must be present.
+    assert "sensitivity_labels" in first
+    assert "suggested_labels" in first


### PR DESCRIPTION
## Summary
- `GET /admin/subjects/{subject_id}/episodes/{episode_id}/citing-memories` returned **HTTP 500 for any episode that actually has citing memories**, because it built `MemoryListItem` without the required `sensitivity_labels` / `suggested_labels` fields.
- Populated the two fields (mirroring the sibling `list_subject_memories`), plus the same `or []` guard on `source_episode_ids`.
- Added a regression test that compiles a memory citing an episode and asserts the endpoint returns 200.

## Before
`MemoryListItem` declares `sensitivity_labels: list[str]` and `suggested_labels: list[str]` with no defaults, so both are required. `list_citing_memories` omitted them, and with `response_model=MemoryListResponse` the resulting `ValidationError` surfaced as **HTTP 500** the moment any memory cited the episode — exactly the reverse-provenance case the endpoint exists to serve. It only "worked" when the result set was empty, and the existing tests only assert route registration, so CI never exercised it with data.

## After
The endpoint returns **HTTP 200** with the citing memories, including the previously omitted governance label fields (empty list is the documented default for both).

## Impact
- `server/api/admin.py` — single `MemoryListItem` construction in `list_citing_memories`.
- Breaking changes: no (the response only gains two fields it already promises elsewhere; the endpoint previously 500'd).
- Performance: none.

## Test plan
- [x] New integration test: ingest episode → compile → `GET …/citing-memories` → assert 200, memory present, label fields present.
- [x] `ruff check server/ tests/` clean.
- [x] Unit suite green (`pytest tests/test_*.py`); integration green except the pre-existing env-only `test_semantic_search_returns_results` (needs a real embedding provider — fails identically on `main`).
