### PR TITLE
chore(ci): invariant guards, AI security review, and repo hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Code owners for security-sensitive surfaces.
+#
+# Listing a path here requests @smaramwbc as a reviewer automatically. It is
+# ENFORCED (review required to merge) only when branch protection has
+# "Require review from Code Owners" enabled for the default branch.
+
+# CI / supply chain — a malicious workflow edit is the highest-impact change.
+/.github/                @smaramwbc
+
+# Auth, tenancy, config, and persistence — isolation-critical code.
+/server/core/            @smaramwbc
+/server/db/              @smaramwbc
+
+# Dependency and image definitions.
+/pyproject.toml          @smaramwbc
+/Dockerfile              @smaramwbc
+/docker-compose.yml      @smaramwbc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: this workflow only reads the repo to run tests.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -1,0 +1,36 @@
+name: Security Review (Claude)
+
+# AI security review of each pull request diff; findings are posted as PR
+# comments. Complements (does not replace) CodeQL and human review.
+#
+# Fork PRs do NOT receive repository secrets — this is a deliberate GitHub
+# protection that stops a malicious PR from stealing CLAUDE_API_KEY. The `if`
+# below skips forks so the job doesn't fail on them; review fork PRs with a
+# maintainer-gated run instead. Requires a CLAUDE_API_KEY repository secret
+# (a key with Claude API + Claude Code usage enabled).
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  security-review:
+    # Same-repo branches only (forks have no secret); Dependabot bumps are
+    # already covered by CodeQL + the dependency review.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 2
+
+      - uses: anthropics/claude-code-security-review@main
+        with:
+          comment-pr: true
+          claude-api-key: ${{ secrets.CLAUDE_API_KEY }}

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -24,13 +24,19 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
       && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    env:
+      CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
 
-      - uses: anthropics/claude-code-security-review@main
+      # Skips cleanly until the CLAUDE_API_KEY secret is added (the job then
+      # passes as a no-op), and auto-activates once it is set.
+      - name: Claude security review
+        if: env.CLAUDE_API_KEY != ''
+        uses: anthropics/claude-code-security-review@main
         with:
           comment-pr: true
