### PR TITLE
fix(context): rank recent episodes, not the oldest 30

### DIFF
--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -65,11 +65,31 @@ async def list_episodes_by_subject(
     *,
     tenant_id: str | None = None,
     limit: int = 100,
+    newest_first: bool = False,
 ) -> Sequence[EpisodeRow]:
     # Order by `occurred_at` (the source-event time) so backfilled episodes
     # land in their real chronological position. `created_at` is the
     # tiebreak so simultaneous events from a single ingest batch retain
     # their insertion order in the response.
+    #
+    # `newest_first=True` selects the most-recent `limit` episodes (then
+    # returns them in ascending chronological order). Callers that want a
+    # bounded "recent activity" window MUST use it: with the default ascending
+    # order, a `limit` smaller than the subject's lifetime episode count
+    # returns the OLDEST `limit` rows — the opposite of recent.
+    if newest_first:
+        stmt = (
+            select(EpisodeRow)
+            .where(EpisodeRow.subject_id == subject_id)
+            .order_by(EpisodeRow.occurred_at.desc(), EpisodeRow.created_at.desc())
+            .limit(limit)
+        )
+        stmt = _tenant_filter(stmt, EpisodeRow.tenant_id, tenant_id)
+        result = await session.execute(stmt)
+        rows = list(result.scalars().all())
+        rows.reverse()  # newest-`limit` fetched desc → return ascending
+        return rows
+
     stmt = (
         select(EpisodeRow)
         .where(EpisodeRow.subject_id == subject_id)

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -179,8 +179,13 @@ async def assemble_context(
     summary_rows = await repo.search_memories(
         session, subject_id, tenant_id=tenant_id, kind="episode_summary", limit=30
     )
+    # `newest_first` so a subject with >30 lifetime episodes contributes its
+    # most-recent 30 to the candidate pool — recency boosts, the "Recent
+    # interactions" rendering, and repeat-issue detection all assume recent
+    # episodes. Without it the oldest 30 would be scored under a "recent"
+    # heading.
     episode_rows = await repo.list_episodes_by_subject(
-        session, subject_id, tenant_id=tenant_id, limit=30
+        session, subject_id, tenant_id=tenant_id, limit=30, newest_first=True
     )
 
     # -- Prepare semantic scoring -------------------------------------------

--- a/server/services/handoff.py
+++ b/server/services/handoff.py
@@ -53,8 +53,12 @@ async def assemble_handoff(
     fact_rows = await repo.search_memories(
         session, subject_id, tenant_id=tenant_id, kind="profile_fact", limit=20
     )
+    # `newest_first` so the cross-session "recent context" below is drawn from
+    # the subject's most-recent 30 episodes, not its oldest 30. PR #205 fixed
+    # the active-session path (session_episode_rows) but this subject-wide
+    # fetch still bound "recent context" to the oldest-30 window.
     episode_rows = await repo.list_episodes_by_subject(
-        session, subject_id, tenant_id=tenant_id, limit=30
+        session, subject_id, tenant_id=tenant_id, limit=30, newest_first=True
     )
     session_episode_rows = await repo.list_episodes_by_session(
         session, subject_id, session_id, tenant_id=tenant_id, limit=30
@@ -144,10 +148,11 @@ async def assemble_handoff(
         )
 
     # -- Recent context (non-current session, most recent first) ------------
-    # `other_eps` is occurred_at ASC (oldest first); take the newest 5 and
-    # reverse so the most-recent cross-session episode leads, matching the
-    # heading. Computed once and reused for provenance + the receipt's
-    # carry-forward set so all three agree on which episodes are surfaced.
+    # `episode_rows` is the subject's most-recent 30 episodes in ascending
+    # order, so `other_eps` (its cross-session subset) is ascending too; take
+    # the newest 5 and reverse so the most-recent cross-session episode leads,
+    # matching the heading. Computed once and reused for provenance + the
+    # receipt's carry-forward set so all three agree on which episodes surface.
     recent_eps = list(reversed(other_eps[-5:]))
     recent_context: list[str] = []
     for ep in recent_eps:

--- a/tests/integration/test_recent_episode_window.py
+++ b/tests/integration/test_recent_episode_window.py
@@ -1,0 +1,80 @@
+"""Regression: the bounded episode fetch used by /v1/context and handoff must
+return the subject's MOST-RECENT `limit` episodes, not its oldest.
+
+`list_episodes_by_subject` orders by occurred_at ascending, so a `limit`
+smaller than the subject's lifetime episode count returned the OLDEST `limit`
+rows. /v1/context (candidate pool, "Recent interactions" rendering, recency
+boost, repeat-issue detection) and the handoff brief's cross-session "recent
+context" both call it with limit=30 and assume recent episodes — so for any
+subject with >30 episodes they silently operated on the oldest 30.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+
+from server.db import repositories as repo
+from server.db.tables import EpisodeRow
+
+
+@pytest.mark.anyio
+async def test_newest_first_returns_recent_window_ascending(session_factory, subject_id):
+    base = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+    async with session_factory() as session:
+        for i in range(40):
+            session.add(
+                EpisodeRow(
+                    id=uuid.uuid4(),
+                    subject_id=subject_id,
+                    source="test",
+                    type="conversation",
+                    payload={"text": f"ep {i}"},
+                    occurred_at=base + dt.timedelta(days=i),
+                )
+            )
+        await session.commit()
+
+    async with session_factory() as session:
+        rows = await repo.list_episodes_by_subject(
+            session, subject_id, limit=30, newest_first=True
+        )
+
+    texts = [r.payload["text"] for r in rows]
+    assert len(rows) == 30
+    # The most-recent 30 (ep 10..39), returned in ascending chronological order.
+    assert texts[0] == "ep 10"
+    assert texts[-1] == "ep 39"
+    assert [r.occurred_at for r in rows] == sorted(r.occurred_at for r in rows)
+    # The genuinely recent episode is present; the oldest is excluded.
+    assert "ep 39" in texts
+    assert "ep 0" not in texts
+
+
+@pytest.mark.anyio
+async def test_default_still_returns_oldest_window(session_factory, subject_id):
+    """Backward-compat: without newest_first, the historical ascending/oldest
+    behaviour is preserved for any other caller."""
+    base = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+    async with session_factory() as session:
+        for i in range(40):
+            session.add(
+                EpisodeRow(
+                    id=uuid.uuid4(),
+                    subject_id=subject_id,
+                    source="test",
+                    type="conversation",
+                    payload={"text": f"ep {i}"},
+                    occurred_at=base + dt.timedelta(days=i),
+                )
+            )
+        await session.commit()
+
+    async with session_factory() as session:
+        rows = await repo.list_episodes_by_subject(session, subject_id, limit=30)
+
+    texts = [r.payload["text"] for r in rows]
+    assert texts[0] == "ep 0"
+    assert texts[-1] == "ep 29"


### PR DESCRIPTION
## Summary
- The bounded episode fetch used by `/v1/context` and the handoff brief returned the subject's **oldest** 30 episodes, not its most recent.
- `list_episodes_by_subject` orders by `occurred_at` ascending, so `limit=30` returns the oldest 30 for any subject with >30 lifetime episodes.
- Added a `newest_first` option (selects the most-recent N, returns them ascending) and opted both call sites in. This completes the >30-episode window fix #205 made for handoff's active-session path.

## Before
For a subject with >30 episodes, `/v1/context` ranked and rendered the **oldest 30** under a "Recent interactions" heading; the recency boost, repeat-issue detection, and the handoff brief's cross-session "recent context" all silently degraded (handoff's `reversed(other_eps[-5:])` picked the newest 5 *within the oldest 30*). The asymmetry with the memory fetches (`created_at desc`) showed the oldest-first selection was unintended.

## After
Both call sites fetch the most-recent 30 episodes, returned in ascending chronological order so the existing slicing/rendering is unchanged. `newest_first` defaults to `False`, preserving the historical behaviour for any other caller.

## Impact
- `server/db/repositories.py` (`list_episodes_by_subject` gains `newest_first`), `server/services/context.py`, `server/services/handoff.py`.
- Breaking changes: no (opt-in flag; default unchanged).
- Performance: identical query + `LIMIT`; one in-Python `reverse()` of ≤`limit` rows.

## Test plan
- [x] New integration test: seed >30 episodes; assert the newest window is returned ascending, and that the default still returns the oldest window (back-compat).
- [x] handoff + context unit suites green (51 passed); golden-path integration green.
- [x] `ruff check server/ tests/` clean; unit suite green.
