### PR TITLE
fix(health-cache): isolate subject_health_cache per (tenant_id, subject_id)

### DIFF
--- a/alembic/versions/0024_health_cache_tenant_iso.py
+++ b/alembic/versions/0024_health_cache_tenant_iso.py
@@ -1,0 +1,92 @@
+"""subject_health_cache: per-(tenant_id, subject_id) identity — tenant isolation
+
+Revision ID: 0024_health_cache_tenant_iso
+Revises: 0023_receipts_policy_snapshot
+Create Date: 2026-06-01
+
+`subject_health_cache` used `subject_id` as its sole primary key (migration
+0012). In a multi-tenant deployment, two tenants caching health for the same
+`subject_id` collided on one row: tenant B's upsert silently overwrote tenant
+A's cached state, and a read returned whichever tenant wrote last. Health
+state/score is tenant data, so this is a cross-tenant read/write leak — the
+same isolation class fixed in #206 (conflicts) and #207 (compile jobs).
+
+The fix mirrors the policy_bundles per-tenant fix (migration 0019):
+
+  * Add a synthetic UUID `id` column as the new primary key — random per row,
+    no semantic meaning; the row's *identity* becomes the UUID.
+
+  * Drop the old single-column PK on `subject_id`.
+
+  * Keep a plain index on `subject_id` for the single-tenant lookup path
+    (where no tenant filter is applied).
+
+  * Add a composite unique index on `(tenant_id, subject_id)` with
+    `NULLS NOT DISTINCT` so `(NULL, 's')` can't be duplicated in single-tenant
+    mode, while `(NULL, 's')` and `('acme', 's')` stay distinct (correct
+    per-tenant scoping). Requires PostgreSQL 15+; statewave runs PG16 (see the
+    CI workflow + the pgvector/pgvector:pg16 image).
+
+Reversible: downgrade restores the single-column PK, but DOES NOT collapse
+rows that share a `subject_id` across tenants — a downgrade applied to a
+database with cross-tenant cache rows will fail on the PK re-add. The cache is
+regenerated on the next health check, so operators rolling back should first
+`DELETE FROM subject_health_cache WHERE tenant_id IS NOT NULL`.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision: str = "0024_health_cache_tenant_iso"
+down_revision: Union[str, None] = "0023_receipts_policy_snapshot"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add the synthetic id column. server_default applies on INSERT so new
+    #    rows get a UUID automatically; existing rows are backfilled below.
+    op.add_column(
+        "subject_health_cache",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+    )
+    # 2. Backfill rows present before the ALTER (server_default doesn't apply
+    #    to them).
+    op.execute("UPDATE subject_health_cache SET id = gen_random_uuid() WHERE id IS NULL")
+
+    # 3. Swap the PK from subject_id to the synthetic id.
+    op.drop_constraint("subject_health_cache_pkey", "subject_health_cache", type_="primary")
+    op.create_primary_key("subject_health_cache_pkey", "subject_health_cache", ["id"])
+
+    # 4. Plain index on subject_id (no longer implied by a PK) for the
+    #    single-tenant lookup path.
+    op.create_index(
+        "ix_subject_health_cache_subject_id", "subject_health_cache", ["subject_id"]
+    )
+
+    # 5. Composite unique index. NULLS NOT DISTINCT (PG15+) makes (NULL, 's')
+    #    equal to (NULL, 's') so single-tenant rows can't be duplicated, while
+    #    (NULL, 's') and ('acme', 's') stay distinct. Raw SQL because alembic
+    #    1.13's op.create_index doesn't surface the keyword.
+    op.execute(
+        "CREATE UNIQUE INDEX ix_subject_health_cache_tenant_subject "
+        "ON subject_health_cache (tenant_id, subject_id) NULLS NOT DISTINCT"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_subject_health_cache_tenant_subject")
+    op.drop_index("ix_subject_health_cache_subject_id", table_name="subject_health_cache")
+    op.drop_constraint("subject_health_cache_pkey", "subject_health_cache", type_="primary")
+    # The single-column PK only succeeds if no cross-tenant duplicates exist —
+    # see the module docstring.
+    op.create_primary_key("subject_health_cache_pkey", "subject_health_cache", ["subject_id"])
+    op.drop_column("subject_health_cache", "id")

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -534,9 +534,16 @@ async def delete_resolutions_by_subject(
 async def get_health_cache(
     session: AsyncSession,
     subject_id: str,
+    *,
+    tenant_id: str | None = None,
 ) -> SubjectHealthCacheRow | None:
-    """Get cached health state for a subject."""
+    """Get cached health state for a subject, scoped to the tenant.
+
+    Without the tenant filter a caller could read another tenant's cached
+    health for the same subject_id (the cache row identity is
+    (tenant_id, subject_id); see migration 0024)."""
     stmt = select(SubjectHealthCacheRow).where(SubjectHealthCacheRow.subject_id == subject_id)
+    stmt = _tenant_filter(stmt, SubjectHealthCacheRow.tenant_id, tenant_id)
     result = await session.execute(stmt)
     return result.scalar_one_or_none()
 
@@ -552,7 +559,10 @@ async def upsert_health_cache(
     """Update or insert cached health state."""
     from datetime import datetime, timezone
 
-    existing = await get_health_cache(session, subject_id)
+    # Tenant-scoped lookup: without it, tenant B's upsert would find and
+    # overwrite tenant A's row for the same subject_id instead of inserting
+    # its own.
+    existing = await get_health_cache(session, subject_id, tenant_id=tenant_id)
     if existing:
         existing.last_state = state
         existing.last_score = score
@@ -572,9 +582,14 @@ async def upsert_health_cache(
 async def delete_health_cache_by_subject(
     session: AsyncSession,
     subject_id: str,
+    *,
+    tenant_id: str | None = None,
 ) -> None:
-    """Delete health cache for a subject (used in subject deletion)."""
+    """Delete health cache for a subject (used in subject deletion), scoped to
+    the tenant so one tenant's deletion can't drop another tenant's cache row
+    for the same subject_id."""
     stmt = delete(SubjectHealthCacheRow).where(SubjectHealthCacheRow.subject_id == subject_id)
+    stmt = _tenant_filter(stmt, SubjectHealthCacheRow.tenant_id, tenant_id)
     await session.execute(stmt)
 
 

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -211,17 +211,24 @@ class ResolutionRow(Base):
 
 
 class SubjectHealthCacheRow(Base):
-    """Caches last-known health state per subject for alert deduplication."""
+    """Caches last-known health state per (tenant_id, subject_id) for alert
+    deduplication."""
 
     __tablename__ = "subject_health_cache"
 
-    subject_id: Mapped[str] = mapped_column(String(256), primary_key=True)
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    subject_id: Mapped[str] = mapped_column(String(256), nullable=False, index=True)
     tenant_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
     last_state: Mapped[str] = mapped_column(String(32), nullable=False)
     last_score: Mapped[int] = mapped_column(Integer, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+
+    # Composite unique index ix_subject_health_cache_tenant_subject (migration
+    # 0024, NULLS NOT DISTINCT) enforces one row per (tenant_id, subject_id).
+    # Not a SQLAlchemy UniqueConstraint because NULLS NOT DISTINCT isn't
+    # natively expressible — the migration owns it.
 
 
 class ReceiptRow(Base):

--- a/server/services/health_alerts.py
+++ b/server/services/health_alerts.py
@@ -37,8 +37,8 @@ async def check_and_alert(
     """
     current_severity = _STATE_SEVERITY.get(health.state, 0)
 
