### PR TITLE
feat(webhooks): optional tenant filter on event status + delivery stats

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -1749,15 +1749,20 @@ async def purge_webhook_events(
 
 
 @router.get("/webhooks/stats")
-async def webhook_stats():
-    """Aggregate webhook delivery statistics."""
-    return await webhooks.get_delivery_stats()
+async def webhook_stats(
+    tenant_id: str | None = Query(None, description="Filter by tenant"),
+):
+    """Aggregate webhook delivery statistics (optionally filtered by tenant)."""
+    return await webhooks.get_delivery_stats(tenant_id=tenant_id)
 
 
 @router.get("/webhooks/{event_id}")
-async def webhook_event_status(event_id: uuid.UUID):
-    """Get delivery status of a specific webhook event."""
-    result = await webhooks.get_event_status(event_id)
+async def webhook_event_status(
+    event_id: uuid.UUID,
+    tenant_id: str | None = Query(None, description="Filter by tenant"),
+):
+    """Get delivery status of a specific webhook event (optionally tenant-filtered)."""
+    result = await webhooks.get_event_status(event_id, tenant_id=tenant_id)
     if result is None:
         raise HTTPException(status_code=404, detail="Webhook event not found")
     return result

--- a/server/services/webhooks.py
+++ b/server/services/webhooks.py
@@ -276,11 +276,20 @@ def _handle_failure(event: WebhookEventRow, error: str) -> None:
 # ── Query helpers (for admin endpoints) ───────────────────────────────────
 
 
-async def get_event_status(event_id: uuid.UUID) -> dict[str, Any] | None:
-    """Get the delivery status of a single webhook event."""
+async def get_event_status(
+    event_id: uuid.UUID, *, tenant_id: str | None = None
+) -> dict[str, Any] | None:
+    """Get the delivery status of a single webhook event.
+
+    When ``tenant_id`` is provided, an event belonging to a different tenant is
+    reported as not-found, so the operator's optional tenant filter behaves
+    consistently with the list/purge endpoints.
+    """
     async with get_session_factory()() as session:
         row = await session.get(WebhookEventRow, event_id)
         if not row:
+            return None
+        if tenant_id is not None and row.tenant_id != tenant_id:
             return None
         return {
             "id": str(row.id),
@@ -297,8 +306,8 @@ async def get_event_status(event_id: uuid.UUID) -> dict[str, Any] | None:
         }
 
 
-async def get_delivery_stats() -> dict[str, Any]:
-    """Get aggregate webhook delivery statistics."""
+async def get_delivery_stats(*, tenant_id: str | None = None) -> dict[str, Any]:
+    """Get aggregate webhook delivery statistics, optionally scoped to a tenant."""
     from sqlalchemy import func as sqlfunc
 
     async with get_session_factory()() as session:
@@ -306,6 +315,8 @@ async def get_delivery_stats() -> dict[str, Any]:
             WebhookEventRow.status,
             sqlfunc.count(WebhookEventRow.id).label("count"),
         ).group_by(WebhookEventRow.status)
+        if tenant_id is not None:
+            stmt = stmt.where(WebhookEventRow.tenant_id == tenant_id)
         result = await session.execute(stmt)
         counts = {row.status: row.count for row in result}
 

