### PR TITLE
fix(admin): keep subject SLA error response shape consistent

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -655,7 +655,22 @@ async def get_subject_sla(
                 "sessions": getattr(sla_result, "sessions", []),
             }
     except Exception:
-        return {"total_sessions": 0, "resolved_sessions": 0, "open_sessions": 0, "sessions": []}
+        # Keep the response shape identical to the success branch — a typed
+        # admin client reading avg_*/breach_count fields would otherwise get
+        # missing keys on a transient failure while still seeing HTTP 200. Also
+        # log it: silently swallowing makes a real DB error indistinguishable
+        # from a genuinely empty subject on this operator-introspection endpoint.
+        logger.warning("subject_sla_failed", subject_id=subject_id, exc_info=True)
+        return {
+            "total_sessions": 0,
+            "resolved_sessions": 0,
+            "open_sessions": 0,
+            "avg_first_response_seconds": None,
+            "avg_resolution_seconds": None,
+            "first_response_breach_count": 0,
+            "resolution_breach_count": 0,
+            "sessions": [],
+        }
 
 
 @router.get("/subjects/{subject_id}/memories", response_model=MemoryListResponse)

--- a/tests/integration/test_admin_sla_error_shape.py
+++ b/tests/integration/test_admin_sla_error_shape.py
@@ -1,0 +1,43 @@
+"""Regression: GET /admin/subjects/{id}/sla must return the same response
+shape on its error path as on success.
+
+The bare-except fallback returned only 4 of the success branch's 8 keys (with
+HTTP 200), so a typed admin client reading avg_*/breach_count got missing keys
+on any transient DB error — and the failure was indistinguishable from a
+genuinely empty subject.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+_EXPECTED_KEYS = {
+    "total_sessions",
+    "resolved_sessions",
+    "open_sessions",
+    "avg_first_response_seconds",
+    "avg_resolution_seconds",
+    "first_response_breach_count",
+    "resolution_breach_count",
+    "sessions",
+}
+
+
+@pytest.mark.anyio
+async def test_sla_error_path_matches_success_shape(
+    client: AsyncClient, subject_id: str, monkeypatch
+):
+    # Success path (empty subject → all-zero metrics) carries the full shape.
+    r = await client.get(f"/admin/subjects/{subject_id}/sla")
+    assert r.status_code == 200
+    assert set(r.json().keys()) == _EXPECTED_KEYS
+
+    # Error path must carry the identical shape, not a truncated one.
+    async def boom(*args, **kwargs):
+        raise RuntimeError("db exploded")
+
+    monkeypatch.setattr("server.services.sla.compute_sla", boom)
+    r = await client.get(f"/admin/subjects/{subject_id}/sla")
+    assert r.status_code == 200
+    assert set(r.json().keys()) == _EXPECTED_KEYS


### PR DESCRIPTION
## Summary
- The `GET /admin/subjects/{id}/sla` error fallback returned only 4 of the 8 keys that the success branch returns (`total_sessions`, `resolved_sessions`, `open_sessions`, `sessions`).
- A typed admin client reading `avg_first_response_seconds`, `avg_resolution_seconds`, `first_response_breach_count`, or `resolution_breach_count` would receive missing keys on any transient error — while still getting HTTP 200.
- The failure was also swallowed silently, making a real DB error indistinguishable from a genuinely empty subject on this operator-introspection endpoint.

## Before
```python
except Exception:
    return {"total_sessions": 0, "resolved_sessions": 0, "open_sessions": 0, "sessions": []}
```
Four missing keys (`avg_*`, `breach_count`s) on the error path.

## After
```python
except Exception:
    logger.warning("subject_sla_failed", subject_id=subject_id, exc_info=True)
    return {
        "total_sessions": 0, "resolved_sessions": 0, "open_sessions": 0,
        "avg_first_response_seconds": None, "avg_resolution_seconds": None,
        "first_response_breach_count": 0, "resolution_breach_count": 0,
        "sessions": [],
    }
```
Full 8-key shape mirroring the success branch. Error is also logged with `exc_info=True`.

## Impact
- No schema change.
- No breaking change — the error path already returned HTTP 200; this only adds the missing keys.
- Prevents `KeyError` in typed admin clients reading SLA metrics during transient failures.
- Makes DB errors on this endpoint observable in logs.

## Test Plan
- `test_sla_error_path_matches_success_shape`: asserts the success-path response contains the full 8-key set; monkeypatches the SLA service to raise, asserts the error path returns the identical key set.