### PR TITLE
fix(subjects): reap resolutions and health-cache on subject delete

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -1930,6 +1930,8 @@ async def delete_subject_admin(
     async with engine_module.get_session_factory()() as session:
         ep_count = await repo.delete_episodes_by_subject(session, subject_id, tenant_id=tenant_id)
         mem_count = await repo.delete_memories_by_subject(session, subject_id, tenant_id=tenant_id)
+        await repo.delete_resolutions_by_subject(session, subject_id, tenant_id=tenant_id)
+        await repo.delete_health_cache_by_subject(session, subject_id, tenant_id=tenant_id)
         await session.commit()
 
     if ep_count == 0 and mem_count == 0:
@@ -2022,6 +2024,12 @@ async def commit_bulk_delete(req: BulkDeleteCommitRequest):
                     session, s.subject_id, tenant_id=s.tenant_id
                 )
                 mem_n = await repo.delete_memories_by_subject(
+                    session, s.subject_id, tenant_id=s.tenant_id
+                )
+                await repo.delete_resolutions_by_subject(
+                    session, s.subject_id, tenant_id=s.tenant_id
+                )
+                await repo.delete_health_cache_by_subject(
                     session, s.subject_id, tenant_id=s.tenant_id
                 )
                 await session.commit()

--- a/server/api/subjects.py
+++ b/server/api/subjects.py
@@ -41,6 +41,13 @@ async def delete_subject(
     """Permanently delete all episodes and memories for a subject. This is irreversible."""
     ep_count = await repo.delete_episodes_by_subject(session, subject_id, tenant_id=tenant_id)
     mem_count = await repo.delete_memories_by_subject(session, subject_id, tenant_id=tenant_id)
+    # "Permanently delete all subject data" must also reap the subject's
+    # resolutions and health-cache row — there is no FK cascade. Leaving them
+    # behind keeps open/resolved-session logic treating the deleted subject's
+    # sessions as live and lets a stale health-cache row suppress/forge alerts
+    # if the subject id is later reused.
+    await repo.delete_resolutions_by_subject(session, subject_id, tenant_id=tenant_id)
+    await repo.delete_health_cache_by_subject(session, subject_id, tenant_id=tenant_id)
     await session.commit()
     await webhooks.fire(
         "subject.deleted",

--- a/tests/integration/test_subject_delete_cleanup.py
+++ b/tests/integration/test_subject_delete_cleanup.py
@@ -1,0 +1,98 @@
+"""Regression: deleting a subject must also reap its resolutions and
+health-cache row.
+
+delete_subject only deleted episodes and memories; there is no FK cascade, and
+the existing delete_resolutions_by_subject / delete_health_cache_by_subject
+helpers were never wired in. The leftovers keep open/resolved-session logic
+treating the deleted subject's sessions as live, and a stale subject_health_cache
+row (PK = subject_id) can suppress or forge a health alert if the id is reused.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+
+from server.db import repositories as repo
+from server.db.tables import EpisodeRow, ResolutionRow, SubjectHealthCacheRow
+
+
+@pytest.mark.anyio
+async def test_delete_subject_reaps_resolutions_and_health_cache(
+    client: AsyncClient, subject_id: str, session_factory
+):
+    async with session_factory() as session:
+        session.add(
+            EpisodeRow(
+                id=uuid.uuid4(),
+                subject_id=subject_id,
+                source="test",
+                type="conversation",
+                payload={"text": "hi"},
+            )
+        )
+        session.add(
+            ResolutionRow(
+                id=uuid.uuid4(),
+                subject_id=subject_id,
+                session_id="s1",
+                status="resolved",
+                resolution_summary="done",
+            )
+        )
+        session.add(
+            SubjectHealthCacheRow(subject_id=subject_id, last_state="healthy", last_score=100)
+        )
+        await session.commit()
+
+    r = await client.delete(f"/v1/subjects/{subject_id}")
+    assert r.status_code == 200
+
+    async with session_factory() as session:
+        res_count = await session.scalar(
+            select(func.count())
+            .select_from(ResolutionRow)
+            .where(ResolutionRow.subject_id == subject_id)
+        )
+        hc_count = await session.scalar(
+            select(func.count())
+            .select_from(SubjectHealthCacheRow)
+            .where(SubjectHealthCacheRow.subject_id == subject_id)
+        )
+    assert res_count == 0, "resolutions must be deleted with the subject"
+    assert hc_count == 0, "health-cache row must be deleted with the subject"
+
+
+@pytest.mark.anyio
+async def test_delete_subject_health_cache_reap_is_tenant_scoped(
+    client: AsyncClient, session_factory
+):
+    """Reaping the health-cache on delete must stay within the caller's tenant.
+
+    delete_subject wired in delete_health_cache_by_subject WITHOUT threading
+    tenant_id. Post-migration-0024 that helper treats tenant_id=None as "match
+    every tenant", so deleting a subject under tenant B also wiped tenant A's
+    cached health for the same subject_id — re-opening the exact cross-tenant
+    leak migration 0024 just closed. delete_resolutions_by_subject is the same
+    shape and is already scoped correctly here.
+    """
+    subject = f"del-iso-{uuid.uuid4().hex[:12]}"
+    async with session_factory() as session:
+        await repo.upsert_health_cache(session, subject, "at_risk", 30, tenant_id="tenant-a")
+        await repo.upsert_health_cache(session, subject, "healthy", 95, tenant_id="tenant-b")
+        await session.commit()
+
+    r = await client.delete(f"/v1/subjects/{subject}", headers={"X-Tenant-ID": "tenant-b"})
+    assert r.status_code == 200
+
+    async with session_factory() as session:
+        gone = await repo.get_health_cache(session, subject, tenant_id="tenant-b")
+        survived = await repo.get_health_cache(session, subject, tenant_id="tenant-a")
+
+    assert gone is None, "tenant B's own health-cache row should be reaped"
+    assert survived is not None and survived.last_state == "at_risk", (
+        "tenant A's health-cache row must survive a tenant-B subject delete"
+    )


### PR DESCRIPTION
## Summary
- reap `resolutions` and `subject_health_cache` when deleting a subject through the public, admin, and bulk-admin delete paths
- keep both cleanup helpers tenant-scoped so deleting one tenant's subject data cannot remove another tenant's cache row for the same subject id
- add integration coverage for orphan cleanup and tenant-scoped health-cache cleanup on subject delete

## Tests
- `.venv\Scripts\python.exe -m ruff check server/api/subjects.py server/api/admin.py tests/integration/test_subject_delete_cleanup.py`
- `$env:PYTHONUTF8='1'; .venv\Scripts\python.exe -m pytest tests/test_no_raw_tokenization.py tests/test_tenant_scoping_invariant.py tests/test_health_cache_scoping.py tests/test_subjects.py -q -o cache_dir=G:\tmp\statewave-pytest-cache`

Integration note: `tests/integration/test_subject_delete_cleanup.py` could not be run locally because this environment has no Postgres/Docker service listening on `localhost:5432` for `statewave_test`.