### PR TITLE
fix(webhooks): persist tenant and dead-letter permanent 4xx

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -1937,6 +1937,7 @@ async def delete_subject_admin(
             "episodes_deleted": ep_count,
             "memories_deleted": mem_count,
         },
+        tenant_id=tenant_id,
     )
     return {
         "subject_id": subject_id,
@@ -2031,6 +2032,7 @@ async def commit_bulk_delete(req: BulkDeleteCommitRequest):
                         "episodes_deleted": ep_n,
                         "memories_deleted": mem_n,
                     },
+                    tenant_id=s.tenant_id,
                 )
             except Exception:
                 await session.rollback()

--- a/server/api/episodes.py
+++ b/server/api/episodes.py
@@ -43,7 +43,11 @@ async def create_episode(
     await repo.insert_episode(session, row)
     await session.commit()
     await session.refresh(row)
-    await webhooks.fire("episode.created", {"id": str(row.id), "subject_id": row.subject_id})
+    await webhooks.fire(
+        "episode.created",
+        {"id": str(row.id), "subject_id": row.subject_id},
+        tenant_id=tenant_id,
+    )
     return EpisodeResponse(
         id=row.id,
         subject_id=row.subject_id,
@@ -97,6 +101,7 @@ async def create_episodes_batch(
                 "count": len(rows),
                 "subject_ids": list({r.subject_id for r in rows}),
             },
+            tenant_id=tenant_id,
         )
         return BatchCreateEpisodesResponse(
             episodes_created=len(rows),

--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -110,6 +110,7 @@ async def _compile_one_batch(
             "subject_id": subject_id,
             "memories_created": len(new_rows),
         },
+        tenant_id=tenant_id,
     )
 
     remaining = await repo.count_uncompiled_episodes(

--- a/server/api/subjects.py
+++ b/server/api/subjects.py
@@ -49,6 +49,7 @@ async def delete_subject(
             "episodes_deleted": ep_count,
             "memories_deleted": mem_count,
         },
+        tenant_id=tenant_id,
     )
     return DeleteSubjectResponse(
         subject_id=subject_id,

--- a/server/api/templates.py
+++ b/server/api/templates.py
@@ -90,7 +90,11 @@ async def apply_memory_template(
     await repo.insert_episode(session, row)
     await session.commit()
     await session.refresh(row)
-    await webhooks.fire("episode.created", {"id": str(row.id), "subject_id": row.subject_id})
+    await webhooks.fire(
+        "episode.created",
+        {"id": str(row.id), "subject_id": row.subject_id},
+        tenant_id=tenant_id,
+    )
 
     return EpisodeResponse(
         id=row.id,

--- a/server/services/health_alerts.py
+++ b/server/services/health_alerts.py
@@ -77,5 +77,5 @@ async def check_and_alert(
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
 
-    await webhooks.fire(event, payload, db=session)
+    await webhooks.fire(event, payload, db=session, tenant_id=tenant_id)
     return event

--- a/server/services/webhooks.py
+++ b/server/services/webhooks.py
@@ -94,7 +94,11 @@ async def stop_worker() -> None:
 
 
 async def fire(
-    event: str, payload: dict[str, Any], db: AsyncSession | None = None
+    event: str,
+    payload: dict[str, Any],
+    db: AsyncSession | None = None,
+    *,
+    tenant_id: str | None = None,
 ) -> uuid.UUID | None:
     """Enqueue a webhook event for delivery.
 
@@ -119,6 +123,7 @@ async def fire(
 
     row = WebhookEventRow(
         id=event_id,
+        tenant_id=tenant_id,
         event=event,
         payload={
             "event": event,
@@ -211,12 +216,35 @@ async def _attempt_delivery(event: WebhookEventRow, session: AsyncSession) -> No
                 attempt=event.attempts,
                 status=resp.status_code,
             )
-        else:
+        elif _is_retryable_status(resp.status_code):
             _handle_failure(event, f"HTTP {resp.status_code}: {resp.text[:200]}")
+        else:
+            _handle_permanent_failure(
+                event, f"HTTP {resp.status_code}: {resp.text[:200]}"
+            )
 
     except Exception as exc:
         event.http_status = None
         _handle_failure(event, f"{type(exc).__name__}: {str(exc)[:200]}")
+
+
+def _is_retryable_status(status_code: int) -> bool:
+    """Return True when a later delivery attempt may reasonably succeed."""
+    return status_code in {408, 409, 425, 429} or status_code >= 500
+
+
+def _handle_permanent_failure(event: WebhookEventRow, error: str) -> None:
+    """Dead-letter non-retryable delivery failures immediately."""
+    event.last_error = error
+    event.status = "dead_letter"
+    event.next_attempt_at = None
+    logger.warning(
+        "webhook_permanent_failure",
+        event_id=str(event.id),
+        event_type=event.event,
+        attempts=event.attempts,
+        last_error=error,
+    )
 
 
 def _handle_failure(event: WebhookEventRow, error: str) -> None:

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -60,6 +61,25 @@ async def test_fire_uses_provided_session():
     mock_session.add.assert_called_once()
     # Should NOT commit — caller's responsibility
     mock_session.commit.assert_not_called()
+
+
+async def test_fire_persists_tenant_id_without_mutating_payload():
+    """Tenant-aware callers should get filterable queue rows without changing payload."""
+    webhooks.configure("http://example.com/hook")
+
+    payload = {"id": "123", "subject_id": "s1"}
+    mock_session = MagicMock()
+
+    event_id = await webhooks.fire(
+        "episode.created", payload, db=mock_session, tenant_id="tenant-a"
+    )
+
+    assert event_id is not None
+    mock_session.add.assert_called_once()
+    row = mock_session.add.call_args[0][0]
+    assert row.tenant_id == "tenant-a"
+    assert row.payload["data"] == payload
+    assert "tenant_id" not in row.payload["data"]
 
 
 def test_backoff_increases_exponentially():
@@ -173,3 +193,69 @@ def test_event_filter_accessor_reflects_configuration():
     # Reconfiguring without events clears the filter.
     webhooks.configure("http://example.com/hook")
     assert webhooks.event_filter() == frozenset()
+
+
+# ── Delivery failure classification ────────────────────────────────────────
+
+
+class _FakeAsyncClient:
+    def __init__(self, status_code: int):
+        self._status_code = status_code
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, json):
+        return SimpleNamespace(status_code=self._status_code, text="response body")
+
+
+def _webhook_row() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        event="episode.created",
+        payload={"event": "episode.created", "data": {"id": "123"}},
+        status="pending",
+        attempts=0,
+        max_attempts=5,
+        next_attempt_at=None,
+        last_attempt_at=None,
+        last_error=None,
+        http_status=None,
+        delivered_at=None,
+    )
+
+
+async def test_permanent_client_error_dead_letters_without_retry(monkeypatch):
+    """Permanent 4xx responses should not consume all retry attempts."""
+    webhooks.configure("http://example.com/hook")
+    row = _webhook_row()
+
+    monkeypatch.setattr("httpx.AsyncClient", lambda timeout: _FakeAsyncClient(400))
+
+    await webhooks._attempt_delivery(row, MagicMock())
+
+    assert row.attempts == 1
+    assert row.http_status == 400
+    assert row.status == "dead_letter"
+    assert row.next_attempt_at is None
+    assert "HTTP 400" in row.last_error
+
+
+async def test_retryable_client_error_still_schedules_retry(monkeypatch):
+    """Rate-limit style 4xx responses should keep the existing retry path."""
+    webhooks.configure("http://example.com/hook")
+    row = _webhook_row()
+
+    monkeypatch.setattr("httpx.AsyncClient", lambda timeout: _FakeAsyncClient(429))
+    monkeypatch.setattr(webhooks, "_backoff_seconds", lambda attempt: 30)
+
+    await webhooks._attempt_delivery(row, MagicMock())
+
+    assert row.attempts == 1
+    assert row.http_status == 429
+    assert row.status == "pending"
+    assert row.next_attempt_at is not None
+    assert "HTTP 429" in row.last_error


### PR DESCRIPTION
## Summary

- Persist `tenant_id` on queued webhook events when the emitting route already has tenant context.
- Thread tenant context through the existing webhook emitters for episodes, memory compilation, subject deletion, templates, admin deletes, and health alerts.
- Dead-letter permanent non-retryable HTTP 4xx webhook responses immediately while keeping retry behavior for `408`, `409`, `425`, `429`, and `5xx`.

## Before

`webhook_events.tenant_id` existed and the admin list/purge endpoints already accepted a `tenant_id` filter, but emitted webhook rows never populated that column. Operator views could therefore not reliably filter delivery history by tenant.

All non-2xx HTTP responses also used the retry path. Permanent client failures such as `400`, `401`, `403`, `404`, or `422` could consume every retry attempt even though a later delivery attempt would not succeed without operator configuration changes.

## After

`webhooks.fire()` accepts an optional `tenant_id` keyword and writes it to `WebhookEventRow.tenant_id` without mutating the webhook payload. Call sites pass the tenant value already in scope.

Delivery classification now treats `408`, `409`, `425`, `429`, and `5xx` as retryable. Other `4xx` responses become `dead_letter` immediately, preserving the error for operator debugging and avoiding retry churn.

## Impact

- Files: `server/services/webhooks.py`, webhook call sites in `server/api/*` and `server/services/health_alerts.py`, plus focused webhook tests.
- Breaking changes: no. The `tenant_id` parameter is optional, and the webhook payload shape is unchanged.
- Operational impact: tenant filters on webhook admin views become meaningful; permanent 4xx delivery failures surface faster.

## Test plan

- [x] New unit tests for tenant persistence, payload preservation, permanent 4xx dead-lettering, and retryable 429 behavior.
- [x] `H:\projet_contribuicao\statewave\.venv\Scripts\python.exe -m ruff check server\ tests\`
- [x] `H:\projet_contribuicao\statewave\.venv\Scripts\python.exe -m pytest tests\test_webhooks.py tests\test_health_alerts.py tests\test_compile_error_handling.py -q`
- [x] With Postgres running: `H:\projet_contribuicao\statewave\.venv\Scripts\python.exe -m pytest (Get-ChildItem tests -File -Filter 'test_*.py').FullName -q --basetemp H:\projet_contribuicao\pytest-tmp` — 696 passed, 5 skipped.
- [x] With Postgres running and stub embeddings: `H:\projet_contribuicao\statewave\.venv\Scripts\python.exe -m pytest tests\integration -q` — 220 passed; the existing local-only `test_semantic_search_returns_results` fails with the stub provider because no semantic embedding results are produced.
