### PR TITLE
fix(admin): scope session timeline metrics by tenant

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -1413,14 +1413,7 @@ async def get_session_timeline(
         episode_rows = result.scalars().all()
 
         # Get total count for this session
-        count_stmt = select(func.count()).select_from(
-            select(EpisodeRow)
-            .where(
-                EpisodeRow.subject_id == subject_id,
-                EpisodeRow.session_id == session_id,
-            )
-            .subquery()
-        )
+        count_stmt = select(func.count()).select_from(base.subquery())
         episode_count = await session.scalar(count_stmt) or 0
 
         # Get citing memory counts for all episode IDs in one query
@@ -1434,6 +1427,8 @@ async def get_session_timeline(
                     MemoryRow.subject_id == subject_id,
                     ep_id == any_(MemoryRow.source_episode_ids),
                 )
+                if tenant_id:
+                    count_q = count_q.where(MemoryRow.tenant_id == tenant_id)
                 citing_counts[str(ep_id)] = await session.scalar(count_q) or 0
 
         # Get resolution for this session
@@ -2511,11 +2506,7 @@ async def admin_list_receipts(
         # is newest-first; ordering by created_at (DB commit time) while
         # cursoring on receipt_id silently drops/duplicates rows across pages
         # (same keyset-pagination bug fixed for repo.list_receipts in #223).
-        stmt = (
-            select(ReceiptRow)
-            .order_by(ReceiptRow.receipt_id.desc())
-            .limit(limit)
-        )
+        stmt = select(ReceiptRow).order_by(ReceiptRow.receipt_id.desc()).limit(limit)
         if subject_id:
             stmt = stmt.where(ReceiptRow.subject_id == subject_id)
         if tenant_id:

--- a/tests/integration/test_admin_session_timeline_tenant_scope.py
+++ b/tests/integration/test_admin_session_timeline_tenant_scope.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from server.db.tables import EpisodeRow, MemoryRow
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_admin_session_timeline_metrics_are_scoped_by_tenant(
+    client: AsyncClient, session_factory
+):
+    subject_id = f"shared-timeline-{uuid.uuid4().hex[:8]}"
+    session_id = f"session-{uuid.uuid4().hex[:8]}"
+
+    async with session_factory() as session:
+        tenant_a_episode = EpisodeRow(
+            subject_id=subject_id,
+            tenant_id="tenant-a",
+            session_id=session_id,
+            source="test",
+            type="message",
+            payload={"text": "tenant a"},
+            metadata_={},
+            provenance={},
+        )
+        session.add(tenant_a_episode)
+        session.add_all(
+            [
+                EpisodeRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-b",
+                    session_id=session_id,
+                    source="test",
+                    type="message",
+                    payload={"text": "tenant b first"},
+                    metadata_={},
+                    provenance={},
+                ),
+                EpisodeRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-b",
+                    session_id=session_id,
+                    source="test",
+                    type="message",
+                    payload={"text": "tenant b second"},
+                    metadata_={},
+                    provenance={},
+                ),
+            ]
+        )
+        await session.flush()
+
+        session.add_all(
+            [
+                MemoryRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-a",
+                    kind="fact",
+                    content="tenant a memory",
+                    summary="tenant a memory",
+                    confidence=1.0,
+                    source_episode_ids=[tenant_a_episode.id],
+                    metadata_={},
+                    status="active",
+                    sensitivity_labels=[],
+                    suggested_labels=[],
+                ),
+                MemoryRow(
+                    subject_id=subject_id,
+                    tenant_id="tenant-b",
+                    kind="fact",
+                    content="tenant b imported memory",
+                    summary="tenant b imported memory",
+                    confidence=1.0,
+                    source_episode_ids=[tenant_a_episode.id],
+                    metadata_={},
+                    status="active",
+                    sensitivity_labels=[],
+                    suggested_labels=[],
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await client.get(
+        f"/admin/subjects/{subject_id}/sessions/{session_id}/timeline",
+        params={"tenant_id": "tenant-a"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["episode_count"] == 1
+    episode_events = [event for event in body["events"] if event["event_type"] == "episode"]
+    assert len(episode_events) == 1
+    assert episode_events[0]["citing_memory_count"] == 1


### PR DESCRIPTION
## Summary
- Scope `/admin/subjects/{subject_id}/sessions/{session_id}/timeline` `episode_count` to the same base query used for tenant-filtered episode rows.
- Scope per-episode `citing_memory_count` to `tenant_id` when the timeline request is tenant-filtered.
- Add an integration regression covering two tenants sharing the same subject/session ids, including a cross-tenant memory reference to prove the metric does not leak.

## Test plan
- `python -m ruff check server\api\admin.py tests\integration\test_admin_session_timeline_tenant_scope.py`
- `python -m ruff format --check server\api\admin.py tests\integration\test_admin_session_timeline_tenant_scope.py`
- `python -m py_compile server\api\admin.py tests\integration\test_admin_session_timeline_tenant_scope.py`
- `python -m pytest tests\test_tenant_scoping_invariant.py tests\test_route_limits_invariant.py tests\test_admin_dashboard.py -q`
- `STATEWAVE_EMBEDDING_PROVIDER=stub STATEWAVE_COMPILER_TYPE=heuristic PYTHONUTF8=1 python -m pytest tests -q --ignore=tests/integration --ignore=tests/smoke --ignore=tests/test_admin_subjects.py --ignore=tests/test_admin_clone.py --ignore=tests/test_memory_templates.py --ignore=tests/test_usage.py`

## Local integration note
- `python -m pytest tests\integration\test_admin_session_timeline_tenant_scope.py -q` was attempted, but this Windows environment has no running `statewave_test` Postgres on localhost:5432.
- `docker compose up -d db` was also attempted, but Docker Desktop's Linux daemon is not available on this machine.