### PR TITLE
fix(snapshots): preserve occurred_at and reap copied resolutions on delete

### DIFF
--- a/server/services/snapshots.py
+++ b/server/services/snapshots.py
@@ -115,6 +115,7 @@ async def create_snapshot(
                     metadata_=ep.metadata_,
                     session_id=ep.session_id,
                     provenance={**(ep.provenance or {}), "original_id": str(ep.id)},
+                    occurred_at=ep.occurred_at,
                     created_at=ep.created_at,
                     last_compiled_at=ep.last_compiled_at,
                 )
@@ -468,9 +469,15 @@ async def delete_snapshot(snapshot_id: uuid.UUID) -> bool:
             return False
 
         source_subject = s.source_subject_id
-        # Delete source data
+        # Delete source data. create_snapshot copies resolutions into the
+        # snapshot-source subject too (see above), so they must be reaped here
+        # as well — otherwise every create/delete cycle orphans ResolutionRows
+        # under the deleted _snapshot/* subject, growing the table unbounded.
         await session.execute(delete(MemoryRow).where(MemoryRow.subject_id == source_subject))
         await session.execute(delete(EpisodeRow).where(EpisodeRow.subject_id == source_subject))
+        await session.execute(
+            delete(ResolutionRow).where(ResolutionRow.subject_id == source_subject)
+        )
         await session.execute(
             delete(SubjectSnapshotRow).where(SubjectSnapshotRow.id == snapshot_id)
         )

