### PR TITLE
fix(admin): scope subject stats by tenant

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -329,9 +329,10 @@ async def list_subjects_admin(
         mem_stats = (
             select(
                 MemoryRow.subject_id,
+                MemoryRow.tenant_id,
                 func.count().label("memory_count"),
             )
-            .group_by(MemoryRow.subject_id)
+            .group_by(MemoryRow.subject_id, MemoryRow.tenant_id)
             .subquery()
         )
 
@@ -339,10 +340,11 @@ async def list_subjects_admin(
         session_stats = (
             select(
                 EpisodeRow.subject_id,
+                EpisodeRow.tenant_id,
                 func.count(func.distinct(EpisodeRow.session_id)).label("session_count"),
             )
             .where(EpisodeRow.session_id.isnot(None))
-            .group_by(EpisodeRow.subject_id)
+            .group_by(EpisodeRow.subject_id, EpisodeRow.tenant_id)
             .subquery()
         )
 
@@ -350,15 +352,26 @@ async def list_subjects_admin(
         open_sessions = (
             select(
                 ResolutionRow.subject_id,
+                ResolutionRow.tenant_id,
                 func.count().label("open_count"),
             )
             .where(ResolutionRow.status == "open")
-            .group_by(ResolutionRow.subject_id)
+            .group_by(ResolutionRow.subject_id, ResolutionRow.tenant_id)
             .subquery()
         )
 
         # Health cache
-        health_cache = select(SubjectHealthCacheRow).subquery()
+        health_cache = select(
+            SubjectHealthCacheRow.subject_id,
+            SubjectHealthCacheRow.tenant_id,
+            SubjectHealthCacheRow.last_state,
+            SubjectHealthCacheRow.last_score,
+        ).subquery()
+
+        def _same_subject_and_tenant(stats):
+            return (ep_stats.c.subject_id == stats.c.subject_id) & (
+                ep_stats.c.tenant_id.is_not_distinct_from(stats.c.tenant_id)
+            )
 
         # Main query joining all
         stmt = select(
@@ -372,10 +385,10 @@ async def list_subjects_admin(
             health_cache.c.last_score.label("health_score"),
             func.coalesce(open_sessions.c.open_count, 0).label("open_sessions"),
         ).select_from(
-            ep_stats.outerjoin(mem_stats, ep_stats.c.subject_id == mem_stats.c.subject_id)
-            .outerjoin(session_stats, ep_stats.c.subject_id == session_stats.c.subject_id)
-            .outerjoin(open_sessions, ep_stats.c.subject_id == open_sessions.c.subject_id)
-            .outerjoin(health_cache, ep_stats.c.subject_id == health_cache.c.subject_id)
+            ep_stats.outerjoin(mem_stats, _same_subject_and_tenant(mem_stats))
+            .outerjoin(session_stats, _same_subject_and_tenant(session_stats))
+            .outerjoin(open_sessions, _same_subject_and_tenant(open_sessions))
+            .outerjoin(health_cache, _same_subject_and_tenant(health_cache))
         )
 
         # Exclude internal subjects

--- a/tests/integration/test_admin_subject_tenant_stats.py
+++ b/tests/integration/test_admin_subject_tenant_stats.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from server.db.tables import EpisodeRow, MemoryRow, ResolutionRow, SubjectHealthCacheRow
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_admin_subject_stats_are_scoped_by_tenant(client: AsyncClient, session_factory):
+    subject_id = f"shared-admin-{uuid.uuid4().hex[:8]}"
+
+    async with session_factory() as session:
+        session.add_all(
+            [
+                EpisodeRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-a",
+                    session_id="a-session",
+                    source="test",
+                    type="message",
+                    payload={"text": "tenant a"},
+                    metadata_={},
+                    provenance={},
+                ),
+                EpisodeRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-b",
+                    session_id="b-session-1",
+                    source="test",
+                    type="message",
+                    payload={"text": "tenant b first"},
+                    metadata_={},
+                    provenance={},
+                ),
+                EpisodeRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-b",
+                    session_id="b-session-2",
+                    source="test",
+                    type="message",
+                    payload={"text": "tenant b second"},
+                    metadata_={},
+                    provenance={},
+                ),
+                MemoryRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-a",
+                    kind="fact",
+                    content="tenant a memory",
+                    summary="tenant a memory",
+                    confidence=1.0,
+                    source_episode_ids=[],
+                    metadata_={},
+                    status="active",
+                    sensitivity_labels=[],
+                    suggested_labels=[],
+                ),
+                MemoryRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-b",
+                    kind="fact",
+                    content="tenant b memory one",
+                    summary="tenant b memory one",
+                    confidence=1.0,
+                    source_episode_ids=[],
+                    metadata_={},
+                    status="active",
+                    sensitivity_labels=[],
+                    suggested_labels=[],
+                ),
+                MemoryRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-b",
+                    kind="fact",
+                    content="tenant b memory two",
+                    summary="tenant b memory two",
+                    confidence=1.0,
+                    source_episode_ids=[],
+                    metadata_={},
+                    status="active",
+                    sensitivity_labels=[],
+                    suggested_labels=[],
+                ),
+                ResolutionRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-b",
+                    session_id="b-session-1",
+                    status="open",
+                    metadata_={},
+                ),
+                SubjectHealthCacheRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-a",
+                    last_state="healthy",
+                    last_score=92,
+                ),
+                SubjectHealthCacheRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-b",
+                    last_state="critical",
+                    last_score=12,
+                ),
+            ]
+        )
+        await session.commit()
+
+    tenant_a = await client.get(
+        "/admin/subjects", params={"tenant_id": "tenant-a", "search": subject_id}
+    )
+    assert tenant_a.status_code == 200
+    tenant_a_body = tenant_a.json()
+    assert tenant_a_body["total"] == 1
+    tenant_a_subject = tenant_a_body["subjects"][0]
+    assert tenant_a_subject["episode_count"] == 1
+    assert tenant_a_subject["memory_count"] == 1
+    assert tenant_a_subject["session_count"] == 1
+    assert tenant_a_subject["open_sessions"] == 0
+    assert tenant_a_subject["health_state"] == "healthy"
+    assert tenant_a_subject["health_score"] == 92
+
+    tenant_b = await client.get(
+        "/admin/subjects", params={"tenant_id": "tenant-b", "search": subject_id}
+    )
+    assert tenant_b.status_code == 200
+    tenant_b_body = tenant_b.json()
+    assert tenant_b_body["total"] == 1
+    tenant_b_subject = tenant_b_body["subjects"][0]
+    assert tenant_b_subject["episode_count"] == 2
+    assert tenant_b_subject["memory_count"] == 2
+    assert tenant_b_subject["session_count"] == 2
+    assert tenant_b_subject["open_sessions"] == 1
+    assert tenant_b_subject["health_state"] == "critical"
+    assert tenant_b_subject["health_score"] == 12


