### PR TITLE
fix(admin): match /admin/receipts cursor key to the sort key (follow-up to #223)

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2506,9 +2506,14 @@ async def admin_list_receipts(
         return datetime.fromisoformat(ts.replace("Z", "+00:00"))
 
     async with engine_module.get_session_factory()() as session:
+        # Order by the SAME key the cursor predicate uses (`receipt_id < cursor`
+        # below). The ULID receipt_id encodes creation time, so receipt_id-desc
+        # is newest-first; ordering by created_at (DB commit time) while
+        # cursoring on receipt_id silently drops/duplicates rows across pages
+        # (same keyset-pagination bug fixed for repo.list_receipts in #223).
         stmt = (
             select(ReceiptRow)
-            .order_by(ReceiptRow.created_at.desc(), ReceiptRow.receipt_id.desc())
+            .order_by(ReceiptRow.receipt_id.desc())
             .limit(limit)
         )
         if subject_id:

--- a/tests/integration/test_admin_receipts_pagination.py
+++ b/tests/integration/test_admin_receipts_pagination.py
@@ -1,0 +1,74 @@
+"""Regression: /admin/receipts cursor pagination must not drop or duplicate rows.
+
+admin_list_receipts ordered by created_at but paginated with `receipt_id < cursor`
+— the same keyset-pagination mismatch fixed for repo.list_receipts in #223, here
+on the operator audit endpoint that compliance reviewers walk page by page.
+created_at (DB commit time) and receipt_id (app-side ULID) come from different
+clocks, so ordering by one while cursoring on the other silently skips/re-shows
+receipts across pages.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from sqlalchemy import delete
+
+from server.db.tables import ReceiptRow
+
+
+@pytest.mark.anyio
+async def test_admin_receipts_pagination_returns_every_row_once(
+    client, session_factory, subject_id
+):
+    n = 5
+    base = dt.datetime(2020, 6, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+    # receipt_id increases lexically with i, but created_at DECREASES with i, so
+    # the two orderings maximally disagree. Namespaced by the unique subject so
+    # they don't collide with other tests sharing the session DB.
+    prefix = (subject_id.replace("-", "") + "0" * 24)[:24]
+    ids = [prefix + f"{i:02d}" for i in range(n)]
+    async with session_factory() as session:
+        for i, rid in enumerate(ids):
+            session.add(
+                ReceiptRow(
+                    receipt_id=rid,
+                    mode="retrieval",
+                    subject_id=subject_id,
+                    context_hash="0" * 64,
+                    context_size_bytes=0,
+                    body={"rid": rid},
+                    as_of=base,
+                    created_at=base - dt.timedelta(days=i),
+                    status="active",
+                )
+            )
+        await session.commit()
+
+    # Walk every page exactly as a client does: next_cursor = last receipt_id,
+    # stop when the server reports no further cursor.
+    seen: list[str] = []
+    cursor: str | None = None
+    limit = 2
+    for _ in range(n + 3):  # safety bound against an infinite loop
+        params = {"subject_id": subject_id, "limit": limit}
+        if cursor:
+            params["cursor"] = cursor
+        resp = await client.get("/admin/receipts", params=params)
+        assert resp.status_code == 200
+        data = resp.json()
+        page = data["receipts"]
+        if not page:
+            break
+        seen.extend(r["rid"] for r in page)
+        if data["next_cursor"] is None:
+            break
+        cursor = data["next_cursor"]
+
+    assert sorted(seen) == sorted(ids), "every receipt must be returned across pages"
+    assert len(seen) == len(set(seen)), "no receipt may be returned twice"
+
+    async with session_factory() as session:
+        await session.execute(delete(ReceiptRow).where(ReceiptRow.subject_id == subject_id))
+        await session.commit()


### PR DESCRIPTION
## What

Follow-up to #223. That PR fixed the keyset-pagination mismatch in `repo.list_receipts` (`/v1/receipts`); the operator audit endpoint `/admin/receipts` (`admin_list_receipts`) carried the **identical** bug in its own inline query and was out of #223's scope.

It ordered by `created_at DESC, receipt_id DESC` but paginated with `WHERE receipt_id < cursor`. `created_at` (DB commit time) and `receipt_id` (app-side ULID) come from different clocks, so the ORDER BY and the cursor predicate disagree — silently skipping or re-showing receipts across pages, in an append-only audit trail that compliance reviewers walk page by page.

## Fix
Order by `receipt_id DESC` alone, matching the cursor column (same fix as #223). One-line query change + comment.

## Test
`tests/integration/test_admin_receipts_pagination.py` seeds receipts whose `created_at` and `receipt_id` orderings maximally disagree, walks every page via the real `/admin/receipts` route, and asserts each receipt appears exactly once. Verified locally: **passes with the fix, fails without it.**