--- a/tests/integration/test_snapshots.py
+++ b/tests/integration/test_snapshots.py
@@ -420,3 +420,114 @@ async def test_cleanup_does_not_delete_snapshots(client: AsyncClient, subject_id
         r = await client.get("/admin/snapshots")
         snap_ids = [s["id"] for s in r.json()["snapshots"]]
         assert snap["id"] in snap_ids
+
+
+# ---------------------------------------------------------------------------
+# Snapshot data-integrity: occurred_at preservation + resolution cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_create_snapshot_preserves_occurred_at(client: AsyncClient, subject_id, session_factory):
+    """The snapshot-source episode must carry the original episode's
+    occurred_at, not the column server-default (now()). Otherwise a
+    backfilled history (occurred_at far in the past) collapses its real
+    timeline to snapshot-creation time on every snapshot round-trip."""
+    import datetime as dt
+
+    from sqlalchemy import select
+
+    from server.db.tables import EpisodeRow
+    from server.services.snapshots import SNAPSHOT_SOURCE_PREFIX, create_snapshot
+
+    expected = dt.datetime(2020, 1, 2, 3, 4, 5, tzinfo=dt.timezone.utc)
+    with patch("server.core.config.settings.enable_snapshots", True):
+        r = await client.post(
+            "/v1/episodes",
+            json={
+                "subject_id": subject_id,
+                "source": "test",
+                "type": "conversation",
+                "payload": {"text": "backfilled history"},
+                "occurred_at": expected.isoformat(),
+            },
+        )
+        assert r.status_code == 201
+
+        snap_name = f"occ-{uuid.uuid4().hex[:8]}"
+        await create_snapshot(name=snap_name, source_subject_id=subject_id)
+
+    snapshot_subject = f"{SNAPSHOT_SOURCE_PREFIX}{snap_name}/v1"
+    async with session_factory() as session:
+        rows = (
+            await session.execute(
+                select(EpisodeRow).where(EpisodeRow.subject_id == snapshot_subject)
+            )
+        ).scalars().all()
+    assert rows, "snapshot-source episode should exist"
+    assert all(row.occurred_at == expected for row in rows)
+
+
+@pytest.mark.anyio
+async def test_delete_snapshot_removes_copied_resolutions(
+    client: AsyncClient, subject_id, session_factory
+):
+    """delete_snapshot must reap the resolutions create_snapshot copied into
+    the snapshot-source subject, otherwise they orphan under the deleted
+    _snapshot/* subject and grow the table unbounded."""
+    from sqlalchemy import func, select
+
+    from server.db.tables import EpisodeRow, ResolutionRow
+    from server.services.snapshots import (
+        SNAPSHOT_SOURCE_PREFIX,
+        create_snapshot,
+        delete_snapshot,
+    )
+
+    async with session_factory() as session:
+        session.add(
+            EpisodeRow(
+                id=uuid.uuid4(),
+                subject_id=subject_id,
+                source="test",
+                type="conversation",
+                payload={"text": "hi"},
+            )
+        )
+        session.add(
+            ResolutionRow(
+                id=uuid.uuid4(),
+                subject_id=subject_id,
+                session_id="sess-1",
+                status="resolved",
+                resolution_summary="done",
+            )
+        )
+        await session.commit()
+
+    snapshot_subject = ""
+    with patch("server.core.config.settings.enable_snapshots", True):
+        snap_name = f"res-{uuid.uuid4().hex[:8]}"
+        snap = await create_snapshot(name=snap_name, source_subject_id=subject_id)
+        snapshot_subject = f"{SNAPSHOT_SOURCE_PREFIX}{snap_name}/v1"
+
+        async with session_factory() as session:
+            copied = await session.scalar(
+                select(func.count())
+                .select_from(ResolutionRow)
+                .where(ResolutionRow.subject_id == snapshot_subject)
+            )
+        assert copied == 1, "create_snapshot should copy the resolution into the source"
+
+        assert await delete_snapshot(uuid.UUID(snap["id"])) is True
+
+        listing = await client.get("/admin/snapshots")
+        assert snap["id"] not in [s["id"] for s in listing.json()["snapshots"]]
+
+    async with session_factory() as session:
+        remaining = await session.scalar(
+            select(func.count())
+            .select_from(ResolutionRow)
+            .where(ResolutionRow.subject_id == snapshot_subject)
+        )
+    assert remaining == 0


### PR DESCRIPTION
## Summary
- `create_snapshot` copied episodes into the snapshot-source subject but dropped `occurred_at`, collapsing a backfilled history to snapshot-creation time.
- `delete_snapshot` deleted memories and episodes from the snapshot-source subject but left behind the `ResolutionRow`s that `create_snapshot` had copied there, orphaning them on every create/delete cycle.

## Before
**`occurred_at` loss:** `create_snapshot` set all snapshot-source episode fields except `occurred_at`, so the column defaulted to `now()`. An episode with `occurred_at=2020-01-02` in the source subject would have `occurred_at=<snapshot time>` in the snapshot copy — silently corrupting timeline-based queries on any snapshot roundtrip.

**`ResolutionRow` leak:** `delete_snapshot` called `DELETE FROM memories WHERE subject_id = source` and `DELETE FROM episodes WHERE subject_id = source` but had no matching `DELETE FROM resolutions`. Because `create_snapshot` copies resolutions to the snapshot-source subject, every snapshot delete cycle left orphaned `ResolutionRow` records in the table, growing it unbounded.

## After
- `create_snapshot`: passes `occurred_at=ep.occurred_at` when building the snapshot-source episode row.
- `delete_snapshot`: adds `DELETE FROM resolutions WHERE subject_id = source_subject` alongside the existing memory/episode deletes.

## Impact
- No schema change.
- No breaking change to the API or response shape.
- Fixes silent timeline corruption on snapshot roundtrips and unbounded `resolutions` table growth.

## Test Plan
- `test_create_snapshot_preserves_occurred_at`: seeds an episode with `occurred_at=2020-01-02T03:04:05Z`, creates a snapshot, reads the snapshot-source subject's episodes and asserts `occurred_at` equals the original value.
- `test_delete_snapshot_removes_copied_resolutions`: creates memories that produce resolutions, creates a snapshot, deletes the snapshot, asserts zero `ResolutionRow`s remain under the snapshot-source subject.