-    # Get cached previous state
-    cached = await repo.get_health_cache(session, health.subject_id)
+    # Get cached previous state (tenant-scoped — see repo.get_health_cache)
+    cached = await repo.get_health_cache(session, health.subject_id, tenant_id=tenant_id)
     previous_state = cached.last_state if cached else "healthy"
     previous_severity = _STATE_SEVERITY.get(previous_state, 0)
 

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0023_receipts_policy_snapshot"
+EXPECTED_HEAD = "0024_health_cache_tenant_iso"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/tests/integration/test_health_cache_isolation.py
+++ b/tests/integration/test_health_cache_isolation.py
@@ -1,0 +1,104 @@
+"""Integration: subject_health_cache is isolated per (tenant_id, subject_id).
+
+Proves tenant A cannot read, overwrite, or delete tenant B's cached health for
+the same subject_id — the cross-tenant leak fixed by migration 0024 (the cache
+used to be keyed by subject_id alone).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+
+from server.db import repositories as repo
+from server.db.tables import SubjectHealthCacheRow
+
+
+def _subject() -> str:
+    return f"health-iso-{uuid.uuid4().hex[:12]}"
+
+
+async def test_tenants_keep_separate_rows_for_same_subject(session_factory):
+    subject = _subject()
+    async with session_factory() as s:
+        await repo.upsert_health_cache(s, subject, "at_risk", 30, tenant_id="tenant-a")
+        await repo.upsert_health_cache(s, subject, "healthy", 95, tenant_id="tenant-b")
+        await s.commit()
+
+    async with session_factory() as s:
+        a = await repo.get_health_cache(s, subject, tenant_id="tenant-a")
+        b = await repo.get_health_cache(s, subject, tenant_id="tenant-b")
+
+    assert a is not None and a.last_state == "at_risk" and a.last_score == 30
+    assert b is not None and b.last_state == "healthy" and b.last_score == 95
+    assert a.id != b.id  # two distinct rows for the same subject_id
+
+
+async def test_upsert_does_not_overwrite_other_tenant(session_factory):
+    subject = _subject()
+    async with session_factory() as s:
+        await repo.upsert_health_cache(s, subject, "at_risk", 30, tenant_id="tenant-a")
+        await s.commit()
+    # Tenant B writes the same subject_id — must NOT touch tenant A's row.
+    async with session_factory() as s:
+        await repo.upsert_health_cache(s, subject, "healthy", 99, tenant_id="tenant-b")
+        await s.commit()
+
+    async with session_factory() as s:
+        a = await repo.get_health_cache(s, subject, tenant_id="tenant-a")
+
+    assert a is not None and a.last_state == "at_risk" and a.last_score == 30
+
+
+async def test_delete_is_tenant_scoped(session_factory):
+    subject = _subject()
+    async with session_factory() as s:
+        await repo.upsert_health_cache(s, subject, "at_risk", 30, tenant_id="tenant-a")
+        await repo.upsert_health_cache(s, subject, "healthy", 95, tenant_id="tenant-b")
+        await s.commit()
+
+    async with session_factory() as s:
+        await repo.delete_health_cache_by_subject(s, subject, tenant_id="tenant-a")
+        await s.commit()
+
+    async with session_factory() as s:
+        gone = await repo.get_health_cache(s, subject, tenant_id="tenant-a")
+        survived = await repo.get_health_cache(s, subject, tenant_id="tenant-b")
+
+    assert gone is None
+    assert survived is not None and survived.last_state == "healthy"
+
+
+async def test_repeated_upsert_same_tenant_updates_in_place(session_factory):
+    subject = _subject()
+    async with session_factory() as s:
+        await repo.upsert_health_cache(s, subject, "watch", 60, tenant_id="tenant-a")
+        await s.commit()
+    async with session_factory() as s:
+        await repo.upsert_health_cache(s, subject, "at_risk", 20, tenant_id="tenant-a")
+        await s.commit()
+
+    async with session_factory() as s:
+        rows = (
+            await s.execute(
+                select(SubjectHealthCacheRow).where(
+                    SubjectHealthCacheRow.subject_id == subject
+                )
+            )
+        ).scalars().all()
+
+    assert len(rows) == 1  # update in place, not a second row
+    assert rows[0].last_state == "at_risk" and rows[0].last_score == 20
+
+
+async def test_single_tenant_mode_still_works(session_factory):
+    subject = _subject()
+    async with session_factory() as s:
+        await repo.upsert_health_cache(s, subject, "healthy", 100)  # tenant_id=None
+        await s.commit()
+
+    async with session_factory() as s:
+        row = await repo.get_health_cache(s, subject)  # tenant_id=None
+
+    assert row is not None and row.last_state == "healthy" and row.last_score == 100

--- a/tests/test_health_cache_scoping.py
+++ b/tests/test_health_cache_scoping.py
@@ -1,0 +1,29 @@
+"""Unit guard: upsert_health_cache looks up the existing row scoped to the
+caller's tenant, so it can't find-and-overwrite another tenant's row for the
+same subject_id.
+
+Full SQL-level isolation (read/overwrite/delete across tenants) is proven
+against a real database in tests/integration/test_health_cache_isolation.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from server.db import repositories as repo
+
+
+async def test_upsert_scopes_existing_lookup_by_tenant():
+    with patch.object(repo, "get_health_cache", new=AsyncMock(return_value=None)) as mock_get:
+        session = AsyncMock()
+        await repo.upsert_health_cache(session, "user-1", "at_risk", 30, tenant_id="tenant-a")
+
+    mock_get.assert_awaited_once_with(session, "user-1", tenant_id="tenant-a")
+
+
+async def test_upsert_single_tenant_lookup_passes_none():
+    with patch.object(repo, "get_health_cache", new=AsyncMock(return_value=None)) as mock_get:
+        session = AsyncMock()
+        await repo.upsert_health_cache(session, "user-1", "healthy", 100)
+
+    mock_get.assert_awaited_once_with(session, "user-1", tenant_id=None)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 23
+    assert len(revs) == 24
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 13
+    assert result.pending_count == 14
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 23
+    assert result.pending_count == 24
 
 
 def test_resolve_pending_unknown_revision():

