### PR TITLE
fix(receipts): make cursor pagination key match the sort key

### DIFF
--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -726,10 +726,18 @@ async def list_receipts(
     individually addressable via `get_receipt_by_id` for forensic
     lookup of "a receipt with id X was emitted and later retired."
     """
+    # Order by the SAME key the cursor predicate uses (`receipt_id < cursor`
+    # below). The ULID receipt_id encodes creation time, so receipt_id-desc is
+    # newest-first as the docstring promises — and keyset pagination is only
+    # sound when ORDER BY and the cursor comparison agree. Ordering by
+    # created_at (a different clock: DB commit time vs the app-side ULID) while
+    # cursoring on receipt_id silently dropped or duplicated rows across pages
+    # whenever the two orderings disagreed (clock skew, multi-replica, or two
+    # receipts in the same millisecond). `since`/`until` still filter created_at.
     stmt = (
         select(ReceiptRow)
         .where(ReceiptRow.subject_id == subject_id)
-        .order_by(ReceiptRow.created_at.desc(), ReceiptRow.receipt_id.desc())
+        .order_by(ReceiptRow.receipt_id.desc())
         .limit(limit)
     )
     stmt = _tenant_filter(stmt, ReceiptRow.tenant_id, tenant_id)

--- a/tests/integration/test_receipts_pagination.py
+++ b/tests/integration/test_receipts_pagination.py
@@ -1,0 +1,75 @@
+"""Regression: cursor pagination over the receipts audit log must not drop or
+duplicate rows.
+
+list_receipts ordered by created_at but paginated with `receipt_id < cursor`.
+Keyset pagination is only sound when the ORDER BY and the cursor predicate use
+the same key; created_at (DB commit time) and receipt_id (app-side ULID) come
+from different clocks and can disagree (clock skew, multi-replica, same-ms
+inserts), silently skipping or re-showing receipts across pages — data loss in
+an append-only audit trail that compliance reviewers walk page by page.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from server.db import repositories as repo
+from server.db.tables import ReceiptRow
+
+
+@pytest.mark.anyio
+async def test_pagination_returns_every_receipt_exactly_once(session_factory, subject_id):
+    n = 5
+    base = dt.datetime(2020, 6, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+    # receipt_id increases lexically with i, but created_at DECREASES with i,
+    # so the created_at order and the receipt_id order maximally disagree.
+    # IDs are namespaced by the unique subject so they neither collide with the
+    # all-zeros "unknown id" probe other tests use nor leak across the shared
+    # session DB.
+    prefix = (subject_id.replace("-", "") + "0" * 24)[:24]
+    ids = [prefix + f"{i:02d}" for i in range(n)]
+    async with session_factory() as session:
+        for i, rid in enumerate(ids):
+            session.add(
+                ReceiptRow(
+                    receipt_id=rid,
+                    mode="retrieval",
+                    subject_id=subject_id,
+                    context_hash="0" * 64,
+                    context_size_bytes=0,
+                    body={},
+                    as_of=base,
+                    created_at=base - dt.timedelta(days=i),
+                    status="active",
+                )
+            )
+        await session.commit()
+
+    # Walk every page exactly as the API does (next_cursor = last receipt_id,
+    # stop when a page is under-full).
+    seen: list[str] = []
+    cursor: str | None = None
+    limit = 2
+    for _ in range(n + 3):  # safety bound against an infinite loop
+        async with session_factory() as session:
+            rows = await repo.list_receipts(
+                session, subject_id, tenant_id=None, limit=limit, cursor=cursor
+            )
+        if not rows:
+            break
+        seen.extend(r.receipt_id for r in rows)
+        if len(rows) < limit:
+            break
+        cursor = rows[-1].receipt_id
+
+    assert sorted(seen) == sorted(ids), "every receipt must be returned across pages"
+    assert len(seen) == len(set(seen)), "no receipt may be returned twice"
+
+    # Clean up this test's receipts from the shared session DB.
+    from sqlalchemy import delete
+
+    async with session_factory() as session:
+        await session.execute(delete(ReceiptRow).where(ReceiptRow.subject_id == subject_id))
+        await session.commit()


### PR DESCRIPTION
## Summary
- `list_receipts` ordered rows by `created_at DESC` but used `receipt_id < cursor` as the keyset-pagination predicate — two different clocks, so keyset pagination was unsound.
- Fix: order by `receipt_id DESC` so the sort key and the cursor key agree.
- `since`/`until` filters on `created_at` are preserved; only the ORDER BY changes.

## Before
`ORDER BY created_at DESC, receipt_id DESC` with `WHERE receipt_id < cursor`  
`created_at` (DB commit time) and `receipt_id` (app-side ULID) come from different clocks. Under clock skew, multi-replica inserts, or two receipts in the same millisecond the orderings can disagree, silently **dropping or duplicating rows** across pages — data loss in an append-only audit trail that compliance reviewers walk page-by-page.

## After
`ORDER BY receipt_id DESC` with `WHERE receipt_id < cursor`  
Sort key and cursor key are the same column. ULID receipt_ids encode creation time, so newest-first semantics are preserved. Keyset pagination is now sound regardless of `created_at` clock behaviour.

## Impact
- No schema change.
- No breaking change to the response shape or field names.
- Fixes silent audit-log corruption on paginated reads when created_at and receipt_id ordering disagrees.

## Test Plan
- New integration test `tests/integration/test_receipts_pagination.py::test_pagination_returns_every_receipt_exactly_once` seeds receipts where `receipt_id` order and `created_at` order are intentionally reversed (maximum disagreement). With the old `ORDER BY created_at`, the test would drop or duplicate rows across pages. With the fix it covers every receipt exactly once.