### PR DESCRIPTION
## Summary
- `GET /admin/subjects` used `(tenant_id, subject_id)` as its base row, but joined memory/session/open-session/health-cache aggregates only by `subject_id`.
- When two tenants used the same `subject_id`, the admin explorer could show tenant A with tenant B's memory count, session count, open-session count, or cached health state.
- Group the aggregate subqueries by `(subject_id, tenant_id)` and join them with `IS NOT DISTINCT FROM` so tenant-scoped rows stay isolated while single-tenant `tenant_id=NULL` rows still match correctly.

## Impact
- No schema change.
- No response-shape change.
- Fixes cross-tenant metric leakage in the admin subject explorer for shared subject IDs.

## Test Plan
- `.venv\\Scripts\\python.exe -m ruff check server\\api\\admin.py tests\\integration\\test_admin_subject_tenant_stats.py`
- `.venv\\Scripts\\python.exe -m ruff format --check server\\api\\admin.py tests\\integration\\test_admin_subject_tenant_stats.py`
- `.venv\\Scripts\\python.exe -m py_compile server\\api\\admin.py tests\\integration\\test_admin_subject_tenant_stats.py`
- `.venv\\Scripts\\python.exe -m pytest tests\\test_tenant_scoping_invariant.py tests\\test_route_limits_invariant.py tests\\test_admin_dashboard.py -q`
- Targeted integration test was attempted locally, but Postgres `statewave_test` was unavailable on `localhost:5432`; Docker Desktop's Linux daemon was also not running, so local DB-backed execution could not be completed here.