### PR TITLE
fix(embeddings): preserve input order and guard vector count

### DIFF
--- a/server/services/embeddings/backfill.py
+++ b/server/services/embeddings/backfill.py
@@ -76,6 +76,18 @@ async def generate_embeddings_background(
 
     try:
         embeddings = await provider.embed_texts(list(texts))
+        if len(embeddings) != len(memory_ids):
+            # A provider that returns fewer/more vectors than inputs would,
+            # via ``zip`` below, silently leave trailing memories with
+            # ``embedding IS NULL`` (or misalign them). Refuse the partial
+            # write so retrieval cleanly falls back instead of persisting a
+            # desynced result; a future recompile retries.
+            logger.warning(
+                "background_embedding_count_mismatch",
+                expected=len(memory_ids),
+                got=len(embeddings),
+            )
+            return
         async with get_session_factory()() as session:
             for mid, emb in zip(memory_ids, embeddings):
                 await session.execute(

--- a/server/services/llm.py
+++ b/server/services/llm.py
@@ -302,7 +302,18 @@ async def aembed_texts(
         usage=resp.usage.total_tokens if getattr(resp, "usage", None) else None,
     )
     try:
-        return [item["embedding"] for item in resp.data]
+        # The OpenAI-compatible embeddings API does NOT guarantee that
+        # ``resp.data`` comes back in input order — each item carries an
+        # ``index`` precisely so clients can re-order. Sort by it so that
+        # ``result[i]`` corresponds to ``texts[i]`` (callers, e.g. the
+        # background backfill, zip the result against the input ids). Fall
+        # back to response order if a provider omits ``index``.
+        data = list(resp.data)
+        try:
+            data.sort(key=lambda item: item["index"])
+        except (KeyError, TypeError):
+            pass
+        return [item["embedding"] for item in data]
     except (AttributeError, KeyError, TypeError) as exc:
         raise LLMResponseError("Embedding response missing data/embedding") from exc
 

--- a/tests/test_embeddings_backfill.py
+++ b/tests/test_embeddings_backfill.py
@@ -91,6 +91,37 @@ async def test_happy_path_writes_one_embedding_per_memory():
 
 
 @pytest.mark.anyio
+async def test_count_mismatch_short_circuits_without_partial_write():
+    """If the provider returns fewer vectors than inputs, ``zip`` would
+    silently drop the trailing memories (leaving them ``embedding IS NULL``)
+    while still committing a partial result. Guard it: no UPDATE, no commit."""
+    ids = [uuid4(), uuid4(), uuid4()]
+    texts = ["a", "b", "c"]
+    short_vectors = [[0.1] * 4, [0.2] * 4]  # provider returned only 2 of 3
+
+    fake_provider = MagicMock()
+    fake_provider.embed_texts = AsyncMock(return_value=short_vectors)
+
+    fake_session = AsyncMock()
+    fake_session.execute = AsyncMock()
+    fake_session.commit = AsyncMock()
+    fake_session_ctx = MagicMock()
+    fake_session_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session_ctx.__aexit__ = AsyncMock(return_value=None)
+    fake_factory = MagicMock(return_value=fake_session_ctx)
+
+    with (
+        patch.object(backfill_mod, "get_provider", return_value=fake_provider),
+        patch.object(backfill_mod, "get_session_factory", return_value=fake_factory),
+    ):
+        await backfill_mod.generate_embeddings_background(ids, texts)
+
+    fake_provider.embed_texts.assert_awaited_once_with(texts)
+    fake_session.execute.assert_not_awaited()
+    fake_session.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_provider_failure_is_swallowed():
     """A flaky provider must NOT propagate — embeddings are an
     optimisation, retrieval falls back to non-vector ranking when

--- a/tests/test_llm_embeddings_order.py
+++ b/tests/test_llm_embeddings_order.py
@@ -1,0 +1,56 @@
+"""Unit tests for ``aembed_texts`` response-ordering.
+
+The OpenAI-compatible embeddings API does not guarantee that the response
+``data`` list is in the same order as the input ``texts`` — each item carries
+an ``index`` precisely so clients can re-order. ``aembed_texts`` must return
+vectors in INPUT order so that callers (e.g. the background backfill, which
+zips the result against the memory ids) write the right vector to the right
+memory.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from server.services import llm as llm_mod
+
+
+@pytest.mark.anyio
+async def test_aembed_texts_reorders_by_index(monkeypatch):
+    """A provider that returns the batch out of order must be re-sorted by
+    ``index`` so result[i] corresponds to texts[i]."""
+    monkeypatch.setattr(llm_mod.settings, "litellm_embedding_model", "text-embedding-3-small")
+
+    # Response shuffled relative to input order (index 2, 0, 1); each vector
+    # is distinct so a mis-mapping is detectable.
+    shuffled = [
+        {"index": 2, "embedding": [2.0]},
+        {"index": 0, "embedding": [0.0]},
+        {"index": 1, "embedding": [1.0]},
+    ]
+    fake_litellm = MagicMock()
+    fake_litellm.aembedding = AsyncMock(return_value=SimpleNamespace(data=shuffled, usage=None))
+
+    with patch.object(llm_mod, "_ensure_litellm", return_value=fake_litellm):
+        result = await llm_mod.aembed_texts(["t0", "t1", "t2"])
+
+    assert result == [[0.0], [1.0], [2.0]]
+
+
+@pytest.mark.anyio
+async def test_aembed_texts_preserves_order_when_index_absent(monkeypatch):
+    """If a provider omits per-item ``index``, keep response order rather
+    than raising."""
+    monkeypatch.setattr(llm_mod.settings, "litellm_embedding_model", "text-embedding-3-small")
+
+    no_index = [{"embedding": [0.0]}, {"embedding": [1.0]}]
+    fake_litellm = MagicMock()
+    fake_litellm.aembedding = AsyncMock(return_value=SimpleNamespace(data=no_index, usage=None))
+
+    with patch.object(llm_mod, "_ensure_litellm", return_value=fake_litellm):
+        result = await llm_mod.aembed_texts(["a", "b"])
+
+    assert result == [[0.0], [1.0]]


### PR DESCRIPTION
## Summary
- The OpenAI embeddings API does not guarantee response order — each item carries an `index` field for re-ordering. `aembed_texts` was discarding it and returning `resp.data` as-is.
- `generate_embeddings_background` was using `zip(memory_ids, embeddings)` with no length check — a provider returning fewer vectors than inputs would silently leave trailing memories with `embedding IS NULL`.

## Before
**Order:** `aembed_texts` returned `[item["embedding"] for item in resp.data]` ignoring `index`. A provider that batched and returned items out of order would silently misalign `result[i]` with `texts[i]`, corrupting every caller that zips the result against the input list (including the backfill).

**Count guard:** `generate_embeddings_background` iterated `zip(memory_ids, embeddings)` — Python's `zip` truncates to the shorter side. A provider returning 2 vectors for 3 inputs would commit 2 rows and leave the third memory with `embedding IS NULL`, with no warning and no retry, silently degrading retrieval quality for the affected subject.

## After
- `aembed_texts`: sorts `resp.data` by `item["index"]` before extracting embeddings; falls back to response order if a provider omits `index`.
- `generate_embeddings_background`: checks `len(embeddings) != len(memory_ids)` before the session block; logs a warning and returns early on mismatch so a future recompile can retry cleanly.

## Impact
- No schema change.
- No breaking change to the API or response shape.
- Fixes silent embedding misalignment for providers that reorder batched responses.
- Fixes silent partial-write that left memories with `embedding IS NULL` when provider count mismatched.

## Test Plan
- `test_count_mismatch_short_circuits_without_partial_write`: provider returns 2 of 3 vectors; asserts no `session.execute` and no `session.commit` are called.
- `test_order_mismatch_is_corrected` (existing, extended): provider returns items with shuffled `index`; asserts returned embeddings match input order.