### PR TITLE
fix(auth): use hmac.compare_digest for API key comparison

### DIFF
--- a/server/core/auth.py
+++ b/server/core/auth.py
@@ -9,6 +9,8 @@ When STATEWAVE_API_KEY is unset/empty, authentication is disabled
 
 from __future__ import annotations
 
+import hmac
+
 import structlog
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
@@ -45,7 +47,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 },
             )
 
-        if provided != self._api_key:
+        if not hmac.compare_digest(provided.encode(), self._api_key.encode()):
             logger.warning("auth_failed", path=request.url.path)
             return JSONResponse(
                 status_code=403,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -59,6 +59,17 @@ async def test_auth_correct_key(auth_app):
     assert r.status_code == 200
 
 
+async def test_auth_same_length_wrong_key(auth_app):
+    # Behavioral parity guard for the constant-time comparison: a wrong key of
+    # the SAME length as the secret must still be rejected with 403. The
+    # existing wrong-key test uses a shorter value; this one exercises the
+    # equal-length path that hmac.compare_digest is specifically used for.
+    wrong = "x" * len("test-secret-key")
+    async with AsyncClient(transport=ASGITransport(app=auth_app), base_url="http://test") as c:
+        r = await c.get("/test", headers={"X-API-Key": wrong})
+    assert r.status_code == 403
+
+
 async def test_auth_query_param(auth_app):
     async with AsyncClient(transport=ASGITransport(app=auth_app), base_url="http://test") as c:
         r = await c.get("/test?api_key=test-secret-key")


### PR DESCRIPTION
## Summary
- Replace `provided != self._api_key` with `hmac.compare_digest(provided.encode(), self._api_key.encode())` in `APIKeyMiddleware`.
- `!=` on strings short-circuits on the first differing byte, leaking key length and content via timing. `hmac.compare_digest` runs in constant time regardless of where the strings diverge.

## Before
```python
if provided != self._api_key:
```
Python's `!=` operator on strings performs a byte-by-byte comparison and returns as soon as a mismatch is found. An attacker making many requests with different key prefixes can measure response times to narrow down the valid API key one character at a time (timing side-channel).

## After
```python
if not hmac.compare_digest(provided.encode(), self._api_key.encode()):
```
`hmac.compare_digest` is implemented in constant time (in CPython it delegates to the C-level `_Py_normalize_encoding` loop that does not branch on content). It is the standard library function recommended by Python docs for secrets comparison.

## Impact
- No functional change for valid or invalid keys — only the timing profile changes.
- Eliminates the timing side-channel that could allow an offline attacker to enumerate valid API key characters via statistical analysis of response latency.
- No dependencies added (`hmac` is stdlib).

## Test Plan
- `test_auth_same_length_wrong_key`: a wrong key of the same length as the secret must return 403 — exercises the equal-length path that `hmac.compare_digest` is specifically designed to handle without leaking timing information.
- Existing `test_auth_*` suite (10 tests) continues to pass.