### PR TITLE
release: v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _If Statewave is useful to you, a ⭐ on the repo helps others discover it._
 
 <!-- QUICKSTART GIF: docs/img/quickstart.gif landing in follow-up PR (issue #4) -->
 
-> **v0.9.2** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
+> **v1.0.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
 
 ## 🎯 Try it
 
@@ -283,7 +283,7 @@ pytest tests/ -v
 
 ## Current limitations
 
-Statewave is in active development (v0.9.2). Honest status:
+Statewave is in active development (v1.0.0). Honest status:
 
 - **Rate limiting is per-IP** — distributed (Postgres-backed), but keyed by IP only, not per-tenant or per-API-key yet
 - **Multi-tenant is app-layer** — query-scoped data isolation (v0.5) + per-tenant config / policy bundles / receipts (v0.8) + HMAC-signed audit + tenant region pin (v0.9), but no Postgres RLS yet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "statewave"
-version = "0.9.2"
+version = "1.0.0"
 description = "Open-source memory runtime for AI agents — durable, structured context with provenance."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Server bump to **v1.0.0** + propagated mechanical mirrors via `tools/bump-version.py`.

- `statewave/pyproject.toml` 0.9.2 → 1.0.0 (the server/reference-impl truth)
- README banner + limitations line mirrors

Validation (local, workspace root): `check-versions.py` exits 0, `check-proof-figures.py` exits 0.

Part of the coordinated v1.0 launch (server + both SDKs + docs all to 1.0.0).