-          claude-api-key: ${{ secrets.CLAUDE_API_KEY }}
+          claude-api-key: ${{ env.CLAUDE_API_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,10 @@ STATEWAVE_EMBEDDING_PROVIDER=stub STATEWAVE_COMPILER_TYPE=heuristic \
 - **Keep claims accurate and modest.** Describe what the code does; back any
   performance or benchmark claim with a reproducible source, and avoid
   unqualified superlatives.
+- **CI enforces a few cross-cutting invariants** — tenant-scoped repository
+  queries, bounded pagination params, and a single shared tokenizer. If a guard
+  test fails, satisfy the rule rather than weakening the test. See
+  [CONTRIBUTING.md](CONTRIBUTING.md#invariants-enforced-by-ci).
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,25 @@ authorized the contribution before submitting.
 - Match the surrounding code's conventions; prefer small, composable
   functions; prefer clear names over comments.
 
+## Invariants enforced by CI
+
+A few cross-cutting rules are checked automatically so a single change can't
+silently reintroduce a whole class of bug. If your PR trips one of these, the
+fix is to satisfy the rule (not to weaken the test):
+
+- **Tenant scoping** — every repository query that takes a `subject_id` must
+  also take a `tenant_id` and apply `_tenant_filter`, so it can't read across
+  tenants. (`tests/test_tenant_scoping_invariant.py`)
+- **Bounded pagination** — every `limit` query parameter needs `ge` and `le`,
+  and every `offset` needs `ge`. (`tests/test_route_limits_invariant.py`)
+- **One tokenizer** — lexical word comparison goes through
+  `server.services.tokenization.tokenize`; raw `.lower().split()` elsewhere is
+  rejected, because punctuation welded onto tokens silently zeros overlap.
+  (`tests/test_no_raw_tokenization.py`, `tests/test_tokenization.py`)
+
+Each rule exists because a real bug shipped without it; the test is the cheapest
+place to catch the next one.
+
 ## Reporting security issues
 
 Please **do not** open a public issue for security vulnerabilities. See

--- a/server/services/conflicts.py
+++ b/server/services/conflicts.py
@@ -21,27 +21,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.db import repositories as repo
 from server.db.tables import MemoryRow
+from server.services.tokenization import EDGE_PUNCT, tokenize
 
 logger = structlog.stdlib.get_logger()
 
 # Similarity threshold for word-overlap conflict detection (0–1)
 _WORD_OVERLAP_THRESHOLD = 0.6
 
-# Punctuation stripped from token edges before the word-overlap comparison,
-# mirroring server.services.context._tokenize_for_relevance. Without it a
-# trailing "." welds onto a word ("Stripe." != "Stripe"), dragging the Jaccard
-# similarity below threshold and silently skipping a valid supersession — the
-# older duplicate then stays active forever and pollutes future bundles.
-_TOKEN_EDGE_PUNCT = "?.,:;()[]{}'\"!"
-
-
-def _tokenize(content: str) -> set[str]:
-    """Lowercase word tokens with surrounding punctuation stripped."""
-    return {
-        stripped
-        for stripped in (t.strip(_TOKEN_EDGE_PUNCT) for t in content.lower().split())
-        if stripped
-    }
+# Tokenization is centralized in server.services.tokenization so this detector
+# and the relevance scorer can never drift apart. Drift silently welds a
+# trailing "." onto a word ("Stripe." != "Stripe"), dragging Jaccard similarity
+# below threshold and skipping a valid supersession (#198/#199).
+_TOKEN_EDGE_PUNCT = EDGE_PUNCT
+_tokenize = tokenize
 
 
 async def resolve_conflicts(

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -33,6 +33,7 @@ from server.services import receipts as receipts_service
 from server.services.compilers.heuristic import extract_payload_text
 from server.services.embeddings import get_provider as get_embedding_provider
 from server.services.embeddings.query_cache import cached_embed_query
+from server.services.tokenization import EDGE_PUNCT, tokenize
 
 logger = structlog.stdlib.get_logger()
 
@@ -897,22 +898,10 @@ def _session_keyword_overlap(current_keywords: set[str], prior_keywords: set[str
     return overlap / len(current_keywords)
 
 
-_RELEVANCE_PUNCT = "?.,:;()[]{}'\"!"
-
-
-def _tokenize_for_relevance(text: str) -> set[str]:
-    """Lowercase word tokens for relevance scoring, with surrounding
-    punctuation stripped. Without stripping, content fragments like
-    `'npm install'` (literal quotes from a markdown code-snippet docs
-    pack) tokenize as `'npm` and won't intersect a query token of `npm`,
-    silently zeroing the lexical signal."""
-    if not text:
-        return set()
-    return {
-        stripped
-        for stripped in (t.strip(_RELEVANCE_PUNCT) for t in text.lower().split())
-        if stripped
-    }
+# Lexical tokenization is centralized in server.services.tokenization so the
+# relevance scorer and the conflict detector can never drift apart (#198/#199).
+_RELEVANCE_PUNCT = EDGE_PUNCT
+_tokenize_for_relevance = tokenize
 
 
 def _has_urgency(text: str) -> bool:

--- a/server/services/tokenization.py
+++ b/server/services/tokenization.py
@@ -1,0 +1,32 @@
+"""Shared lexical tokenization — the single source of truth for the
+edge-punctuation stripping used by relevance scoring (``context.py``) and
+conflict detection (``conflicts.py``).
+
+Keeping it in one place is a correctness guard. When the two copies drifted
+apart, a trailing ``"."`` welded onto a word (``"Stripe." != "Stripe"``) and a
+sentence-final ``"outage!"`` failed to match ``"outage"``, silently zeroing
+word-overlap (the bug class fixed in #198/#199). A CI fitness function
+(``tests/test_no_raw_tokenization.py``) keeps raw ``.lower().split()`` from
+creeping back into other modules.
+"""
+
+from __future__ import annotations
+
+# Punctuation stripped from the edges of each token before comparison.
+EDGE_PUNCT = "?.,:;()[]{}'\"!"
+
+
+def tokenize(text: str) -> set[str]:
+    """Lowercase word tokens with surrounding punctuation stripped.
+
+    Without stripping, fragments like ``'npm install'`` (literal quotes from a
+    markdown code snippet) tokenize as ``'npm`` and won't intersect a clean
+    query token ``npm``, silently zeroing the lexical signal.
+    """
+    if not text:
+        return set()
+    return {
+        stripped
+        for stripped in (token.strip(EDGE_PUNCT) for token in text.lower().split())
+        if stripped
+    }

--- a/tests/test_no_raw_tokenization.py
+++ b/tests/test_no_raw_tokenization.py
@@ -1,0 +1,29 @@
+"""Fitness function: raw ``.lower().split()`` whitespace tokenization for lexical
+comparison must go through ``server.services.tokenization``.
+
+Raw splitting leaves punctuation welded onto tokens (``'npm`` won't match
+``npm``; ``"Stripe."`` won't match ``"Stripe"``) — the silent-overlap bug class
+of #198/#199. Only the shared tokenizer module may contain the pattern; any new
+occurrence elsewhere fails CI and should call ``tokenize()`` instead.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+_SERVER = pathlib.Path(__file__).resolve().parents[1] / "server"
+_ALLOWED = {_SERVER / "services" / "tokenization.py"}
+
+
+def test_no_raw_lower_split_outside_shared_tokenizer():
+    offenders: list[str] = []
+    for path in _SERVER.rglob("*.py"):
+        if path in _ALLOWED:
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if ".lower().split()" in line:
+                offenders.append(f"{path.relative_to(_SERVER.parent)}:{lineno}")
+    assert not offenders, (
+        "Use server.services.tokenization.tokenize() instead of raw "
+        ".lower().split() for lexical comparison: " + "; ".join(offenders)
+    )

--- a/tests/test_route_limits_invariant.py
+++ b/tests/test_route_limits_invariant.py
@@ -1,0 +1,57 @@
+"""Fitness function: pagination parameters must be bounded.
+
+An unbounded ``limit`` lets a caller request the whole table (or, with
+``limit=0`` / a negative value, get surprising empty results) — the boundary
+class fixed in #208/#209. This test scans every route module and asserts each
+``limit`` Query has both ``ge`` and ``le``, and each ``offset`` Query has ``ge``.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_API_DIR = pathlib.Path(__file__).resolve().parents[1] / "server" / "api"
+
+_REQUIRED = {"limit": {"ge", "le"}, "offset": {"ge"}}
+
+
+def _query_keywords(default: ast.expr | None) -> set[str] | None:
+    """Return the keyword-arg names of a ``Query(...)`` default, else None."""
+    if isinstance(default, ast.Call) and isinstance(default.func, ast.Name):
+        if default.func.id == "Query":
+            return {kw.arg for kw in default.keywords if kw.arg is not None}
+    return None
+
+
+def _iter_param_defaults(func: ast.AsyncFunctionDef | ast.FunctionDef):
+    a = func.args
+    positional = a.args
+    pos_defaults = [None] * (len(positional) - len(a.defaults)) + list(a.defaults)
+    yield from zip(positional, pos_defaults)
+    yield from zip(a.kwonlyargs, a.kw_defaults)
+
+
+def _violations() -> list[str]:
+    bad: list[str] = []
+    for path in sorted(_API_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            for arg, default in _iter_param_defaults(node):
+                required = _REQUIRED.get(arg.arg)
+                if required is None:
+                    continue
+                kws = _query_keywords(default)
+                if kws is None:
+                    continue
+                missing = required - kws
+                if missing:
+                    bad.append(f"{path.name}:{node.name}:{arg.arg} missing {sorted(missing)}")
+    return bad
+
+
+def test_pagination_params_are_bounded():
+    bad = _violations()
+    assert not bad, "Unbounded pagination params (add ge/le to Query): " + "; ".join(bad)

--- a/tests/test_tenant_scoping_invariant.py
+++ b/tests/test_tenant_scoping_invariant.py
@@ -1,0 +1,58 @@
+"""Fitness function: every subject-scoped repository query must also accept a
+``tenant_id``.
+
+A query keyed only by ``subject_id`` silently reads across tenants — the bug
+class fixed in #206 (conflict resolution) and #207 (compile-job polling). This
+test fails CI when a *new* repository helper takes ``subject_id`` without a
+``tenant_id`` parameter, so the next one can't merge unscoped.
+
+The allowlist is a shrinking register of *known* gaps, not a license to add
+more. Do not append to it to silence a finding — add the ``tenant_id`` and apply
+``_tenant_filter`` instead.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_REPOSITORIES = (
+    pathlib.Path(__file__).resolve().parents[1] / "server" / "db" / "repositories.py"
+)
+
+# Known, accepted exceptions. The subject-health cache is keyed by a bare
+# ``subject_id`` PRIMARY KEY (server/db/tables.py: SubjectHealthCacheRow), so
+# isolating it needs a composite-key schema migration, not a query filter — it
+# is tracked separately. Multi-tenancy is experimental and does not yet enforce
+# full isolation.
+_ALLOWED_UNSCOPED = {
+    "get_health_cache",
+    "delete_health_cache_by_subject",
+}
+
+
+def _subject_scoped_without_tenant() -> set[str]:
+    tree = ast.parse(_REPOSITORIES.read_text())
+    out: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            args = {a.arg for a in node.args.args} | {a.arg for a in node.args.kwonlyargs}
+            if "subject_id" in args and "tenant_id" not in args:
+                out.add(node.name)
+    return out
+
+
+def test_subject_queries_are_tenant_scoped():
+    offenders = _subject_scoped_without_tenant() - _ALLOWED_UNSCOPED
+    assert not offenders, (
+        "These repository functions take subject_id but not tenant_id — add a "
+        "tenant_id parameter and apply _tenant_filter so they cannot read across "
+        f"tenants: {sorted(offenders)}"
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    # Keep the register honest: once a function is fixed it must be removed from
+    # the allowlist, or the list rots into a place new gaps hide.
+    stale = _ALLOWED_UNSCOPED - _subject_scoped_without_tenant()
+    assert not stale, f"Remove now-fixed entries from the allowlist: {sorted(stale)}"

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -1,0 +1,32 @@
+"""The lexical tokenizer is a single source of truth (server.services.tokenization).
+
+Relevance scoring and conflict detection must share it. When they drifted, a
+trailing "." silently zeroed word-overlap (the "Stripe." != "Stripe" class of
+bug, #198/#199). These tests fail if the two ever diverge again.
+"""
+
+from __future__ import annotations
+
+from server.services import conflicts, context
+from server.services.tokenization import EDGE_PUNCT, tokenize
+
+
+def test_relevance_and_conflict_share_one_constant():
+    assert context._RELEVANCE_PUNCT is EDGE_PUNCT
+    assert conflicts._TOKEN_EDGE_PUNCT is EDGE_PUNCT
+
+
+def test_relevance_and_conflict_share_one_tokenizer():
+    assert context._tokenize_for_relevance is tokenize
+    assert conflicts._tokenize is tokenize
+
+
+def test_tokenize_strips_edge_punctuation():
+    assert tokenize("Production outage!") == {"production", "outage"}
+    assert tokenize("'npm install'") == {"npm", "install"}
+    assert tokenize("Stripe.") == {"stripe"}
+
+
+def test_tokenize_handles_empty_and_blank():
+    assert tokenize("") == set()
+    assert tokenize("   ") == set()


### PR DESCRIPTION
## What

Defense-in-depth so the bug *classes* recent contributions surfaced get caught by CI automatically, plus repo hardening.

### Layer 1 — invariant guards (fitness functions)
- **One tokenizer.** Lexical tokenization is consolidated into `server/services/tokenization.py`; `context.py` and `conflicts.py` now share one constant + function and can't drift apart (the punctuation-overlap class, #198/#199). `test_no_raw_tokenization.py` rejects raw `.lower().split()` anywhere else; `test_tokenization.py` asserts the single source of truth.
- **Tenant scoping** (`test_tenant_scoping_invariant.py`) — every repository query that takes `subject_id` must also take `tenant_id` (the cross-tenant read class, #206/#207). New violations fail CI.
- **Bounded pagination** (`test_route_limits_invariant.py`) — every `limit` Query needs `ge`+`le`, every `offset` needs `ge` (the #208/#209 class).

### Layer 2 — AI security review
- `claude-security-review.yml` runs an AI security pass on each PR diff and comments findings. Runs on **same-repo** PRs only — fork PRs get no secrets by design, so they're skipped and reviewed via the maintainer-gated path. **Requires a `CLAUDE_API_KEY` repo secret.**

### Layer 3 — hardening
- `.github/CODEOWNERS` requests owner review on `.github/`, `server/core`, `server/db`, and dependency/image files.
- `permissions: contents: read` (least privilege) on the CI workflow.

### Layer 4 — docs
- The invariants are documented in `CONTRIBUTING.md` and `AGENTS.md` so contributors and AI reviewers know the rules.

## Known gap surfaced (not fixed here)
The tenant-scoping guard flagged a real one: `get_health_cache` / `delete_health_cache_by_subject` lack `tenant_id` while `upsert_health_cache` has it — so one tenant can read/overwrite another's cached health for the same subject. It's keyed by a bare `subject_id` **primary key**, so a correct fix needs a composite-key schema migration (a design decision), not a query filter. Allowlisted with justification and left for a focused follow-up.

## Verification
- 694 passed, 1 skipped locally (`pytest tests/test_*.py`); `ruff check server/ tests/` clean; workflow YAML validated.

## Owner follow-ups (settings, not code)
- Add the `CLAUDE_API_KEY` secret to activate Layer 2.
- Enable "Require review from Code Owners" in branch protection to make CODEOWNERS binding.
- Enable secret scanning + push protection.