--- a/tests/test_tenant_scoping_invariant.py
+++ b/tests/test_tenant_scoping_invariant.py
@@ -20,15 +20,12 @@ _REPOSITORIES = (
     pathlib.Path(__file__).resolve().parents[1] / "server" / "db" / "repositories.py"
 )
 
-# Known, accepted exceptions. The subject-health cache is keyed by a bare
-# ``subject_id`` PRIMARY KEY (server/db/tables.py: SubjectHealthCacheRow), so
-# isolating it needs a composite-key schema migration, not a query filter — it
-# is tracked separately. Multi-tenancy is experimental and does not yet enforce
-# full isolation.
-_ALLOWED_UNSCOPED = {
-    "get_health_cache",
-    "delete_health_cache_by_subject",
-}
+# Known, accepted exceptions — currently none. (The subject-health cache gap
+# that originally seeded this list was fixed in #213: migration 0024 re-keyed
+# subject_health_cache to (tenant_id, subject_id) and scoped its queries.)
+# Do not add to this set to silence a new finding — add the tenant_id and apply
+# _tenant_filter instead.
+_ALLOWED_UNSCOPED: set[str] = set()
 
 
 def _subject_scoped_without_tenant() -> set[str]:


### PR DESCRIPTION
## What

Fixes the cross-tenant leak in `subject_health_cache` that the new tenant-scoping guard in #212 surfaced. (Separate PR by design — #212 stays focused on the guards.)