--- a/tests/integration/test_webhook_status_tenant_filter.py
+++ b/tests/integration/test_webhook_status_tenant_filter.py
@@ -1,0 +1,74 @@
+"""Integration: optional tenant filter on the operator webhook read endpoints.
+
+The /admin/webhooks endpoints are operator-global; `list`/`purge` already accept
+an optional `tenant_id` filter, and these tests cover the same filter on
+`/admin/webhooks/stats` and `/admin/webhooks/{event_id}` (added so an operator
+can scope debugging to one tenant). Unique tenant ids keep the assertions
+independent of other rows in the shared test database.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from server.db.tables import WebhookEventRow
+
+
+def _tenant() -> str:
+    return f"wt-{uuid.uuid4().hex[:10]}"
+
+
+async def _seed(session_factory, tenant_a: str, tenant_b: str) -> WebhookEventRow:
+    """Two events for tenant_a (pending, delivered) and one for tenant_b
+    (dead_letter). Returns the tenant_a pending row."""
+    a_pending = WebhookEventRow(
+        tenant_id=tenant_a, event="episode.created", payload={"event": "x", "data": {}},
+        status="pending",
+    )
+    rows = [
+        a_pending,
+        WebhookEventRow(
+            tenant_id=tenant_a, event="episode.created", payload={"event": "x", "data": {}},
+            status="delivered",
+        ),
+        WebhookEventRow(
+            tenant_id=tenant_b, event="episode.created", payload={"event": "x", "data": {}},
+            status="dead_letter",
+        ),
+    ]
+    async with session_factory() as s:
+        s.add_all(rows)
+        await s.commit()
+        await s.refresh(a_pending)
+    return a_pending
+
+
+async def test_stats_filtered_by_tenant(client, session_factory):
+    tenant_a, tenant_b = _tenant(), _tenant()
+    await _seed(session_factory, tenant_a, tenant_b)
+
+    resp = await client.get("/admin/webhooks/stats", params={"tenant_id": tenant_a})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["pending"] == 1
+    assert body["delivered"] == 1
+    assert body["dead_letter"] == 0  # tenant_b's dead_letter must not leak in
+    assert body["total"] == 2
+
+
+async def test_event_status_tenant_filter(client, session_factory):
+    tenant_a, tenant_b = _tenant(), _tenant()
+    row = await _seed(session_factory, tenant_a, tenant_b)
+
+    # Matching tenant → found.
+    ok = await client.get(f"/admin/webhooks/{row.id}", params={"tenant_id": tenant_a})
+    assert ok.status_code == 200
+    assert ok.json()["id"] == str(row.id)
+
+    # Wrong tenant → not-found (consistent with the filter on list/purge).
+    miss = await client.get(f"/admin/webhooks/{row.id}", params={"tenant_id": tenant_b})
+    assert miss.status_code == 404
+
+    # No filter → operator global view still returns it.
+    glob = await client.get(f"/admin/webhooks/{row.id}")
+    assert glob.status_code == 200

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -259,3 +259,71 @@ async def test_retryable_client_error_still_schedules_retry(monkeypatch):
     assert row.status == "pending"
     assert row.next_attempt_at is not None
     assert "HTTP 429" in row.last_error
+
+
+# ── get_event_status tenant filter ─────────────────────────────────────────
+
+
+class _FakeGetSession:
+    """Async-context session whose .get() returns a fixed row."""
+
+    def __init__(self, row):
+        self._row = row
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, _model, _key):
+        return self._row
+
+
+def _status_row(tenant_id: str | None):
+    import datetime as _dt
+
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        event="episode.created",
+        status="pending",
+        attempts=0,
+        max_attempts=5,
+        last_attempt_at=None,
+        next_attempt_at=None,
+        last_error=None,
+        http_status=None,
+        created_at=_dt.datetime(2026, 6, 1, tzinfo=_dt.timezone.utc),
+        delivered_at=None,
+    )
+
+
+async def test_get_event_status_returns_event_for_matching_tenant():
+    row = _status_row("tenant-a")
+    with patch(
+        "server.services.webhooks.get_session_factory", return_value=lambda: _FakeGetSession(row)
+    ):
+        result = await webhooks.get_event_status(row.id, tenant_id="tenant-a")
+    assert result is not None and result["id"] == str(row.id)
+
+
+async def test_get_event_status_hides_event_from_other_tenant():
+    # A tenant filter that doesn't match the row's tenant must read as not-found,
+    # mirroring the list/purge filter semantics.
+    row = _status_row("tenant-a")
+    with patch(
+        "server.services.webhooks.get_session_factory", return_value=lambda: _FakeGetSession(row)
+    ):
+        result = await webhooks.get_event_status(row.id, tenant_id="tenant-b")
+    assert result is None
+
+
+async def test_get_event_status_without_tenant_filter_returns_event():
+    # No filter = operator global view (unchanged default behavior).
+    row = _status_row("tenant-a")
+    with patch(
+        "server.services.webhooks.get_session_factory", return_value=lambda: _FakeGetSession(row)
+    ):
+        result = await webhooks.get_event_status(row.id)
+    assert result is not None and result["id"] == str(row.id)


### PR DESCRIPTION
## What

Adds an **optional** `tenant_id` filter to the two operator webhook read endpoints that lacked it, for consistency with `list`/`purge` (which already have it). Follow-up to #214, which persists `tenant_id` on webhook events.

- `GET /admin/webhooks/{event_id}` → `get_event_status(event_id, tenant_id=...)` reports an event belonging to another tenant as **404** when the filter is set.
- `GET /admin/webhooks/stats` → `get_delivery_stats(tenant_id=...)` counts only that tenant's events.

Both default to the **unchanged operator-global view** when no `tenant_id` is supplied.

## Why this is a convenience filter, not an isolation fix

`/admin/*` is operator-gated by the single `STATEWAVE_API_KEY` (no per-tenant auth on admin routes), so these endpoints are intentionally operator-global. This change only makes per-tenant **debugging** symmetric across the webhook read endpoints — it is not a security boundary.

## Tests
- **Unit** (`test_webhooks.py`): `get_event_status` returns the event for a matching tenant, 404-equivalent (None) for a mismatched tenant, and the event when no filter is given.
- **Integration** (`test_webhook_status_tenant_filter.py`, real Postgres): `stats` counts only the filtered tenant (a second tenant's `dead_letter` doesn't leak in); the `{event_id}` route returns 200 for matching tenant, 404 for wrong tenant, 200 with no filter.

## Local verification
`ruff` clean; unit suite green; integration tests pass against a migrated Postgres.
