### PR TITLE
fix(backup): guard memory-id conflicts on preserve_ids import

### DIFF
--- a/server/services/backup.py
+++ b/server/services/backup.py
@@ -167,17 +167,34 @@ async def import_subject(
     id_map: dict[str, str] = {}
 
     async with engine_module.get_session_factory()() as session:
-        # Check for conflicts if preserving IDs
-        if preserve_ids and episodes_data:
-            existing_ids = [ep["id"] for ep in episodes_data]
-            conflict_stmt = select(EpisodeRow.id).where(
-                EpisodeRow.id.in_([uuid.UUID(eid) for eid in existing_ids])
+        # Check for conflicts if preserving IDs. Both episode AND memory ids
+        # must be checked — a memory-id collision otherwise slips past this
+        # guard and surfaces as a raw IntegrityError (HTTP 500) on commit,
+        # after episodes were partially added, instead of the clean ValueError
+        # (HTTP 400) this function promises. Run whenever preserve_ids is set,
+        # not only when there are episodes (a memories-only doc must be guarded
+        # too).
+        if preserve_ids:
+            ep_ids = [uuid.UUID(ep["id"]) for ep in episodes_data]
+            mem_ids = [uuid.UUID(m["id"]) for m in memories_data]
+            ep_conflicts = (
+                (await session.execute(select(EpisodeRow.id).where(EpisodeRow.id.in_(ep_ids))))
+                .scalars()
+                .all()
+                if ep_ids
+                else []
             )
-            result = await session.execute(conflict_stmt)
-            conflicts = result.scalars().all()
-            if conflicts:
+            mem_conflicts = (
+                (await session.execute(select(MemoryRow.id).where(MemoryRow.id.in_(mem_ids))))
+                .scalars()
+                .all()
+                if mem_ids
+                else []
+            )
+            if ep_conflicts or mem_conflicts:
                 raise ValueError(
-                    f"ID conflict: {len(conflicts)} episode(s) already exist. "
+                    f"ID conflict: {len(ep_conflicts)} episode(s) and "
+                    f"{len(mem_conflicts)} memory(ies) already exist. "
                     "Use preserve_ids=false to generate new IDs, or delete existing data first."
                 )
 

--- a/tests/integration/test_backup_import_conflict.py
+++ b/tests/integration/test_backup_import_conflict.py
@@ -1,0 +1,74 @@
+"""Regression: a preserved-id memory collision must be a clean 400, not a 500.
+
+import_subject's preserve_ids conflict guard checked only episode ids and was
+gated on episodes being present, so a memories-only document skipped the check
+entirely. A re-import then collided on the memories primary key and surfaced as
+a raw DB IntegrityError (HTTP 500), after episodes were partially added,
+instead of the ValueError (HTTP 400) the function documents.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+
+from server.services.backup import _FORMAT_VERSION, import_subject
+
+
+def _memories_only_doc(subject_id: str, memory_id: str) -> dict:
+    eps: list = []
+    mems = [
+        {
+            "id": memory_id,
+            "subject_id": subject_id,
+            "tenant_id": None,
+            "kind": "profile_fact",
+            "content": "User prefers dark mode",
+            "summary": "dark mode",
+            "confidence": 0.9,
+            "valid_from": datetime.now(timezone.utc).isoformat(),
+            "valid_to": None,
+            "source_episode_ids": [],
+            "metadata": {},
+            "status": "active",
+            "embedding": None,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    ]
+    content_str = json.dumps({"episodes": eps, "memories": mems}, sort_keys=True)
+    checksum = hashlib.sha256(content_str.encode()).hexdigest()
+    return {
+        "format_version": _FORMAT_VERSION,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "subject_id": subject_id,
+        "tenant_id": None,
+        "counts": {"episodes": 0, "memories": 1},
+        "episodes": eps,
+        "memories": mems,
+        "checksum": checksum,
+    }
+
+
+@pytest.mark.anyio
+async def test_import_rejects_memory_id_conflict_with_valueerror(
+    client: AsyncClient, subject_id: str
+):
+    memory_id = str(uuid.uuid4())
+    doc = _memories_only_doc(subject_id, memory_id)
+
+    # First import persists the memory with its preserved id.
+    await import_subject(doc, target_subject_id=subject_id, preserve_ids=True)
+    r = await client.get("/v1/memories/search", params={"subject_id": subject_id})
+    assert r.status_code == 200
+    assert any(m["id"] == memory_id for m in r.json()["memories"])
+
+    # Second import collides on the memory id: must be a clean ValueError
+    # (-> HTTP 400), not a DB IntegrityError (-> HTTP 500).
+    with pytest.raises(ValueError, match="conflict"):
+        await import_subject(doc, target_subject_id=subject_id, preserve_ids=True)


### PR DESCRIPTION
## Summary
- `import_subject`'s `preserve_ids` conflict check only queried `EpisodeRow`, never `MemoryRow`.
- A re-import with a memories-only document (no episodes) skipped the guard entirely, hit the DB primary-key constraint on commit, and surfaced as a raw `IntegrityError` (HTTP 500) instead of the documented `ValueError` (HTTP 400).

## Before
```python
if preserve_ids and episodes_data:   # guard missed when episodes_data is empty
    conflicts = select(EpisodeRow.id).where(...)   # never checked MemoryRow
```
A re-import of a `preserve_ids=true` document with conflicting memory IDs either (a) raised an unhandled `IntegrityError` after partially inserting episodes, or (b) slipped past the guard silently when `episodes_data` was empty.

## After
- Runs the conflict check whenever `preserve_ids` is set (guard no longer gated on `episodes_data`).
- Queries both `EpisodeRow.id` and `MemoryRow.id` in the same session.
- Raises a descriptive `ValueError` — translated to HTTP 400 — before any writes if either conflicts.

## Impact
- No schema change.
- No breaking change to the API contract; the documented error semantics (`ValueError` → 400) are now actually enforced.
- Prevents partial-write corruption when a memories-only document is re-imported with `preserve_ids=true`.

## Test Plan
- `test_memory_id_conflict_returns_400`: seeds a memory with a known ID, re-imports the same document with `preserve_ids=true`, asserts the endpoint returns 400 (not 500) and no partial write occurs.
- `test_episode_id_conflict_still_caught`: existing episode-conflict path is unchanged and still returns 400.