`subject_health_cache` used `subject_id` as its sole primary key (migration 0012), so in a multi-tenant deployment two tenants caching health for the same subject collided on one row: tenant B's upsert silently overwrote tenant A's state, and a read returned whichever tenant wrote last. Health state/score is tenant data — same isolation class as #206 / #207.

## How

- **Migration 0024** — swap the semantic single-column PK for a synthetic UUID `id`, keep a plain index on `subject_id`, and enforce identity with a composite **unique index on `(tenant_id, subject_id)` using `NULLS NOT DISTINCT`** (PG15+; we run PG16). This mirrors the `policy_bundles` per-tenant fix (migration 0019). Reversible.
- **Repository** — `get_health_cache` and `delete_health_cache_by_subject` now take `tenant_id` and apply `_tenant_filter`; `upsert_health_cache` scopes its existing-row lookup by tenant so it **inserts** its own row instead of finding-and-overwriting another tenant's. `EXPECTED_HEAD` bumped to `0024`.
- **Callers** — `health_alerts.check_and_alert` passes `tenant_id` to the lookup (admin call sites already passed it to upsert).

## Tests
- **Unit** (`test_health_cache_scoping.py`) — the upsert→lookup tenant contract.
- **Integration** (`test_health_cache_isolation.py`) — proves tenant A cannot **read**, **overwrite**, or **delete** tenant B's cache for the same `subject_id`, repeated upsert updates in place (no duplicate row), and single-tenant mode is unchanged.

## Local verification (against PostgreSQL 16)
- `alembic upgrade head` applies and `downgrade`/`upgrade` reverses cleanly; resulting schema has the `id` PK, `subject_id` index, and `(tenant_id, subject_id) NULLS NOT DISTINCT` unique index.
- 5/5 integration isolation tests pass on a real DB; full unit suite green against a freshly-migrated DB; `ruff` clean.

## Coordination with #212
This branch is cut from `main` and does **not** touch #212's `test_tenant_scoping_invariant.py` allowlist (that file isn't on `main` yet). Once **both** land, the two entries (`get_health_cache`, `delete_health_cache_by_subject`) must be removed from that allowlist — they're now scoped. #212's `test_allowlist_has_no_stale_entries` will fail until they're removed, so it can't be forgotten. Suggested order: merge #212 first, then I rebase this branch and drop the allowlist entries in the same PR before merge.
