### PR TITLE
feat: generic claim-keyed conflict resolution and atomic structured memories

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,7 +85,7 @@ STATEWAVE_EMBEDDING_PROVIDER=stub
 # STATEWAVE_WEBHOOK_URL=
 # STATEWAVE_WEBHOOK_TIMEOUT=5.0
 
-# ── Multi-tenant (EXPERIMENTAL) ──────────────────────────────
+# ── Multi-tenant (app-layer isolation — see README limitations) ──
 # STATEWAVE_TENANT_HEADER=X-Tenant-ID
 # STATEWAVE_REQUIRE_TENANT=false
 
@@ -105,9 +105,8 @@ STATEWAVE_EMBEDDING_PROVIDER=stub
 # Missing kind = no expiry for that kind (forever).
 #
 # Soft-delete only — rows are kept for audit and future receipt lookup.
-# Per-subject / per-tenant / per-policy TTL is NOT supported here; that
-# layer lands with the policy engine (issue #50). See full operator
-# guide at: https://github.com/smaramwbc/statewave-docs/blob/main/deployment/memory-ttl.md
+# Per-subject / per-tenant / per-policy TTL is NOT supported here. See full
+# operator guide at: https://github.com/smaramwbc/statewave-docs/blob/main/deployment/memory-ttl.md
 #
 # Example:
 # STATEWAVE_KIND_TTL_DAYS={"episode_summary": 30, "artifact_ref": 90}

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -90,7 +90,7 @@ body:
         - OS: [e.g., macOS 14.0, Ubuntu 22.04]
         - Python version: [e.g., 3.11.4]
         - Node.js version: [if applicable]
-        - Statewave version: [e.g., 0.7.1]
+        - Statewave version: [e.g., 1.0.0]
         - SDK version: [if using SDK]
         - Deployment: [local, Docker, Fly.io, etc.]
     validations:

--- a/.github/ISSUE_TEMPLATE/operator_issue.yml
+++ b/.github/ISSUE_TEMPLATE/operator_issue.yml
@@ -86,7 +86,7 @@ body:
       label: Environment
       description: Provide your environment details
       placeholder: |
-        - Statewave version: [e.g., 0.7.1]
+        - Statewave version: [e.g., 1.0.0]
         - Docker version: [if applicable]
         - Database: [PostgreSQL version]
         - Cloud region: [if applicable]

--- a/.github/ISSUE_TEMPLATE/sdk_issue.yml
+++ b/.github/ISSUE_TEMPLATE/sdk_issue.yml
@@ -87,7 +87,7 @@ body:
       label: Environment
       description: Provide your environment details
       placeholder: |
-        - SDK version: [e.g., 0.7.1]
+        - SDK version: [e.g., 1.0.0]
         - Python/Node.js version:
         - OS:
     validations:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ implementation. For the big picture, see the
 
 The canonical steps live in
 [CONTRIBUTING.md](CONTRIBUTING.md#development-setup) and the
-[README quick start](README.md#quick-start) — don't duplicate them, follow
+[README Quickstart](README.md#quickstart) — don't duplicate them, follow
 them. In short:
 
 ```bash
@@ -68,7 +68,7 @@ add tests for behavior changes, and make sure `ruff` and `pytest` pass.
 
 This project dogfoods Statewave. The easiest way to give your assistant a
 queryable project brain for this repo is the **Statewave IDE Companion**
-extension for **VS Code / Cursor** (publisher `statewavedev`) — install it from
+extension for **VS Code / Cursor** (publisher `statewavedev`, available as a preview) — install it from
 your editor's extensions marketplace. It exposes your workspace, docs, git
 state, structure, and run-commands to Copilot / Cursor / Claude over MCP and
 **registers the MCP server for you** (no manual config); it just needs a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ of contributing to an Apache-2.0-licensed project.
 
 ## Development setup
 
-See the [Quick start](README.md#quick-start) section in the README for the
+See the [Quickstart](README.md#quickstart) section in the README for the
 canonical setup. In short:
 
 ```bash

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -55,7 +55,7 @@ walks through clone → run → store and retrieve your first memory in about 5 
 ## Pin a version
 
 ```sh
-STATEWAVE_VERSION=0.7.0 docker compose up -d
+STATEWAVE_VERSION=1.0.0 docker compose up -d
 ```
 
 ## Handling port conflicts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<!-- HERO GRAPHIC: docs/img/hero.png landing in follow-up PR (issue #4) -->
-
 # Statewave
 
 [![CI](https://github.com/smaramwbc/statewave/workflows/CI/badge.svg)](https://github.com/smaramwbc/statewave/actions/workflows/ci.yml)
@@ -11,8 +9,6 @@
 Statewave is the open-source memory runtime that gives AI agents reproducible, provenance-tagged context — without sampling-noise from query-time retrieval.
 
 _If Statewave is useful to you, a ⭐ on the repo helps others discover it._
-
-<!-- QUICKSTART GIF: docs/img/quickstart.gif landing in follow-up PR (issue #4) -->
 
 > **v1.0.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
 
@@ -260,7 +256,7 @@ All settings use the `STATEWAVE_` env prefix. Copy `.env.example` to `.env` to g
 | `STATEWAVE_WEBHOOK_EVENTS` | — | Comma-separated event-type allowlist (empty = deliver every event) |
 | `STATEWAVE_RECEIPT_SIGNING_KEYS` | — | JSON `{"<key_id>": "<base64>"}` map of HMAC keys for receipt signing (≥32 bytes each). Never persisted to the DB; per-tenant active key id set via `tenant_configs.config.receipt_signing_key_id`. |
 | `STATEWAVE_AUTO_LABELING_ENABLED` | `false` | Run heuristic detectors at compile time and stamp advisory `suggested_labels` on memories (v0.9). See [`docs/auto-labeling.md`](docs/auto-labeling.md). |
-| `STATEWAVE_AUTO_LABELING_PROVIDER` | `heuristic` | Detector provider. Only `heuristic` is valid in v0.9; the switch is reserved for future LLM-based classifiers. |
+| `STATEWAVE_AUTO_LABELING_PROVIDER` | `heuristic` | Detector provider. Only `heuristic` is currently supported (since v0.9); the switch is reserved for future LLM-based classifiers. |
 | `STATEWAVE_REGION` | — | Region this server process is running in. When set, requests for tenants pinned to a different region are refused with HTTP 403 `residency.mismatch` (v0.9). Empty = single-region mode, residency disabled. See [`docs/residency.md`](docs/residency.md). |
 | `STATEWAVE_TENANT_HEADER` | `X-Tenant-ID` | Header for multi-tenant isolation |
 | `STATEWAVE_REQUIRE_TENANT` | `false` | Reject requests without tenant header |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,6 +74,8 @@ This policy applies to all Statewave repositories:
 - `statewave-examples` - Examples
 - `statewave-web` - Marketing site + embedded demo
 - `statewave-admin` - Admin dashboard
+- `statewave-connectors` - Connector ecosystem (`@statewavedev/connectors-*` on npm)
+- `statewave-bench` - Benchmark tooling
 
 ## Contact
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   api:
     # Default to the published multi-arch image — `docker compose up -d` works
-    # without a local checkout. Pin a version with STATEWAVE_VERSION=0.7.0.
+    # without a local checkout. Pin a version with STATEWAVE_VERSION=1.0.0.
     # Contributors who want to rebuild locally: `docker compose build api`
     # rebuilds from the Dockerfile in this repo and tags the same name.
     image: statewavedev/statewave:${STATEWAVE_VERSION:-latest}

--- a/docs/auto-labeling.md
+++ b/docs/auto-labeling.md
@@ -30,7 +30,7 @@ existing tenants. To enable it process-wide:
 
 ```bash
 STATEWAVE_AUTO_LABELING_ENABLED=true
-STATEWAVE_AUTO_LABELING_PROVIDER=heuristic   # the only v0.9 provider
+STATEWAVE_AUTO_LABELING_PROVIDER=heuristic   # the only supported provider (introduced in v0.9)
 ```
 
 With the flag on, both compilers (`heuristic` and `llm`) run the
@@ -159,8 +159,8 @@ The promoted labels are:
 }
 ```
 
-`promoted_by` is `null` in v0.9 — no admin identity layer exists
-yet. The TODO is tracked at the field level so when admin identity
+`promoted_by` is `null` (v0.9+, still true in v1.0.0) — no admin
+identity layer exists yet. The TODO is tracked at the field level so when admin identity
 lands the column populates without an audit schema break. Time and
 what-was-promoted are captured today.
 
@@ -176,7 +176,7 @@ A 404 means the memory ID is unknown OR (with `tenant_id` set) belongs
 to a different tenant — the two cases are indistinguishable on the
 wire so a misconfigured caller cannot probe cross-tenant.
 
-## What auto-labeling does **NOT** do (v0.9)
+## What auto-labeling does **NOT** do (v0.9+)
 
 * **Does not refuse or filter retrieval.** The policy evaluator
   ignores `suggested_labels`.
@@ -200,7 +200,7 @@ and are load-bearing for the governance story.
 3. Append the dataclass to the `DETECTORS` tuple.
 4. Add positive + negative unit tests in
    `tests/test_auto_labeling.py` and update the registry assertion
-   if you intend the new label to be part of the v0.9 contract.
+   if you intend the new label to be part of the current contract.
 
 Detectors should bias toward **precision over recall**: a false
 positive is a noisy admin row; a flood of false positives undermines

--- a/docs/claim-resolution.md
+++ b/docs/claim-resolution.md
@@ -1,0 +1,131 @@
+# Claim-keyed conflict resolution
+
+Statewave resolves contradictory memories with a **hybrid** strategy. By
+default — no flag, no opt-in — it adds a wording-independent path on top of the
+existing lexical one. This page explains what claims are, how compilers emit
+them, and how the resolver uses them.
+
+> This is **not** comprehensive natural-language contradiction understanding.
+> It is a deliberately narrow, registry-gated mechanism for a small set of
+> single-valued attributes. When in doubt, Statewave omits the claim and falls
+> back to the original behavior.
+
+## Claims are optional compiler annotations
+
+A memory may carry an optional **claim envelope** under `metadata_.claim`
+describing *what* it asserts:
+
+```json
+{
+  "claim": {
+    "schema_version": 1,
+    "key": "employment.current_employer",
+    "value": "globex",
+    "scope": "single",
+    "source": "heuristic"
+  }
+}
+```
+
+It is purely additive: `metadata_` stays arbitrary JSONB, the claim rides inside
+it, and a memory without a claim behaves exactly as before. There is **no schema
+change, no migration, no backfill, and no required field**. A server upgrade
+does not reinterpret or rewrite any stored memory; old and unkeyed memories keep
+their legacy behavior, and supersession state only ever changes when a *new*
+compile runs the resolver.
+
+## The registry is authoritative
+
+The canonical key vocabulary and each key's **cardinality** live in one
+versioned registry (`server/services/claims.py`):
+
+| Cardinality | Keys | Behavior |
+|---|---|---|
+| `single` | `identity.name`, `employment.current_employer`, `location.current_home`, `billing.primary_payment_processor` | one current value wins |
+| `multi` | `tools.used`, `skills`, `preferences`, `payment.processors_used` | values coexist |
+
+A small set of **approved aliases** (`employer`/`works_at`/`company` →
+`employment.current_employer`, etc.) is normalized centrally. Anything else — an
+unknown key, an unapproved alias, an unsupported `schema_version`, or a malformed
+envelope — is **non-authoritative**: it never drives supersession. Cardinality
+is *never* taken from caller or model input; the registry decides.
+
+## Compilers omit claims when uncertain
+
+Compilers optimize for **near-zero wrongful claims**, not coverage. Omission is
+always preferred to guessing — the resolver is already safe when claims are
+absent.
+
+### Heuristic compiler (default, local, no LLM/GPU/credentials)
+
+Coverage is intentionally narrow — only three keys, and only from unambiguous
+present-tense first-person triggers:
+
+| Trigger | Key |
+|---|---|
+| `my name is …` | `identity.name` |
+| `i work at …` | `employment.current_employer` |
+| `i live in …` | `location.current_home` |
+
+Deliberately **rejected** (memory still emitted, no claim):
+
+- `i'm` / `i am` for names (`I am Bob's friend`), `i'm at` / `i am at` for
+  employer (`I'm at the gym`), `i'm from` / `i am from` for home (origin, not
+  current residence);
+- negation, uncertainty, and history markers (`not`, `might`, `used to`,
+  `previously`, `until`, …);
+- reported speech inside quotes;
+- generic tool usage — `I use Stripe` is **not** a
+  `billing.primary_payment_processor` claim;
+- the team/group and use/prefer/favorite patterns (no canonical single-valued
+  key).
+
+### LLM compiler
+
+The structured output schema gains an **optional** `claim` field. The model is
+**untrusted**: it may *propose* a key/value (and explicit temporal bounds), but
+Statewave then canonicalizes the key through the registry + approved aliases,
+stamps the registry-authoritative scope, normalizes the value, and **drops**
+anything it cannot confidently key. A malformed or unknown proposal never fails
+the rest of the compile and never persists in an authoritative form. The
+granular-extraction objective is unchanged — claims do not reduce or merge the
+memories the model would otherwise emit.
+
+## The resolver
+
+Structured claims activate the hybrid resolver (`server/services/conflicts.py`).
+For the active memories of a subject:
+
+- **Claim path** (authoritative, per canonical key, single-valued claims only):
+  same key + **different normalized value** + **overlapping validity** →
+  newest wins (supersede the older). Non-overlapping windows **coexist** as
+  history. The legacy path is told to skip these pairs so lexical overlap can
+  never undo the temporal/cardinality decision.
+- **Legacy path** (unchanged lexical Jaccard): everything else — unkeyed,
+  malformed, unknown-key, unsupported-version, multi-valued, mixed
+  keyed/unkeyed, and single-valued *same-value* duplicates.
+
+### Temporal and cardinality safeguards
+
+- **Cardinality**: `multi` keys never supersede (e.g. `I use Stripe` /
+  `I use PayPal` under `payment.processors_used` coexist). Only `single` keys
+  newest-win.
+- **Temporal**: a missing `valid_to` is open-ended; touching intervals do not
+  overlap, so *"Acme until 2020"* and *"Globex from 2020"* coexist — a current
+  fact never deletes a historical one.
+- **Determinism**: winner order is semantic `valid_from` (only when both claims
+  supply it) → `created_at` → stable memory id. Input and DB return order never
+  affect the result.
+
+## Known limitations (initial key set)
+
+- Only four single-valued keys are recognized; everything else is unkeyed and
+  uses legacy behavior. The set is intentionally minimal and may grow only with
+  evidence.
+- The heuristic compiler emits claims for three of those keys and never invents
+  temporal bounds; richer extraction is the LLM compiler's job.
+- Value comparison is normalized-string equality, not entity resolution
+  (`Acme` and `Acme Corp` are treated as different values).
+- `employment.current_employer` is for *current* employment; explicitly
+  historical statements are left unkeyed by the heuristic rather than forced
+  into a current-employer key.

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -106,7 +106,7 @@ machine-readable code is on `error.code`:
 | `error.code`                            | When                                                                 |
 |-----------------------------------------|----------------------------------------------------------------------|
 | `unreplayable.missing_policy_snapshot`  | Pre-v0.9 receipt. The column is NULL — no snapshot was captured.    |
-| `unreplayable.nested_replay`            | Receipt is itself a replay. v0.9 ships one level only.              |
+| `unreplayable.nested_replay`            | Receipt is itself a replay. Replay is single-level only (since v0.9). |
 | `unreplayable.invalid_snapshot`         | Snapshot YAML failed to parse. Tampering or corruption — see below. |
 
 Receipt-not-found returns plain 404 with the same wire shape as

--- a/docs/residency.md
+++ b/docs/residency.md
@@ -56,7 +56,7 @@ probing the residency boundary.
 - **No in-DB region column on every row.** That would conflate
   residency with multi-tenancy. Residency is per-tenant, not
   per-row.
-- **Total isolation** in v0.9. Cross-region admin reads are not
+- **Total isolation** (v0.9+). Cross-region admin reads are not
   allowed. Unified federated audit is a future feature, not implicit
   cross-region access — building it as an explicit separate surface
   later is safer than letting cross-region reads sneak in by default
@@ -118,7 +118,7 @@ auditor answer end-to-end:
 
 ## Ops runbook — spinning up a second region
 
-The v0.9 design ships **code + config model + ops runbook only**. No
+The residency layer (v0.9+) ships **code + config model + ops runbook only**. No
 second region is deployed by this PR; this section is the
 reproducible recipe for an operator standing one up.
 
@@ -197,12 +197,12 @@ reproducible recipe for an operator standing one up.
   v0.9 design decision is total isolation. The same middleware
   enforces both.
 
-## What residency does NOT do (v0.9)
+## What residency does NOT do (v0.9+)
 
 - **Does not move data.** Pinning a tenant assumes the data is
   already in the target region. The export/import + pin workflow
   is the operator's responsibility.
-- **Does not unify cross-region audit reads.** v0.9 ships total
+- **Does not unify cross-region audit reads.** Residency (v0.9+) ships total
   isolation. Federated audit search is a future feature, built as
   an explicit cross-region surface — never as implicit access.
 - **Does not deploy a second region.** This PR is code + config

--- a/docs/state-assembly-receipts.md
+++ b/docs/state-assembly-receipts.md
@@ -82,8 +82,9 @@ must_emit`. The inputs are consulted in this order:
    `tenant_configs.config`) — set in the admin dashboard. `always`
    overrides per-request `false`; `never` suppresses everything.
    Compliance-grade tenants flip this on once. Default `on_request`.
-3. **Per-policy force-on** (deferred until #50). v1 of this layer
-   returns "no opinion" so the call collapses to inputs 1 and 2.
+3. **Per-policy force-on** (reserved — not yet wired to the policy
+   engine; #50 shipped without it). The current implementation returns
+   "no opinion", so the call collapses to inputs 1 and 2.
 4. **Env kill-switch** (`STATEWAVE_RECEIPTS_DISABLED=true`) —
    emergency operational hygiene; not the everyday control.
 
@@ -236,11 +237,11 @@ assembly internals:
 - **Auto-labeling** ([#158](https://github.com/smaramwbc/statewave/issues/158)) — shipped v0.9. Heuristic detectors stamp advisory `suggested_labels` on memories; the policy evaluator never reads them. Operator review + promote via the admin app (#160). See [`docs/auto-labeling.md`](auto-labeling.md).
 - **Per-tenant residency** ([#161](https://github.com/smaramwbc/statewave/issues/161)) — shipped v0.9. `STATEWAVE_REGION` + `tenant_configs.config.region` enforced at the application layer. See [`docs/residency.md`](residency.md).
 
-## Still out of scope (v0.9)
+## Still out of scope (v0.9+, current as of v1.0.0)
 
 - Review-time redaction UI for receipts.
 - Cross-tenant receipt aggregation / fleet-wide audit views. Single-tenant audit ships; federated cross-region audit is an explicit future surface, not implicit access (see `docs/residency.md`).
-- KMS / Vault-backed signing (architecture is compatible — a future PR swaps the key resolver behind the same `receipt_signing_keys` settings field; v0.9 reads keys from env / secret-manager mount).
-- Asymmetric signatures (the `algorithm` field reserves space for `ed25519-canonical-v1` etc.; v0.9 ships HMAC only).
+- KMS / Vault-backed signing (architecture is compatible — a future PR swaps the key resolver behind the same `receipt_signing_keys` settings field; the current release reads keys from env / secret-manager mount).
+- Asymmetric signatures (the `algorithm` field reserves space for `ed25519-canonical-v1` etc.; the current release ships HMAC only).
 - Bulk re-signing of pre-v0.9 receipts (forward-only signing — they verify as `no_signature`).
-- Byte-for-byte historical replay (memory snapshots). v0.9 ships `current code + original policy`; the data model leaves room for memory snapshots without a schema break.
+- Byte-for-byte historical replay (memory snapshots). The current release ships `current code + original policy`; the data model leaves room for memory snapshots without a schema break.

--- a/helm/statewave/Chart.yaml
+++ b/helm/statewave/Chart.yaml
@@ -10,11 +10,11 @@ type: application
 
 # Chart version follows the chart's own lifecycle, not the API image's.
 # Bump this for any chart-template change.
-version: 0.1.0
+version: 0.2.0
 
 # appVersion tracks the Statewave API release this chart was validated
 # against. Operators can override the deployed image via image.tag.
-appVersion: "0.7.0"
+appVersion: "1.0.0"
 
 home: https://statewave.ai
 sources:

--- a/helm/statewave/README.md
+++ b/helm/statewave/README.md
@@ -115,7 +115,7 @@ At higher replica counts, put a transaction-mode PgBouncer in front of Postgres.
 ```bash
 helm upgrade statewave ./helm/statewave \
   --reuse-values \
-  --set image.tag=0.7.1
+  --set image.tag=1.0.0
 ```
 
 The pre-upgrade Job runs `alembic upgrade head` before the rollout begins. Rolling upgrades require backwards-compatible schemas across one version (the project's standard policy) — see the [migration runbook](https://github.com/smaramwbc/statewave-docs/blob/main/deployment/migrations.md).

--- a/helm/statewave/values.yaml
+++ b/helm/statewave/values.yaml
@@ -130,7 +130,7 @@ webhooks:
   timeoutSeconds: 5.0
 
 # ──────────────────────────────────────────────────
-# Multi-tenant (experimental)
+# Multi-tenant (app-layer isolation via X-Tenant-ID)
 # ──────────────────────────────────────────────────
 multiTenant:
   enabled: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 4 - Beta",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,14 @@ description = "Open-source memory runtime for AI agents — durable, structured 
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Intended Audience :: Developers",
+]
 dependencies = [
     "fastapi>=0.136.3,<1",
     "uvicorn[standard]>=0.49.0,<1",
@@ -34,6 +42,12 @@ otel = [
     "opentelemetry-sdk>=1.42.1,<2",
     "opentelemetry-exporter-otlp>=1.42.1,<2",
 ]
+
+[project.urls]
+Homepage = "https://statewave.ai"
+Repository = "https://github.com/smaramwbc/statewave"
+Issues = "https://github.com/smaramwbc/statewave/issues"
+Documentation = "https://github.com/smaramwbc/statewave-docs"
 
 [build-system]
 requires = ["hatchling"]

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -306,6 +306,41 @@ async def mark_memories_superseded(
     await session.execute(stmt)
 
 
+async def superseded_only_episode_ids(
+    session: AsyncSession,
+    subject_id: str,
+    *,
+    tenant_id: str | None = None,
+) -> set[uuid.UUID]:
+    """Episode IDs whose backing memories are ALL non-active.
+
+    Phase-1 leak fix: a correctly-superseded fact must not resurface verbatim
+    via its originating episode in the "Recent interactions" context section.
+    An episode that still backs at least one *active* memory — or that backs no
+    memory at all — is NOT returned (i.e. it is kept), so partially-superseded
+    and raw uncompiled episodes are preserved exactly as today. Only an episode
+    referenced solely by superseded/tombstoned memories is reported obsolete.
+
+    Pure, deterministic set logic over committed rows — no embeddings, no LLM,
+    stub-safe — so it suppresses leaks regardless of which compile batch
+    produced the supersession. Read-only.
+    """
+    stmt = select(MemoryRow.status, MemoryRow.source_episode_ids).where(
+        MemoryRow.subject_id == subject_id
+    )
+    stmt = _tenant_filter(stmt, MemoryRow.tenant_id, tenant_id)
+    result = await session.execute(stmt)
+
+    alive: set[uuid.UUID] = set()
+    dead: set[uuid.UUID] = set()
+    for status, episode_ids in result.all():
+        if not episode_ids:
+            continue
+        (alive if status == "active" else dead).update(episode_ids)
+    # Referenced only by non-active memories, never by an active one.
+    return dead - alive
+
+
 # ---------------------------------------------------------------------------
 # Semantic search
 # ---------------------------------------------------------------------------

--- a/server/services/claims.py
+++ b/server/services/claims.py
@@ -25,7 +25,9 @@ ingestion, compilation, retrieval, or serialization.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+import math
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
@@ -39,21 +41,49 @@ logger = structlog.stdlib.get_logger()
 # keys like ``starter_pack_id``; the llm compiler uses ``compiler``/``model``).
 CLAIM_METADATA_KEY = "claim"
 
-# Bumped only on a breaking envelope-shape change. Unknown/newer versions are
-# ignored (degrade to legacy), so an older reader never trips on future data.
+# Supported envelope schema versions.
+#   v1 — subject-relative claim: a single canonical key + scalar value (legacy).
+#   v2 — external-entity claim:  key + entity_key + canonical qualifier map +
+#        structured canonical value (issue #236 follow-up).
+# An UNSUPPORTED version degrades to legacy (never authoritative), so an older
+# reader never trips on future data. ``CLAIM_SCHEMA_VERSION`` stays 1 for the
+# v1 builder's stamp; v2 producers stamp 2 explicitly.
 CLAIM_SCHEMA_VERSION = 1
+_SUPPORTED_SCHEMA_VERSIONS = (1, 2)
 
 # Cardinality of a canonical claim key.
 SCOPE_SINGLE = "single"  # one current value wins (name, current employer, …)
 SCOPE_MULTI = "multi"  # values coexist (tools used, skills, preferences, …)
 
+# How a claim's value is canonicalized for equality (registry-declared).
+VALUE_STRING = "string"  # v1 scalar: lowercase/strip/collapse-ws
+VALUE_CANONICAL_JSON = "canonical_json"  # v2 structured: deterministic JSON
+
 
 @dataclass(frozen=True)
-class ClaimKeySpec:
-    """Authoritative spec for a registered canonical claim key."""
+class ClaimDefinition:
+    """Declarative, authoritative policy for one canonical claim key.
+
+    The resolver consumes definitions *generically* — it never special-cases a
+    domain. Cardinality, entity/qualifier requirements, and value normalization
+    all live here, so adding a new domain (pricing, ratings, …) is a registry
+    entry, not a resolver branch.
+    """
 
     key: str
-    scope: str  # SCOPE_SINGLE | SCOPE_MULTI
+    scope: str  # SCOPE_SINGLE | SCOPE_MULTI — authoritative cardinality
+    entity_required: bool = False
+    required_qualifiers: frozenset[str] = field(default_factory=frozenset)
+    optional_qualifiers: frozenset[str] = field(default_factory=frozenset)
+    value_normalization: str = VALUE_STRING
+
+    @property
+    def supports_v2(self) -> bool:
+        return self.value_normalization == VALUE_CANONICAL_JSON or self.entity_required
+
+
+# Back-compat alias: older imports referenced ClaimKeySpec.
+ClaimKeySpec = ClaimDefinition
 
 
 # --------------------------------------------------------------------------- #
@@ -78,9 +108,21 @@ _MULTI_VALUED_KEYS = (
     "payment.processors_used",
 )
 
-CLAIM_REGISTRY: dict[str, ClaimKeySpec] = {
-    **{k: ClaimKeySpec(k, SCOPE_SINGLE) for k in _SINGLE_VALUED_KEYS},
-    **{k: ClaimKeySpec(k, SCOPE_MULTI) for k in _MULTI_VALUED_KEYS},
+CLAIM_REGISTRY: dict[str, ClaimDefinition] = {
+    **{k: ClaimDefinition(k, SCOPE_SINGLE) for k in _SINGLE_VALUED_KEYS},
+    **{k: ClaimDefinition(k, SCOPE_MULTI) for k in _MULTI_VALUED_KEYS},
+    # v2 external-entity claim. Generic and reusable for ANY organization — the
+    # entity is identified by `entity_key`, never hard-coded. Currency and
+    # charge unit are part of IDENTITY (different currency = different fact), so
+    # they are required qualifiers, not value fields.
+    "pricing.processing_rate": ClaimDefinition(
+        key="pricing.processing_rate",
+        scope=SCOPE_SINGLE,
+        entity_required=True,
+        required_qualifiers=frozenset({"payment_method", "rate_type", "currency", "charge_unit"}),
+        optional_qualifiers=frozenset({"region", "customer_segment", "channel", "plan"}),
+        value_normalization=VALUE_CANONICAL_JSON,
+    ),
 }
 
 # Approved deterministic aliases → canonical key. Unknown aliases do NOT create
@@ -129,6 +171,102 @@ def normalize_value(value: Any) -> str | None:
     return norm or None
 
 
+# --------------------------------------------------------------------------- #
+# v2 canonicalization — entity, qualifiers, and structured value.
+# All deterministic and domain-agnostic. Any failure returns None so the claim
+# is simply non-authoritative (under-resolution), never raising.
+# --------------------------------------------------------------------------- #
+
+
+def canonical_entity_key(entity_key: Any) -> str | None:
+    """Normalize an entity key (e.g. ``organization:stripe``). Lowercased,
+    stripped, internal whitespace collapsed. Non-string/empty → None."""
+    return normalize_value(entity_key)
+
+
+def normalize_qualifiers(quals: Any, definition: ClaimDefinition) -> dict[str, str] | None:
+    """Validate + normalize the qualifier map into a clean dict.
+
+    Rules: keys/values normalized deterministically; object ordering irrelevant;
+    ALL required qualifiers must be present (missing → non-authoritative, NOT a
+    wildcard); unapproved qualifier keys are REJECTED (the documented safe
+    policy); only string scalar values are accepted."""
+    if not isinstance(quals, dict):
+        return None
+    allowed = definition.required_qualifiers | definition.optional_qualifiers
+    norm: dict[str, str] = {}
+    for k, v in quals.items():
+        if not isinstance(k, str):
+            return None
+        nk = normalize_value(k)
+        nv = normalize_value(v)
+        if nk is None or nv is None:
+            return None
+        if nk not in allowed:
+            return None  # unapproved qualifier → reject (safe policy)
+        if nk in norm:
+            return None  # duplicate after normalization → ambiguous
+        norm[nk] = nv
+    if not definition.required_qualifiers <= set(norm):
+        return None  # a required qualifier is missing → non-authoritative
+    return norm
+
+
+def canonical_qualifiers(quals: Any, definition: ClaimDefinition) -> str | None:
+    """Stable string identity for a qualifier map (sorted keys). Two different
+    qualifier maps canonicalize differently and never share a bucket."""
+    norm = normalize_qualifiers(quals, definition)
+    if norm is None:
+        return None
+    return json.dumps(norm, sort_keys=True, separators=(",", ":"))
+
+
+def _json_safe(value: Any) -> bool:
+    """True iff value is a finite JSON scalar / nested dict(str-keys)/list."""
+    if value is None or isinstance(value, (str, bool)):
+        return True
+    if isinstance(value, int):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, dict):
+        return all(isinstance(k, str) and _json_safe(v) for k, v in value.items())
+    if isinstance(value, list):
+        return all(_json_safe(v) for v in value)
+    return False  # no arbitrary Python objects
+
+
+def canonical_value(value: Any, definition: ClaimDefinition) -> str | None:
+    """Canonicalize a claim value per its definition, deterministically.
+
+    ``string``: v1 scalar normalization. ``canonical_json``: sorted-key JSON of
+    a JSON-safe structured value (reject non-finite numbers and arbitrary
+    objects), so equivalent object orderings compare equal and avoid raw
+    floating-point surprises (percentages as basis points, money as minor units)."""
+    if definition.value_normalization == VALUE_STRING:
+        return normalize_value(value)
+    if definition.value_normalization == VALUE_CANONICAL_JSON:
+        if not _json_safe(value):
+            return None
+        try:
+            return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    """Best-effort ISO datetime parse; never raises (bad date → None/omit)."""
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
 class ClaimEnvelope(BaseModel):
     """Strict-but-tolerant validation of the stored envelope shape.
 
@@ -151,13 +289,19 @@ class ClaimEnvelope(BaseModel):
 
 @dataclass(frozen=True)
 class ResolvedClaim:
-    """A validated, registry-authoritative claim ready for the resolver."""
+    """A validated, registry-authoritative claim ready for the resolver.
+
+    ``bucket`` is the GENERIC contradiction-bucket identity the resolver groups
+    by — the resolver never inspects key/entity/qualifiers directly. v1 buckets
+    by key alone; v2 buckets by (key, entity, canonical qualifiers).
+    """
 
     canonical_key: str
-    value: str  # normalized
-    scope: str  # authoritative, from registry
+    value: str  # canonical (normalized scalar for v1, canonical JSON for v2)
+    scope: str  # authoritative cardinality, from the registry definition
     valid_from: datetime | None
     valid_to: datetime | None
+    bucket: tuple = ()
 
 
 def resolve_claim(metadata: dict | None) -> ResolvedClaim | None:
@@ -165,7 +309,7 @@ def resolve_claim(metadata: dict | None) -> ResolvedClaim | None:
 
     Returns ``None`` (→ legacy behavior) for every unsafe case: no envelope,
     malformed envelope, unsupported ``schema_version``, unknown/unregistered
-    key, or unusable value. Never raises.
+    key, missing required identity, or unusable value. Never raises.
     """
     if not isinstance(metadata, dict):
         return None
@@ -173,27 +317,31 @@ def resolve_claim(metadata: dict | None) -> ResolvedClaim | None:
     if not isinstance(raw, dict):
         return None
 
+    version = raw.get("schema_version")
+    if version == 1:
+        return _resolve_v1(raw)
+    if version == 2:
+        return _resolve_v2(raw)
+    logger.info("claim_envelope_unsupported_version", version=version)
+    return None
+
+
+def _resolve_v1(raw: dict) -> ResolvedClaim | None:
     try:
         env = ClaimEnvelope.model_validate(raw)
     except ValidationError:
-        # Observability without leaking the value itself.
-        logger.info("claim_envelope_invalid", reason="validation_error",
-                    raw_key=raw.get("key") if isinstance(raw.get("key"), str) else None)
+        logger.info(
+            "claim_envelope_invalid",
+            reason="validation_error",
+            raw_key=raw.get("key") if isinstance(raw.get("key"), str) else None,
+        )
         return None
-
-    if env.schema_version != CLAIM_SCHEMA_VERSION:
-        logger.info("claim_envelope_unsupported_version", version=env.schema_version)
-        return None
-
     canonical = canonicalize_key(env.key)
     if canonical is None:
-        # Unknown / unregistered key → non-authoritative, never supersedes.
         return None
-
     value = normalize_value(env.value)
     if value is None:
         return None
-
     spec = CLAIM_REGISTRY[canonical]
     return ResolvedClaim(
         canonical_key=canonical,
@@ -201,6 +349,37 @@ def resolve_claim(metadata: dict | None) -> ResolvedClaim | None:
         scope=spec.scope,
         valid_from=env.valid_from,
         valid_to=env.valid_to,
+        bucket=("v1", canonical),
+    )
+
+
+def _resolve_v2(raw: dict) -> ResolvedClaim | None:
+    canonical = canonicalize_key(raw.get("key"))
+    if canonical is None:
+        return None
+    definition = CLAIM_REGISTRY[canonical]
+    if not definition.supports_v2:
+        logger.info("claim_envelope_invalid", reason="v2_unsupported_key", raw_key=canonical)
+        return None
+    entity = canonical_entity_key(raw.get("entity_key"))
+    if definition.entity_required and entity is None:
+        logger.info("claim_envelope_invalid", reason="missing_entity", raw_key=canonical)
+        return None
+    quals = canonical_qualifiers(raw.get("qualifiers", {}), definition)
+    if quals is None:
+        logger.info("claim_envelope_invalid", reason="qualifiers", raw_key=canonical)
+        return None
+    value = canonical_value(raw.get("value"), definition)
+    if value is None:
+        logger.info("claim_envelope_invalid", reason="value", raw_key=canonical)
+        return None
+    return ResolvedClaim(
+        canonical_key=canonical,
+        value=value,
+        scope=definition.scope,
+        valid_from=_parse_dt(raw.get("valid_from")),
+        valid_to=_parse_dt(raw.get("valid_to")),
+        bucket=("v2", canonical, entity, quals),
     )
 
 
@@ -237,6 +416,52 @@ def build_claim_envelope(
         env["valid_to"] = valid_to.isoformat()
     if confidence is not None:
         env["confidence"] = confidence
+    return {CLAIM_METADATA_KEY: env}
+
+
+def build_v2_envelope(raw_claim: Any) -> dict | None:
+    """Validate a producer-supplied v2 claim and return a CLEAN storable
+    envelope, or ``None`` if it is not authoritative.
+
+    Storing a re-canonicalized envelope (canonical entity, normalized
+    qualifiers) keeps persisted data deterministic; the resolver re-validates on
+    read regardless. The structured value is stored verbatim (already proven
+    canonical-safe). Used by the structured memory-candidate path.
+    """
+    if not isinstance(raw_claim, dict):
+        return None
+    canonical = canonicalize_key(raw_claim.get("key"))
+    if canonical is None:
+        return None
+    definition = CLAIM_REGISTRY[canonical]
+    if not definition.supports_v2:
+        return None
+    entity = canonical_entity_key(raw_claim.get("entity_key"))
+    if definition.entity_required and entity is None:
+        return None
+    quals = normalize_qualifiers(raw_claim.get("qualifiers", {}), definition)
+    if quals is None:
+        return None
+    if canonical_value(raw_claim.get("value"), definition) is None:
+        return None
+    env: dict[str, Any] = {
+        "schema_version": 2,
+        "key": canonical,
+        "entity_key": entity,
+        "qualifiers": quals,
+        "value": raw_claim.get("value"),
+        "source": raw_claim.get("source")
+        if isinstance(raw_claim.get("source"), str)
+        else "structured_candidate",
+    }
+    vf, vt = _parse_dt(raw_claim.get("valid_from")), _parse_dt(raw_claim.get("valid_to"))
+    if vf is not None:
+        env["valid_from"] = vf.isoformat()
+    if vt is not None:
+        env["valid_to"] = vt.isoformat()
+    conf = raw_claim.get("confidence")
+    if isinstance(conf, (int, float)) and math.isfinite(conf):
+        env["confidence"] = conf
     return {CLAIM_METADATA_KEY: env}
 
 

--- a/server/services/claims.py
+++ b/server/services/claims.py
@@ -221,12 +221,13 @@ def build_claim_envelope(
     without a claim".
     """
     canonical = canonicalize_key(key)
-    if canonical is None or normalize_value(value) is None:
+    normalized = normalize_value(value)
+    if canonical is None or normalized is None:
         return None
     env: dict[str, Any] = {
         "schema_version": CLAIM_SCHEMA_VERSION,
         "key": canonical,
-        "value": value,
+        "value": normalized,  # store the normalized value (resolver compares on it)
         "scope": CLAIM_REGISTRY[canonical].scope,
         "source": source,
     }

--- a/server/services/claims.py
+++ b/server/services/claims.py
@@ -1,0 +1,275 @@
+"""Optional, additive **claim envelope** for memories.
+
+A claim names *what* a memory asserts — a canonical key (entity + attribute)
+plus a value — so the resolver can detect contradictions independent of
+wording ("employer: Acme" vs "employer: Globex") instead of relying on lexical
+overlap, which conflates duplicate / distinct / contradiction.
+
+Design invariants (see issue smaramwbc/statewave#236):
+
+* **Additive only.** The envelope lives under ``metadata_["claim"]`` (JSONB).
+  No new column, no required field, no migration. Memories without it behave
+  exactly as before.
+* **Registry is authoritative.** Cardinality (single- vs multi-valued) comes
+  from the controlled :data:`CLAIM_REGISTRY`, never from caller/LLM input. An
+  unregistered key is non-authoritative and never drives supersession.
+* **Fail safe to legacy.** Anything missing, malformed, unknown-key, or of an
+  unsupported ``schema_version`` resolves to *no claim* (``None``) — the
+  resolver then uses the legacy lexical path. The preferred failure mode is
+  under-resolution, never wrongful deletion or ingestion failure.
+
+Nothing here ever raises on bad input: :func:`resolve_claim` swallows
+validation errors and returns ``None`` so a malformed claim can never break
+ingestion, compilation, retrieval, or serialization.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import structlog
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+logger = structlog.stdlib.get_logger()
+
+# Sub-key under MemoryRow.metadata_ that carries the envelope. Chosen to not
+# collide with existing metadata producers (memory_packs uses flat top-level
+# keys like ``starter_pack_id``; the llm compiler uses ``compiler``/``model``).
+CLAIM_METADATA_KEY = "claim"
+
+# Bumped only on a breaking envelope-shape change. Unknown/newer versions are
+# ignored (degrade to legacy), so an older reader never trips on future data.
+CLAIM_SCHEMA_VERSION = 1
+
+# Cardinality of a canonical claim key.
+SCOPE_SINGLE = "single"  # one current value wins (name, current employer, …)
+SCOPE_MULTI = "multi"  # values coexist (tools used, skills, preferences, …)
+
+
+@dataclass(frozen=True)
+class ClaimKeySpec:
+    """Authoritative spec for a registered canonical claim key."""
+
+    key: str
+    scope: str  # SCOPE_SINGLE | SCOPE_MULTI
+
+
+# --------------------------------------------------------------------------- #
+# Canonical registry — deliberately small and high-confidence.
+#
+# ONLY keys listed here are authoritative. Aliases normalize *to* a canonical
+# key and are accepted ONLY when explicitly registered (deterministic mapping).
+# Everything else is non-authoritative: parsed but never allowed to supersede.
+# Unknown keys default to coexistence-safe behavior by being absent here.
+# --------------------------------------------------------------------------- #
+_SINGLE_VALUED_KEYS = (
+    "identity.name",
+    "employment.current_employer",
+    "location.current_home",
+    "billing.primary_payment_processor",
+)
+
+_MULTI_VALUED_KEYS = (
+    "tools.used",
+    "skills",
+    "preferences",
+    "payment.processors_used",
+)
+
+CLAIM_REGISTRY: dict[str, ClaimKeySpec] = {
+    **{k: ClaimKeySpec(k, SCOPE_SINGLE) for k in _SINGLE_VALUED_KEYS},
+    **{k: ClaimKeySpec(k, SCOPE_MULTI) for k in _MULTI_VALUED_KEYS},
+}
+
+# Approved deterministic aliases → canonical key. Unknown aliases do NOT create
+# new authoritative buckets; they resolve to ``None`` (legacy fallback).
+CLAIM_ALIASES: dict[str, str] = {
+    "name": "identity.name",
+    "full_name": "identity.name",
+    "employer": "employment.current_employer",
+    "works_at": "employment.current_employer",
+    "company": "employment.current_employer",
+    "current_employer": "employment.current_employer",
+    "home": "location.current_home",
+    "home_location": "location.current_home",
+    "current_home": "location.current_home",
+    "primary_payment_processor": "billing.primary_payment_processor",
+    "tools": "tools.used",
+    "payment_processors": "payment.processors_used",
+}
+
+
+def canonicalize_key(raw_key: str | None) -> str | None:
+    """Map an envelope key (or approved alias) to a registered canonical key.
+
+    Returns ``None`` for anything not explicitly registered — so unknown or
+    drifted keys (employer vs works_at vs company are handled; arbitrary
+    strings are not) never become authoritative contradiction buckets.
+    """
+    if not raw_key or not isinstance(raw_key, str):
+        return None
+    key = raw_key.strip()
+    if key in CLAIM_REGISTRY:
+        return key
+    return CLAIM_ALIASES.get(key)
+
+
+def normalize_value(value: Any) -> str | None:
+    """Normalize a claim value for equality comparison.
+
+    Lowercased, stripped, internal whitespace collapsed. Non-string or empty
+    values yield ``None`` (claim not usable). Intentionally conservative: it
+    does NOT attempt entity resolution ("Acme" vs "Acme Corp" stay distinct).
+    """
+    if not isinstance(value, str):
+        return None
+    norm = " ".join(value.strip().split()).lower()
+    return norm or None
+
+
+class ClaimEnvelope(BaseModel):
+    """Strict-but-tolerant validation of the stored envelope shape.
+
+    ``extra='ignore'`` keeps the envelope forward-compatible (a newer producer
+    may add fields an older reader ignores). Validation is non-destructive:
+    callers never mutate the stored dict based on this model.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    schema_version: int
+    key: str
+    value: str
+    scope: str | None = None  # advisory only — registry is authoritative
+    valid_from: datetime | None = None
+    valid_to: datetime | None = None
+    confidence: float | None = None
+    source: str | None = None
+
+
+@dataclass(frozen=True)
+class ResolvedClaim:
+    """A validated, registry-authoritative claim ready for the resolver."""
+
+    canonical_key: str
+    value: str  # normalized
+    scope: str  # authoritative, from registry
+    valid_from: datetime | None
+    valid_to: datetime | None
+
+
+def resolve_claim(metadata: dict | None) -> ResolvedClaim | None:
+    """Parse + validate ``metadata['claim']`` into a :class:`ResolvedClaim`.
+
+    Returns ``None`` (→ legacy behavior) for every unsafe case: no envelope,
+    malformed envelope, unsupported ``schema_version``, unknown/unregistered
+    key, or unusable value. Never raises.
+    """
+    if not isinstance(metadata, dict):
+        return None
+    raw = metadata.get(CLAIM_METADATA_KEY)
+    if not isinstance(raw, dict):
+        return None
+
+    try:
+        env = ClaimEnvelope.model_validate(raw)
+    except ValidationError:
+        # Observability without leaking the value itself.
+        logger.info("claim_envelope_invalid", reason="validation_error",
+                    raw_key=raw.get("key") if isinstance(raw.get("key"), str) else None)
+        return None
+
+    if env.schema_version != CLAIM_SCHEMA_VERSION:
+        logger.info("claim_envelope_unsupported_version", version=env.schema_version)
+        return None
+
+    canonical = canonicalize_key(env.key)
+    if canonical is None:
+        # Unknown / unregistered key → non-authoritative, never supersedes.
+        return None
+
+    value = normalize_value(env.value)
+    if value is None:
+        return None
+
+    spec = CLAIM_REGISTRY[canonical]
+    return ResolvedClaim(
+        canonical_key=canonical,
+        value=value,
+        scope=spec.scope,
+        valid_from=env.valid_from,
+        valid_to=env.valid_to,
+    )
+
+
+def build_claim_envelope(
+    key: str,
+    value: str,
+    *,
+    valid_from: datetime | None = None,
+    valid_to: datetime | None = None,
+    confidence: float | None = None,
+    source: str = "heuristic",
+) -> dict | None:
+    """Build a storable envelope for a compiler — or ``None`` to omit it.
+
+    Returns ``None`` (attach nothing, keep legacy behavior) unless ``key``
+    resolves to a registered canonical key and ``value`` normalizes cleanly.
+    Compilers must treat a ``None`` return as "uncertain — emit the memory
+    without a claim".
+    """
+    canonical = canonicalize_key(key)
+    if canonical is None or normalize_value(value) is None:
+        return None
+    env: dict[str, Any] = {
+        "schema_version": CLAIM_SCHEMA_VERSION,
+        "key": canonical,
+        "value": value,
+        "scope": CLAIM_REGISTRY[canonical].scope,
+        "source": source,
+    }
+    if valid_from is not None:
+        env["valid_from"] = valid_from.isoformat()
+    if valid_to is not None:
+        env["valid_to"] = valid_to.isoformat()
+    if confidence is not None:
+        env["confidence"] = confidence
+    return {CLAIM_METADATA_KEY: env}
+
+
+def intervals_overlap(
+    a_from: datetime | None,
+    a_to: datetime | None,
+    b_from: datetime | None,
+    b_to: datetime | None,
+) -> bool:
+    """Half-open temporal overlap test, ``None`` = open-ended (±infinity).
+
+    Two validity intervals ``[from, to)`` overlap iff ``a_from < b_to`` and
+    ``b_from < a_to``. A missing ``from`` is treated as the beginning of time
+    and a missing ``to`` as open-ended, so two "current" facts (no ``valid_to``)
+    always overlap — the case that must resolve newest-wins. Touching-only
+    intervals (``a_to == b_from``) do NOT overlap, so a past fact whose
+    ``valid_to`` equals the successor's ``valid_from`` coexists as history.
+    """
+    a_from_eff = a_from or datetime.min.replace(tzinfo=None)
+    b_from_eff = b_from or datetime.min.replace(tzinfo=None)
+
+    def _lt(lo: datetime | None, hi: datetime | None) -> bool:
+        # lo < hi where a None hi means +inf (always greater).
+        if hi is None:
+            return True
+        return _aware(lo) < _aware(hi)
+
+    return _lt(a_from_eff, b_to) and _lt(b_from_eff, a_to)
+
+
+def _aware(dt: datetime) -> datetime:
+    """Make a datetime safely comparable (assume UTC-naive == UTC)."""
+    from datetime import timezone
+
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt

--- a/server/services/compilers/heuristic.py
+++ b/server/services/compilers/heuristic.py
@@ -37,6 +37,15 @@ class HeuristicCompiler:
         return memories
 
     def _compile_episode(self, ep: EpisodeRow) -> list[MemoryRow]:
+        # Structured memory candidates short-circuit the heuristic path: compile
+        # the producer-supplied atomic facts deterministically, NO catch-all
+        # episode_summary. Lazy import avoids a heuristic<->structured cycle.
+        from server.services.structured import compile_candidates
+
+        structured = compile_candidates(ep)
+        if structured is not None:
+            return structured
+
         results: list[MemoryRow] = []
         text = extract_payload_text(ep.payload)
         if not text:

--- a/server/services/compilers/heuristic.py
+++ b/server/services/compilers/heuristic.py
@@ -17,6 +17,7 @@ from typing import Sequence
 from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
 from server.services.auto_labeling import apply_suggestions
+from server.services.claims import build_claim_envelope
 from server.services.memory_ttl import compute_valid_to
 
 
@@ -61,8 +62,10 @@ class HeuristicCompiler:
             )
         )
 
-        # Profile facts
-        for fact in _extract_profile_facts(text):
+        # Profile facts. Text/kind/count/order are unchanged; a conservatively
+        # recognized single-valued claim (if any) is attached additively in
+        # metadata_, otherwise metadata_ stays {} exactly as before.
+        for fact, claim_md in _extract_facts_with_claims(text):
             results.append(
                 MemoryRow(
                     id=uuid.uuid4(),
@@ -74,7 +77,7 @@ class HeuristicCompiler:
                     valid_from=ep_valid_from,
                     valid_to=compute_valid_to("profile_fact", ep_valid_from, ttl),
                     source_episode_ids=[ep.id],
-                    metadata_={},
+                    metadata_=claim_md or {},
                     status="active",
                 )
             )
@@ -198,9 +201,75 @@ _FACT_PATTERNS: list[re.Pattern[str]] = [
 ]
 
 
-def _extract_profile_facts(text: str) -> list[str]:
-    facts: list[str] = []
-    for pattern in _FACT_PATTERNS:
+# Pattern index -> (canonical claim key, required trigger prefix). ONLY the
+# three cleanly single-valued triggers get a claim. The required prefix is
+# deliberately TIGHTER than the extraction regex, dropping every ambiguous
+# alternative the regex also accepts:
+#   - "i'm"/"i am" (could be a possessive or place: "I am Bob's friend") — only
+#     the explicit "my name is" is a confident self-name assertion;
+#   - "i'm at"/"i am at" (a location, not an employer: "I'm at the gym") — only
+#     "i work at" reliably means current employer;
+#   - "i'm from"/"i am from" (ORIGIN, not current home) — only "i live in".
+# The team/group pattern (idx 2) and the packed use/prefer/favorite pattern
+# (idx 4) have no canonical single-valued key and never emit a claim. We do NOT
+# emit billing.primary_payment_processor here: generic "I use Stripe" must stay
+# unkeyed (the LLM compiler may key it only on explicit "primary/current" language).
+_CLAIMABLE_PATTERNS: dict[int, tuple[str, str]] = {
+    0: ("identity.name", "my name is"),
+    1: ("employment.current_employer", "i work at"),
+    3: ("location.current_home", "i live in"),
+}
+
+# A first-person assertion carrying any of these is not a confident CURRENT
+# single-valued fact (negation, uncertainty, or explicit history). When present
+# in the clause we emit the memory exactly as before, WITHOUT a claim.
+_CLAIM_BLOCKERS = re.compile(
+    r"\b(?:not|never|no\s+longer|n't|"
+    r"might|maybe|may|could|would|considering|thinking|planning|hop(?:e|ing)|"
+    r"want\s+to|plan\s+to|"
+    r"used\s+to|previously|formerly|former|ex|until|ago|left|past|if)\b",
+    re.IGNORECASE,
+)
+
+
+def _claim_blocked(text: str, m: "re.Match[str]") -> bool:
+    """True if the match sits in reported speech (double quotes) or its clause
+    carries a negation / uncertainty / history marker — i.e. not a confident
+    current fact. Omission is always preferred to a wrong authoritative claim."""
+    before = text[: m.start()]
+    if before.count('"') % 2 == 1:
+        return True
+    if before.count("“") > before.count("”"):  # smart quotes
+        return True
+    window = text[max(0, m.start() - 48) : m.end()]
+    return bool(_CLAIM_BLOCKERS.search(window))
+
+
+def _extract_facts_with_claims(text: str) -> list[tuple[str, dict | None]]:
+    """Each extracted fact text, paired with an optional claim envelope.
+
+    Claim emission is conservative by design: only the three tight single-valued
+    triggers, only the registry-canonical value, only when no negation / quote /
+    history / uncertainty marker is present. Everything else -> (fact, None),
+    emitted exactly as before.
+    """
+    out: list[tuple[str, dict | None]] = []
+    for idx, pattern in enumerate(_FACT_PATTERNS):
+        spec = _CLAIMABLE_PATTERNS.get(idx)
         for m in pattern.finditer(text):
-            facts.append(m.group(0).strip().rstrip(".").rstrip(","))
-    return facts
+            fact = m.group(0).strip().rstrip(".").rstrip(",")
+            claim_md: dict | None = None
+            if spec is not None:
+                key, trigger = spec
+                value = (m.group(1) or "").strip().rstrip(".").rstrip(",")
+                if value and fact.lower().startswith(trigger) and not _claim_blocked(text, m):
+                    # build_claim_envelope re-validates against the registry and
+                    # returns None for anything it cannot confidently key.
+                    claim_md = build_claim_envelope(key, value, source="heuristic")
+            out.append((fact, claim_md))
+    return out
+
+
+def _extract_profile_facts(text: str) -> list[str]:
+    """Unchanged public surface: the extracted fact strings (group(0)) only."""
+    return [fact for fact, _ in _extract_facts_with_claims(text)]

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -210,15 +210,25 @@ class LLMCompiler:
         provider round-trip fails, so the caller does not mistake a provider
         outage for an empty extraction and consume the episodes (issue #201).
         """
-        # Extract text from each episode, skip empties
+        # Structured episodes compile deterministically from producer-supplied
+        # candidates — they never go to the LLM. Lazy import avoids a cycle.
+        from server.services.structured import compile_candidates
+
+        structured_memories: list[MemoryRow] = []
         episode_texts: list[tuple[EpisodeRow, str]] = []
         for ep in episodes:
+            structured = compile_candidates(ep)
+            if structured is not None:
+                structured_memories.extend(structured)
+                continue
             text = extract_payload_text(ep.payload)
             if text:
                 episode_texts.append((ep, text[:4000]))  # Cap per-episode text
 
         if not episode_texts:
-            return []
+            if structured_memories and settings.auto_labeling_enabled:
+                apply_suggestions(structured_memories)
+            return structured_memories
 
         # Group into batches by total character count
         batches = self._create_batches(episode_texts)
@@ -229,8 +239,8 @@ class LLMCompiler:
         tasks = [self._process_batch(batch, semaphore) for batch in batches]
         batch_results = await asyncio.gather(*tasks)
 
-        # Flatten results
-        memories: list[MemoryRow] = []
+        # Flatten results (structured candidates first, then LLM extractions)
+        memories: list[MemoryRow] = list(structured_memories)
         for result in batch_results:
             memories.extend(result)
 

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -29,10 +29,17 @@ from typing import Any, Sequence
 
 import structlog
 
+from datetime import datetime
+
 from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
 from server.services import llm as llm_adapter
 from server.services.auto_labeling import apply_suggestions
+from server.services.claims import (
+    CLAIM_REGISTRY,
+    SCOPE_SINGLE,
+    build_claim_envelope,
+)
 from server.services.compilers.errors import CompilationError
 from server.services.compilers.heuristic import episode_valid_from, extract_payload_text
 from server.services.memory_ttl import compute_valid_to
@@ -103,6 +110,64 @@ Granularity — extract DETAILS, not just headlines:
 - A profile_fact about a person can be ONE specific item — don't wait to find "enough" to summarize.
 - Better to emit 30 concrete granular memories than 5 vague ones. The retrieval layer ranks them; the compiler's job is recall.
 """
+
+# The single-valued canonical keys the model may PROPOSE. The registry remains
+# authoritative for canonicalization, scope, and membership — the model never
+# decides those (see _llm_claim_metadata).
+_SINGLE_CLAIM_KEYS = sorted(k for k, spec in CLAIM_REGISTRY.items() if spec.scope == SCOPE_SINGLE)
+
+_SYSTEM_PROMPT += (
+    "\n\nOptional structured claim (advanced — usually OMITTED):\n"
+    '- A memory MAY carry an optional "claim" object, but ONLY when it asserts a CURRENT,\n'
+    "  single-valued fact about the subject that exactly matches one of these canonical keys:\n"
+    + "".join(f"    * {k}\n" for k in _SINGLE_CLAIM_KEYS)
+    + '- Shape: {"key": <one canonical key above>, "value": <the value>, and OPTIONALLY\n'
+    '  "valid_from"/"valid_to" as ISO-8601 dates ONLY when the source states them explicitly}.\n'
+    '- OMIT "claim" whenever you are not certain — omission is ALWAYS preferred to guessing.\n'
+    "- Do NOT emit a claim for negated, hypothetical, uncertain, quoted/reported, historical, or\n"
+    "  third-party statements. Distinguish a current single-valued state from a past one.\n"
+    "- Generic tool usage is NOT a billing.primary_payment_processor claim: only assert that key when\n"
+    '  the source explicitly says it is the PRIMARY or CURRENT payment processor. "I use Stripe"\n'
+    "  alone must NOT produce a claim.\n"
+    "- Use ONLY the keys listed; never invent keys, scopes, or cardinality. Claims are optional\n"
+    "  annotations — do NOT reduce, merge, or skip the granular memories you would otherwise emit.\n"
+)
+
+
+def _safe_dt(value: Any) -> datetime | None:
+    """Parse an LLM-proposed ISO date, or None. Never raises; a bad date simply
+    drops the temporal field rather than rejecting the whole claim."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def _llm_claim_metadata(mem: dict) -> dict | None:
+    """Validate an LLM-PROPOSED claim into an authoritative envelope, or None.
+
+    The model is untrusted for canonicalization, scope, and registry membership:
+    we only take its proposed key/value/temporal, then ``build_claim_envelope``
+    canonicalizes the key through the registry + approved aliases, stamps the
+    registry-authoritative scope, normalizes the value, and returns None for any
+    unknown key or unusable value. An unknown/malformed proposal therefore never
+    persists under ``metadata_.claim`` in an authoritative form — it is dropped.
+    """
+    raw = mem.get("claim")
+    if not isinstance(raw, dict):
+        return None
+    key, value = raw.get("key"), raw.get("value")
+    if not isinstance(key, str) or not isinstance(value, str):
+        return None
+    return build_claim_envelope(
+        key,
+        value,
+        valid_from=_safe_dt(raw.get("valid_from")),
+        valid_to=_safe_dt(raw.get("valid_to")),
+        source="llm",
+    )
 
 
 class LLMCompiler:
@@ -285,6 +350,15 @@ class LLMCompiler:
                     summary = str(raw_summary)[:200] if raw_summary else content[:200]
 
                 ep_valid_from = episode_valid_from(source_ep)
+                # Optional, validated claim. A malformed/unknown proposal is
+                # dropped and never fails the rest of the response.
+                metadata: dict[str, Any] = {"compiler": "llm", "model": self._model}
+                try:
+                    claim_md = _llm_claim_metadata(mem)
+                except Exception:  # pragma: no cover - defensive; never break compile
+                    claim_md = None
+                if claim_md:
+                    metadata.update(claim_md)
                 results.append(
                     MemoryRow(
                         id=uuid.uuid4(),
@@ -296,7 +370,7 @@ class LLMCompiler:
                         valid_from=ep_valid_from,
                         valid_to=compute_valid_to(kind, ep_valid_from, settings.kind_ttl_days),
                         source_episode_ids=[source_ep.id],
-                        metadata_={"compiler": "llm", "model": self._model},
+                        metadata_=metadata,
                         status="active",
                     )
                 )

--- a/server/services/conflicts.py
+++ b/server/services/conflicts.py
@@ -240,7 +240,14 @@ def _legacy_resolve(
 
 def _claim_owned_pair(a: MemoryRow, b: MemoryRow, claims: dict[uuid.UUID, ResolvedClaim]) -> bool:
     ca, cb = claims.get(a.id), claims.get(b.id)
-    return ca is not None and cb is not None and ca.bucket == cb.bucket and ca.value != cb.value
+    if ca is None or cb is None:
+        return False  # a mixed keyed/unkeyed pair keeps existing legacy behavior
+    # The claim path owns EVERY pair of single-valued claims except an exact
+    # duplicate (same bucket + same value), which it defers to legacy dedup. In
+    # particular two DIFFERENT claim identities must coexist — lexical overlap
+    # between their texts must never supersede across distinct buckets (e.g.
+    # Stripe-card vs Stripe-ACH rates).
+    return not (ca.bucket == cb.bucket and ca.value == cb.value)
 
 
 def _legacy_sort_key(m: MemoryRow) -> tuple[datetime, datetime, str]:

--- a/server/services/conflicts.py
+++ b/server/services/conflicts.py
@@ -80,9 +80,7 @@ async def resolve_conflicts(
     Call contract unchanged: exactly one ``list_active_memories_by_subject``
     read and at most one ``mark_memories_superseded`` write.
     """
-    memories = await repo.list_active_memories_by_subject(
-        session, subject_id, tenant_id=tenant_id
-    )
+    memories = await repo.list_active_memories_by_subject(session, subject_id, tenant_id=tenant_id)
     if len(memories) < 2:
         return []
 
@@ -123,12 +121,15 @@ def _resolve_single_valued_claims(
     if len(keyed) < 2:
         return []
 
-    by_key: dict[str, list[MemoryRow]] = {}
+    # Bucket by the GENERIC contradiction identity. v1 buckets by key alone; v2
+    # by (key, entity, canonical qualifiers). The resolver never inspects
+    # entity/qualifiers itself — it only requires that two claims share a bucket.
+    by_bucket: dict[tuple, list[MemoryRow]] = {}
     for m in keyed:
-        by_key.setdefault(claims[m.id].canonical_key, []).append(m)
+        by_bucket.setdefault(claims[m.id].bucket, []).append(m)
 
     superseded_ids: list[uuid.UUID] = []
-    for key, group in by_key.items():
+    for _bucket, group in by_bucket.items():
         if len(group) < 2:
             continue
         group.sort(key=functools.cmp_to_key(lambda a, b: _claim_cmp(a, b, claims)))
@@ -140,10 +141,10 @@ def _resolve_single_valued_claims(
                 if group[j].status != "active":
                     continue
                 cj = claims[group[j].id]
-                # Authoritative ONLY for a genuine contradiction: same canonical
-                # key (by grouping) + DIFFERENT normalized value + OVERLAPPING
-                # validity. Same value is a duplicate (left to legacy dedup);
-                # non-overlapping windows coexist as history.
+                # Authoritative ONLY for a genuine contradiction: same bucket (by
+                # grouping) + DIFFERENT canonical value + OVERLAPPING validity.
+                # Same value is a duplicate (left to legacy dedup); non-
+                # overlapping windows coexist as history.
                 if ci.value == cj.value:
                     continue
                 if not _claim_overlap(group[i], ci, group[j], cj):
@@ -155,7 +156,7 @@ def _resolve_single_valued_claims(
                     "memory_superseded",
                     old_id=str(group[i].id),
                     new_id=str(group[j].id),
-                    claim_key=key,
+                    claim_key=ci.canonical_key,
                     strategy="claim_contradiction",
                 )
                 break
@@ -179,9 +180,7 @@ def _claim_cmp(a: MemoryRow, b: MemoryRow, claims: dict[uuid.UUID, ResolvedClaim
     return -1 if sa < sb else (1 if sa > sb else 0)
 
 
-def _claim_overlap(
-    mi: MemoryRow, ci: ResolvedClaim, mj: MemoryRow, cj: ResolvedClaim
-) -> bool:
+def _claim_overlap(mi: MemoryRow, ci: ResolvedClaim, mj: MemoryRow, cj: ResolvedClaim) -> bool:
     """Temporal overlap of two claims, using each claim's own validity window
     when supplied and otherwise the memory row's valid_from/valid_to."""
     i_from = ci.valid_from if ci.valid_from is not None else mi.valid_from
@@ -239,16 +238,9 @@ def _legacy_resolve(
     return superseded_ids
 
 
-def _claim_owned_pair(
-    a: MemoryRow, b: MemoryRow, claims: dict[uuid.UUID, ResolvedClaim]
-) -> bool:
+def _claim_owned_pair(a: MemoryRow, b: MemoryRow, claims: dict[uuid.UUID, ResolvedClaim]) -> bool:
     ca, cb = claims.get(a.id), claims.get(b.id)
-    return (
-        ca is not None
-        and cb is not None
-        and ca.canonical_key == cb.canonical_key
-        and ca.value != cb.value
-    )
+    return ca is not None and cb is not None and ca.bucket == cb.bucket and ca.value != cb.value
 
 
 def _legacy_sort_key(m: MemoryRow) -> tuple[datetime, datetime, str]:

--- a/server/services/conflicts.py
+++ b/server/services/conflicts.py
@@ -1,18 +1,36 @@
 """Memory conflict resolution service.
 
-Detects conflicting memories for the same subject and kind, superseding
-older ones when a newer memory covers the same topic. Uses content similarity
-(word overlap or embedding distance) to detect conflicts.
+Two paths, hybrid and strictly additive:
+
+* **Claim path** (new, issue #236) — for memories carrying a valid,
+  registry-recognized *single-valued* claim (see ``server.services.claims``).
+  Within one canonical key, a newer claim whose normalized value DIFFERS and
+  whose validity interval OVERLAPS the older one supersedes it — wording-
+  independent contradiction resolution. Non-overlapping intervals coexist
+  (history preserved). This path is authoritative for single-valued, same-key,
+  different-value pairs and explicitly removes them from the lexical pass, so
+  lexical overlap can never undo its cardinality/temporal decisions.
+
+* **Legacy path** (unchanged) — token-overlap (Jaccard) supersession for
+  EVERYTHING else: unkeyed, malformed, unknown-key, unsupported-version,
+  multi-valued, and mixed keyed/unkeyed pairings, plus single-valued *same
+  value* duplicates (existing duplicate handling). Byte-identical to before for
+  any memory without a usable single-valued claim.
+
+No opt-in flag, no schema change, no migration. The resolver runs only at
+compile time (``server.api.memories``); reads and server startup never invoke
+it, so an upgrade alone never changes stored supersession state.
 
 Strategy:
-- Group active memories by (subject_id, kind).
-- Within each group, compare each pair for similarity.
-- When two memories conflict, the older one is marked as "superseded"
-  with valid_to set to the newer memory's valid_from.
+- Group active memories by (subject_id, kind) for the legacy path and by
+  (subject_id, claim_key) for the claim path.
+- When two memories conflict, the older one is marked as "superseded" with
+  valid_to set to the newer memory's valid_from.
 """
 
 from __future__ import annotations
 
+import functools
 import uuid
 from datetime import datetime, timezone
 
@@ -21,6 +39,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.db import repositories as repo
 from server.db.tables import MemoryRow
+from server.services.claims import (
+    SCOPE_SINGLE,
+    ResolvedClaim,
+    intervals_overlap,
+    resolve_claim,
+)
 from server.services.tokenization import EDGE_PUNCT, tokenize
 
 logger = structlog.stdlib.get_logger()
@@ -35,6 +59,15 @@ _WORD_OVERLAP_THRESHOLD = 0.6
 _TOKEN_EDGE_PUNCT = EDGE_PUNCT
 _tokenize = tokenize
 
+_MIN_DT = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _aware(dt: datetime | None) -> datetime:
+    """Coerce to a comparable, tz-aware datetime (None -> -infinity, naive -> UTC)."""
+    if dt is None:
+        return _MIN_DT
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
 
 async def resolve_conflicts(
     session: AsyncSession,
@@ -42,34 +75,156 @@ async def resolve_conflicts(
     *,
     tenant_id: str | None = None,
 ) -> list[uuid.UUID]:
-    """Detect and resolve conflicting memories. Returns IDs of superseded memories."""
+    """Detect and resolve conflicting memories. Returns IDs of superseded memories.
+
+    Call contract unchanged: exactly one ``list_active_memories_by_subject``
+    read and at most one ``mark_memories_superseded`` write.
+    """
     memories = await repo.list_active_memories_by_subject(
         session, subject_id, tenant_id=tenant_id
     )
     if len(memories) < 2:
         return []
 
-    # Group by kind — conflicts only make sense within the same kind
+    # Validate claims once. ONLY registry-recognized single-valued claims are
+    # authoritative for the claim path; anything else (no claim, malformed,
+    # unknown key, unsupported version, multi-valued) resolves to None here and
+    # is handled exactly as today by the legacy lexical path.
+    claims: dict[uuid.UUID, ResolvedClaim] = {}
+    for m in memories:
+        rc = resolve_claim(m.metadata_)
+        if rc is not None and rc.scope == SCOPE_SINGLE:
+            claims[m.id] = rc
+
+    superseded_ids: list[uuid.UUID] = []
+    # Claim path first; it marks losers status="superseded" in place, so the
+    # legacy pass skips them via its existing status guard. The legacy pass
+    # additionally skips single-valued same-key *different-value* pairs so it
+    # can never undo a temporal coexistence the claim path established.
+    superseded_ids.extend(_resolve_single_valued_claims(memories, claims))
+    superseded_ids.extend(_legacy_resolve(memories, claims))
+
+    if superseded_ids:
+        await repo.mark_memories_superseded(session, superseded_ids)
+
+    return superseded_ids
+
+
+# --------------------------------------------------------------------------- #
+# Claim path — cardinality- and temporally-gated supersession
+# --------------------------------------------------------------------------- #
+
+
+def _resolve_single_valued_claims(
+    memories: list[MemoryRow],
+    claims: dict[uuid.UUID, ResolvedClaim],
+) -> list[uuid.UUID]:
+    keyed = [m for m in memories if m.id in claims]
+    if len(keyed) < 2:
+        return []
+
+    by_key: dict[str, list[MemoryRow]] = {}
+    for m in keyed:
+        by_key.setdefault(claims[m.id].canonical_key, []).append(m)
+
+    superseded_ids: list[uuid.UUID] = []
+    for key, group in by_key.items():
+        if len(group) < 2:
+            continue
+        group.sort(key=functools.cmp_to_key(lambda a, b: _claim_cmp(a, b, claims)))
+        for i in range(len(group)):
+            if group[i].status != "active":
+                continue
+            ci = claims[group[i].id]
+            for j in range(i + 1, len(group)):
+                if group[j].status != "active":
+                    continue
+                cj = claims[group[j].id]
+                # Authoritative ONLY for a genuine contradiction: same canonical
+                # key (by grouping) + DIFFERENT normalized value + OVERLAPPING
+                # validity. Same value is a duplicate (left to legacy dedup);
+                # non-overlapping windows coexist as history.
+                if ci.value == cj.value:
+                    continue
+                if not _claim_overlap(group[i], ci, group[j], cj):
+                    continue
+                superseded_ids.append(group[i].id)
+                group[i].status = "superseded"
+                group[i].valid_to = group[j].valid_from or datetime.now(timezone.utc)
+                logger.info(
+                    "memory_superseded",
+                    old_id=str(group[i].id),
+                    new_id=str(group[j].id),
+                    claim_key=key,
+                    strategy="claim_contradiction",
+                )
+                break
+    return superseded_ids
+
+
+def _claim_cmp(a: MemoryRow, b: MemoryRow, claims: dict[uuid.UUID, ResolvedClaim]) -> int:
+    """Deterministic total order for the claim path: semantic valid_from (when
+    BOTH claims supply it) → persisted created_at → stable memory id. Ascending,
+    so the last (newest) element is the winner and earlier ones are superseded.
+    Input and DB return order never affect the result."""
+    ca, cb = claims[a.id], claims[b.id]
+    if ca.valid_from is not None and cb.valid_from is not None:
+        av, bv = _aware(ca.valid_from), _aware(cb.valid_from)
+        if av != bv:
+            return -1 if av < bv else 1
+    ac, bc = _aware(a.created_at), _aware(b.created_at)
+    if ac != bc:
+        return -1 if ac < bc else 1
+    sa, sb = str(a.id), str(b.id)
+    return -1 if sa < sb else (1 if sa > sb else 0)
+
+
+def _claim_overlap(
+    mi: MemoryRow, ci: ResolvedClaim, mj: MemoryRow, cj: ResolvedClaim
+) -> bool:
+    """Temporal overlap of two claims, using each claim's own validity window
+    when supplied and otherwise the memory row's valid_from/valid_to."""
+    i_from = ci.valid_from if ci.valid_from is not None else mi.valid_from
+    i_to = ci.valid_to if ci.valid_to is not None else mi.valid_to
+    j_from = cj.valid_from if cj.valid_from is not None else mj.valid_from
+    j_to = cj.valid_to if cj.valid_to is not None else mj.valid_to
+    return intervals_overlap(i_from, i_to, j_from, j_to)
+
+
+# --------------------------------------------------------------------------- #
+# Legacy path — unchanged lexical (Jaccard) supersession
+# --------------------------------------------------------------------------- #
+
+
+def _legacy_resolve(
+    memories: list[MemoryRow],
+    claims: dict[uuid.UUID, ResolvedClaim],
+) -> list[uuid.UUID]:
+    if len(memories) < 2:
+        return []
+
     by_kind: dict[str, list[MemoryRow]] = {}
     for m in memories:
         by_kind.setdefault(m.kind, []).append(m)
 
     superseded_ids: list[uuid.UUID] = []
-
     for kind, group in by_kind.items():
         if len(group) < 2:
             continue
-        # Sort by created_at ascending so we supersede older ones
-        group.sort(key=lambda m: m.created_at or datetime.min.replace(tzinfo=timezone.utc))
-
+        group.sort(key=_legacy_sort_key)
         for i in range(len(group)):
             if group[i].status != "active":
                 continue
             for j in range(i + 1, len(group)):
                 if group[j].status != "active":
                     continue
+                # The claim path owns single-valued same-key DIFFERENT-value
+                # pairs; never let lexical overlap undo its temporal/cardinality
+                # call. (Same-value duplicates are intentionally NOT skipped, so
+                # existing duplicate handling still dedups them.)
+                if _claim_owned_pair(group[i], group[j], claims):
+                    continue
                 if _are_conflicting(group[i], group[j]):
-                    # Supersede the older memory
                     superseded_ids.append(group[i].id)
                     group[i].status = "superseded"
                     group[i].valid_to = group[j].valid_from or datetime.now(timezone.utc)
@@ -78,13 +233,29 @@ async def resolve_conflicts(
                         old_id=str(group[i].id),
                         new_id=str(group[j].id),
                         kind=kind,
+                        strategy="lexical",
                     )
-                    break  # This memory is already superseded, move on
-
-    if superseded_ids:
-        await repo.mark_memories_superseded(session, superseded_ids)
-
+                    break
     return superseded_ids
+
+
+def _claim_owned_pair(
+    a: MemoryRow, b: MemoryRow, claims: dict[uuid.UUID, ResolvedClaim]
+) -> bool:
+    ca, cb = claims.get(a.id), claims.get(b.id)
+    return (
+        ca is not None
+        and cb is not None
+        and ca.canonical_key == cb.canonical_key
+        and ca.value != cb.value
+    )
+
+
+def _legacy_sort_key(m: MemoryRow) -> tuple[datetime, datetime, str]:
+    """Preserve current created_at-primary ordering; add valid_from then id as
+    deterministic tie-breaks so previously input/DB-order-dependent ties (equal
+    or missing created_at) now resolve identically every run."""
+    return (_aware(m.created_at), _aware(m.valid_from), str(m.id))
 
 
 def _are_conflicting(older: MemoryRow, newer: MemoryRow) -> bool:

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -459,6 +459,18 @@ async def assemble_context(
             if row.source_episode_ids:
                 covered_episode_ids.update(str(eid) for eid in row.source_episode_ids)
 
+        # Suppress episodes whose backing memories are ALL superseded. Without
+        # this, a correctly-superseded fact still resurfaces verbatim here
+        # ("Recent interactions") and leaks the stale value back into the
+        # prompt. Episodes that still back an active memory — or back no memory
+        # at all — are preserved. Deterministic set logic; no embeddings/LLM.
+        obsolete_episode_ids: set[str] = {
+            str(eid)
+            for eid in await repo.superseded_only_episode_ids(
+                session, subject_id, tenant_id=tenant_id
+            )
+        }
+
         # Fetch resolved sessions to penalize their episodes
         resolved_sessions = await repo.get_resolved_session_ids(
             session, subject_id, tenant_id=tenant_id
@@ -514,6 +526,8 @@ async def assemble_context(
         for row in episode_rows:
             if str(row.id) in covered_episode_ids:
                 continue  # already represented by a summary
+            if str(row.id) in obsolete_episode_ids:
+                continue  # backing memories all superseded (Phase-1 leak fix)
             ep_text = _short_episode_text(row.payload, row.source, row.type)
             content_text = extract_payload_text(row.payload)
             ep_relevance = _relevance_score(content_text, task_tokens)

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -31,6 +31,7 @@ from server.schemas.responses import (
 from server.services import policy as policy_service
 from server.services import receipts as receipts_service
 from server.services.compilers.heuristic import extract_payload_text
+from server.services.structured import is_structured_episode
 from server.services.embeddings import get_provider as get_embedding_provider
 from server.services.embeddings.query_cache import cached_embed_query
 from server.services.tokenization import EDGE_PUNCT, tokenize
@@ -528,6 +529,12 @@ async def assemble_context(
                 continue  # already represented by a summary
             if str(row.id) in obsolete_episode_ids:
                 continue  # backing memories all superseded (Phase-1 leak fix)
+            if is_structured_episode(row.payload):
+                # Compiled from structured candidates: its active atomic memories
+                # ARE its representation. Never inject the raw mixed body, so a
+                # superseded atomic fact cannot leak back through it. The raw
+                # episode stays in timeline/admin/history.
+                continue
             ep_text = _short_episode_text(row.payload, row.source, row.type)
             content_text = extract_payload_text(row.payload)
             ep_relevance = _relevance_score(content_text, task_tokens)

--- a/server/services/structured.py
+++ b/server/services/structured.py
@@ -1,0 +1,153 @@
+"""Structured memory candidates.
+
+A producer that already knows facts in structured form (a connector, a demo
+agent, a structured candidate mapper) may attach them to an episode so Statewave
+compiles them into **separate atomic memories** instead of one indivisible prose
+blob — and so a stale atomic fact can be superseded without dragging down the
+independent facts that shared its source episode.
+
+Ingestion extension point (additive, namespaced, opaque to old readers):
+
+    episode.payload["statewave"]["memory_candidates"] = [
+        {"kind": "domain_fact", "text": "...", "metadata": {...}, "claim": {...}},
+        ...
+    ]
+
+The raw ``payload`` body (timeline/source/audit) is untouched; candidates are an
+additive sibling key.
+
+Deterministic fallback policy (documented):
+  1. Container missing or not a non-empty list  -> full legacy compiler path.
+  2. ANY candidate missing valid text or a mappable kind -> full legacy path
+     (never partially drop an episode).
+  3. Candidate text + kind valid but its optional claim invalid -> emit the
+     candidate as an UNKEYED memory (keep text/kind/metadata, drop the claim).
+  4. Accepted set -> compile atomically, and do NOT also emit a catch-all
+     episode_summary.
+
+Active-context representation: an episode that was compiled from accepted
+candidates is NOT injected verbatim into active context (see
+``server.services.context``); its active atomic memories are the representation.
+The raw episode stays available in timeline/admin/history. No textual redaction,
+no word detection — purely the presence of accepted structured candidates.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from server.core.config import settings
+from server.db.tables import EpisodeRow, MemoryRow
+from server.services.claims import build_claim_envelope, build_v2_envelope
+from server.services.compilers.heuristic import episode_valid_from
+from server.services.memory_ttl import compute_valid_to
+
+CANDIDATE_CONTAINER_KEY = "statewave"
+CANDIDATE_LIST_KEY = "memory_candidates"
+
+# Candidate kind -> stored MemoryKind. No enum change: "domain_fact" maps to the
+# existing ``profile_fact`` kind. Unknown kinds make the container non-acceptable
+# (full legacy fallback), never a silent drop.
+_KIND_MAP = {
+    "domain_fact": "profile_fact",
+    "fact": "profile_fact",
+    "profile_fact": "profile_fact",
+    "episode_summary": "episode_summary",
+    "procedure": "procedure",
+}
+
+
+def _container(payload: Any) -> Any:
+    if isinstance(payload, dict):
+        sw = payload.get(CANDIDATE_CONTAINER_KEY)
+        if isinstance(sw, dict):
+            return sw.get(CANDIDATE_LIST_KEY)
+    return None
+
+
+def accepted_candidates(payload: Any) -> list[dict] | None:
+    """Validated candidate list, or ``None`` to use the full legacy path.
+
+    Read-only and deterministic — used by both the compiler (to emit atomic
+    memories) and context assembly (to recognize a structured episode). Returns
+    ``None`` for rules 1 and 2 of the fallback policy.
+    """
+    cont = _container(payload)
+    if not isinstance(cont, list) or not cont:
+        return None
+    for c in cont:
+        if not isinstance(c, dict):
+            return None
+        text = c.get("text")
+        if not isinstance(text, str) or not text.strip():
+            return None
+        kind = c.get("kind")
+        if not isinstance(kind, str) or kind.strip().lower() not in _KIND_MAP:
+            return None
+    return cont
+
+
+def is_structured_episode(payload: Any) -> bool:
+    return accepted_candidates(payload) is not None
+
+
+def _candidate_claim_metadata(claim: Any) -> dict | None:
+    """Validate a candidate's optional claim into a clean stored envelope, or
+    ``None`` (rule 3 → unkeyed). Producers never define authoritative scope."""
+    if not isinstance(claim, dict):
+        return None
+    version = claim.get("schema_version")
+    if version == 2:
+        return build_v2_envelope(claim)
+    if version == 1:
+        return build_claim_envelope(
+            claim.get("key"),
+            claim.get("value"),
+            source=claim.get("source")
+            if isinstance(claim.get("source"), str)
+            else "structured_candidate",
+        )
+    return None
+
+
+def compile_candidates(ep: EpisodeRow) -> list[MemoryRow] | None:
+    """Compile an episode's accepted structured candidates into atomic memories,
+    or ``None`` if the episode has none (caller uses the legacy path).
+
+    No catch-all ``episode_summary`` is emitted. Existing candidate ``metadata``
+    survives; a valid claim is attached, an invalid one is dropped (text kept).
+    """
+    cands = accepted_candidates(ep.payload)
+    if cands is None:
+        return None
+
+    vf = episode_valid_from(ep)
+    ttl = settings.kind_ttl_days
+    out: list[MemoryRow] = []
+    for c in cands:
+        kind = _KIND_MAP[c["kind"].strip().lower()]
+        text = c["text"]
+        metadata: dict[str, Any] = dict(c.get("metadata") or {})
+        claim_md = _candidate_claim_metadata(c.get("claim"))
+        if claim_md:
+            metadata.update(claim_md)
+        confidence = c.get("confidence")
+        if not isinstance(confidence, (int, float)):
+            confidence = 0.9
+        out.append(
+            MemoryRow(
+                id=uuid.uuid4(),
+                subject_id=ep.subject_id,
+                kind=kind,
+                content=text,
+                summary=text[:200],
+                confidence=float(max(0.0, min(1.0, confidence))),
+                valid_from=vf,
+                valid_to=compute_valid_to(kind, vf, ttl),
+                source_episode_ids=[ep.id],
+                metadata_=metadata,
+                status="active",
+            )
+        )
+    return out

--- a/tests/integration/test_claim_resolution_compat.py
+++ b/tests/integration/test_claim_resolution_compat.py
@@ -1,0 +1,212 @@
+"""Real-Postgres compatibility matrix for hybrid claim-keyed resolution.
+
+Exercises the resolver against a live DB (mark_memories_superseded actually
+updates rows), plus the externally-visible surfaces that must keep working:
+metadata round-trip through the API, export/import of claim metadata + status,
+and the invariant that reads never mutate supersession state.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+
+import tests.integration.conftest as _conftest
+from server.db import repositories as repo
+from server.db.tables import EpisodeRow, MemoryRow
+from server.services.backup import export_subject, import_subject
+from server.services.conflicts import resolve_conflicts
+from server.services.context import assemble_context
+from server.db.engine import set_engine_for_testing
+
+_NOW = dt.datetime.now(dt.timezone.utc)
+
+
+def _claim(key, value, *, valid_from=None, valid_to=None):
+    env = {"schema_version": 1, "key": key, "value": value}
+    if valid_from is not None:
+        env["valid_from"] = valid_from.isoformat()
+    if valid_to is not None:
+        env["valid_to"] = valid_to.isoformat()
+    return {"claim": env}
+
+
+def _mem(subject_id, content, *, metadata=None, age_days=0, status="active"):
+    return MemoryRow(
+        id=uuid.uuid4(),
+        subject_id=subject_id,
+        kind="profile_fact",
+        content=content,
+        summary=content[:200],
+        confidence=0.9,
+        valid_from=_NOW - dt.timedelta(days=age_days),
+        created_at=_NOW - dt.timedelta(days=age_days),
+        source_episode_ids=[uuid.uuid4()],
+        metadata_=metadata or {},
+        status=status,
+    )
+
+
+async def _statuses(session_factory, subject_id):
+    async with session_factory() as s:
+        rows = await repo.list_memories_by_subject(s, subject_id, limit=500)
+    return {r.id: r.status for r in rows}
+
+
+# --- resolver on a live DB ----------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_employer_contradiction_supersedes_on_real_db(session_factory, subject_id):
+    older = _mem(subject_id, "spent years at Acme", metadata=_claim("employer", "Acme"), age_days=10)
+    newer = _mem(subject_id, "new gig at Globex", metadata=_claim("employer", "Globex"), age_days=0)
+    async with session_factory() as s:
+        s.add_all([older, newer])
+        await s.commit()
+
+    async with session_factory() as s:
+        result = await resolve_conflicts(s, subject_id)
+        await s.commit()
+
+    assert older.id in result
+    statuses = await _statuses(session_factory, subject_id)
+    assert statuses[older.id] == "superseded"
+    assert statuses[newer.id] == "active"
+
+
+@pytest.mark.anyio
+async def test_legacy_only_db_unchanged(session_factory, subject_id):
+    older = _mem(subject_id, "my name is Alice", age_days=10)
+    newer = _mem(subject_id, "my name is Alice Chen", age_days=0)
+    distinct = _mem(subject_id, "I work at Globex Corporation", age_days=5)
+    async with session_factory() as s:
+        s.add_all([older, newer, distinct])
+        await s.commit()
+
+    async with session_factory() as s:
+        result = await resolve_conflicts(s, subject_id)
+        await s.commit()
+
+    statuses = await _statuses(session_factory, subject_id)
+    assert statuses[older.id] == "superseded"  # legacy Jaccard
+    assert statuses[newer.id] == "active"
+    assert statuses[distinct.id] == "active"  # distinct fact coexists
+
+
+@pytest.mark.anyio
+async def test_historical_and_current_coexist_on_real_db(session_factory, subject_id):
+    hist = _mem(subject_id, "worked at Acme",
+                metadata=_claim("employer", "Acme", valid_from=dt.datetime(2015, 1, 1, tzinfo=dt.timezone.utc),
+                                valid_to=dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)), age_days=10)
+    curr = _mem(subject_id, "now at Globex",
+                metadata=_claim("employer", "Globex", valid_from=dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)), age_days=0)
+    async with session_factory() as s:
+        s.add_all([hist, curr])
+        await s.commit()
+
+    async with session_factory() as s:
+        result = await resolve_conflicts(s, subject_id)
+        await s.commit()
+
+    assert result == []
+    statuses = await _statuses(session_factory, subject_id)
+    assert statuses[hist.id] == "active" and statuses[curr.id] == "active"
+
+
+@pytest.mark.anyio
+async def test_mixed_keyed_unkeyed_and_malformed_remain_stable(session_factory, subject_id):
+    keyed = _mem(subject_id, "at Globex", metadata=_claim("employer", "Globex"), age_days=0)
+    malformed = _mem(subject_id, "random note", metadata={"claim": {"oops": True}}, age_days=1)
+    unknown = _mem(subject_id, "shoe note", metadata=_claim("shoe_size", "10"), age_days=2)
+    unkeyed = _mem(subject_id, "totally distinct fact about cats", age_days=3)
+    async with session_factory() as s:
+        s.add_all([keyed, malformed, unknown, unkeyed])
+        await s.commit()
+
+    async with session_factory() as s:
+        result = await resolve_conflicts(s, subject_id)
+        await s.commit()
+
+    # Nothing conflicts: distinct content, single keyed value, malformed/unknown
+    # fall back to legacy and don't match anything.
+    assert result == []
+    statuses = await _statuses(session_factory, subject_id)
+    assert all(v == "active" for v in statuses.values())
+
+
+# --- reads never mutate -------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_reads_do_not_mutate_supersession_state(session_factory, subject_id):
+    active = _mem(subject_id, "Stripe pricing is 2.9% plus 30 cents", age_days=0)
+    superseded = _mem(subject_id, "Stripe pricing is 3.5% plus 35 cents", age_days=5, status="superseded")
+    async with session_factory() as s:
+        s.add_all([active, superseded])
+        await s.commit()
+
+    async with session_factory() as s:
+        await assemble_context(s, subject_id, task="Stripe pricing", max_tokens=2000)
+
+    statuses = await _statuses(session_factory, subject_id)
+    assert statuses[active.id] == "active"
+    assert statuses[superseded.id] == "superseded"  # unchanged by a read
+
+
+# --- export/import round-trip -------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_export_import_preserves_claim_metadata_and_status(session_factory, subject_id):
+    claimed = _mem(subject_id, "at Globex", metadata=_claim("employer", "Globex"), age_days=0)
+    gone = _mem(subject_id, "at Acme", metadata=_claim("employer", "Acme"), age_days=5, status="superseded")
+    async with session_factory() as s:
+        s.add_all([claimed, gone])
+        await s.commit()
+
+    prev = set_engine_for_testing(_conftest._engine, _conftest._session_factory)
+    try:
+        doc = await export_subject(subject_id)
+        target = f"copy-{uuid.uuid4().hex[:8]}"
+        await import_subject(doc, target_subject_id=target, preserve_ids=False)
+    finally:
+        set_engine_for_testing(*prev)
+
+    imported = await _statuses(session_factory, target)
+    # Both statuses survived the round-trip (superseded not dropped, not reset).
+    assert sorted(imported.values()) == ["active", "superseded"]
+    async with session_factory() as s:
+        rows = await repo.list_memories_by_subject(s, target, limit=500)
+    claims = [r.metadata_.get("claim") for r in rows if r.metadata_.get("claim")]
+    assert len(claims) == 2
+    assert {c["value"] for c in claims} == {"Globex", "Acme"}
+    # Stored keys round-trip VERBATIM — the resolver canonicalizes the alias at
+    # resolve time, it never rewrites persisted metadata.
+    assert all(c["key"] == "employer" for c in claims)
+
+
+# --- API opaque pass-through --------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_claim_metadata_roundtrips_through_api(client, subject_id):
+    md = _claim("employer", "Globex")
+    md["unrelated"] = {"nested": [1, 2, 3]}
+    resp = await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": subject_id,
+            "source": "chat",
+            "type": "message",
+            "payload": {"text": "I just joined Globex"},
+            "metadata": md,
+        },
+    )
+    assert resp.status_code == 201
+    assert resp.json()["metadata"] == md  # echoed verbatim, claim sub-key intact
+
+    tl = await client.get("/v1/timeline", params={"subject_id": subject_id})
+    assert tl.status_code == 200
+    assert tl.json()["episodes"][0]["metadata"] == md

--- a/tests/integration/test_claim_resolution_compat.py
+++ b/tests/integration/test_claim_resolution_compat.py
@@ -15,7 +15,7 @@ import pytest
 
 import tests.integration.conftest as _conftest
 from server.db import repositories as repo
-from server.db.tables import EpisodeRow, MemoryRow
+from server.db.tables import MemoryRow
 from server.services.backup import export_subject, import_subject
 from server.services.conflicts import resolve_conflicts
 from server.services.context import assemble_context
@@ -86,7 +86,7 @@ async def test_legacy_only_db_unchanged(session_factory, subject_id):
         await s.commit()
 
     async with session_factory() as s:
-        result = await resolve_conflicts(s, subject_id)
+        await resolve_conflicts(s, subject_id)
         await s.commit()
 
     statuses = await _statuses(session_factory, subject_id)

--- a/tests/integration/test_episode_leak.py
+++ b/tests/integration/test_episode_leak.py
@@ -1,0 +1,181 @@
+"""Phase-1 episode-leak fix.
+
+A fact that has been correctly *superseded* must not resurface verbatim via its
+originating episode in the "Recent interactions" section of an assembled
+context — otherwise the stale value leaks straight back into the prompt even
+though its memory is no longer active.
+
+`repo.superseded_only_episode_ids` reports episodes referenced *solely* by
+non-active memories; `assemble_context` skips them. Episodes that still back an
+active memory, or back no memory at all, are preserved unchanged.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+
+from server.db import repositories as repo
+from server.db.tables import EpisodeRow, MemoryRow
+from server.services.context import assemble_context
+
+_BASE = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+
+
+def _episode(subject_id: str, text: str, *, tenant_id: str | None = None) -> EpisodeRow:
+    return EpisodeRow(
+        id=uuid.uuid4(),
+        subject_id=subject_id,
+        tenant_id=tenant_id,
+        source="test",
+        type="conversation",
+        payload={"text": text},
+        occurred_at=_BASE,
+    )
+
+
+def _memory(
+    subject_id: str,
+    content: str,
+    *,
+    status: str,
+    episode_ids: list[uuid.UUID],
+    kind: str = "profile_fact",
+    tenant_id: str | None = None,
+) -> MemoryRow:
+    return MemoryRow(
+        id=uuid.uuid4(),
+        subject_id=subject_id,
+        tenant_id=tenant_id,
+        kind=kind,
+        content=content,
+        summary=content[:200],
+        confidence=0.9,
+        valid_from=_BASE,
+        source_episode_ids=episode_ids,
+        metadata_={},
+        status=status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# repo.superseded_only_episode_ids — deterministic set logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_episode_backed_only_by_superseded_is_obsolete(session_factory, subject_id):
+    ep = _episode(subject_id, "Stripe charges 3.5%")
+    async with session_factory() as session:
+        session.add(ep)
+        session.add(_memory(subject_id, "Stripe 3.5%", status="superseded", episode_ids=[ep.id]))
+        await session.commit()
+
+    async with session_factory() as session:
+        obsolete = await repo.superseded_only_episode_ids(session, subject_id)
+
+    assert obsolete == {ep.id}
+
+
+@pytest.mark.anyio
+async def test_episode_with_an_active_backing_is_kept(session_factory, subject_id):
+    """Partial supersession: an episode backing BOTH a superseded and an active
+    memory must be preserved (the active fact still depends on it)."""
+    ep = _episode(subject_id, "shared episode")
+    async with session_factory() as session:
+        session.add(ep)
+        session.add(_memory(subject_id, "old fact", status="superseded", episode_ids=[ep.id]))
+        session.add(_memory(subject_id, "live fact", status="active", episode_ids=[ep.id]))
+        await session.commit()
+
+    async with session_factory() as session:
+        obsolete = await repo.superseded_only_episode_ids(session, subject_id)
+
+    assert obsolete == set()
+
+
+@pytest.mark.anyio
+async def test_episode_with_no_backing_memory_is_kept(session_factory, subject_id):
+    """A raw / uncompiled episode (no memory references it) is never obsolete."""
+    ep = _episode(subject_id, "uncompiled raw episode")
+    async with session_factory() as session:
+        session.add(ep)
+        await session.commit()
+
+    async with session_factory() as session:
+        obsolete = await repo.superseded_only_episode_ids(session, subject_id)
+
+    assert obsolete == set()
+
+
+@pytest.mark.anyio
+async def test_tombstoned_backing_also_counts_as_dead(session_factory, subject_id):
+    ep = _episode(subject_id, "tombstoned-backed")
+    async with session_factory() as session:
+        session.add(ep)
+        session.add(_memory(subject_id, "gone", status="tombstoned", episode_ids=[ep.id]))
+        await session.commit()
+
+    async with session_factory() as session:
+        obsolete = await repo.superseded_only_episode_ids(session, subject_id)
+
+    assert obsolete == {ep.id}
+
+
+@pytest.mark.anyio
+async def test_obsolete_lookup_is_tenant_scoped(session_factory, subject_id):
+    """A superseded memory under tenant B must not mark tenant A's episode
+    obsolete (and vice-versa), even if they share a subject id."""
+    ep_a = _episode(subject_id, "tenant a episode", tenant_id="tenant-a")
+    async with session_factory() as session:
+        session.add(ep_a)
+        session.add(
+            _memory(subject_id, "a superseded", status="superseded",
+                    episode_ids=[ep_a.id], tenant_id="tenant-a")
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        obsolete_a = await repo.superseded_only_episode_ids(session, subject_id, tenant_id="tenant-a")
+        obsolete_b = await repo.superseded_only_episode_ids(session, subject_id, tenant_id="tenant-b")
+
+    assert obsolete_a == {ep_a.id}
+    assert obsolete_b == set()
+
+
+# ---------------------------------------------------------------------------
+# assemble_context — the leak is closed end to end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_assembled_context_drops_superseded_backed_episode(session_factory, subject_id):
+    stale_ep = _episode(subject_id, "Stripe charges 3.5% plus 35 cents per transaction")
+    live_ep = _episode(subject_id, "Stripe charges 2.9% plus 30 cents per transaction")
+    async with session_factory() as session:
+        session.add(stale_ep)
+        session.add(live_ep)
+        session.add(
+            _memory(subject_id, "Stripe pricing is 3.5% plus 35 cents",
+                    status="superseded", episode_ids=[stale_ep.id])
+        )
+        session.add(
+            _memory(subject_id, "Stripe pricing is 2.9% plus 30 cents",
+                    status="active", episode_ids=[live_ep.id])
+        )
+        await session.commit()
+
+    async with session_factory() as session:
+        bundle = await assemble_context(
+            session, subject_id, task="What is Stripe's current processing fee?", max_tokens=4000
+        )
+
+    episode_ids = {str(e.id) for e in bundle.episodes}
+    # The live episode survives; the superseded-backed one is dropped.
+    assert str(live_ep.id) in episode_ids
+    assert str(stale_ep.id) not in episode_ids
+    # And the stale value never reaches the assembled prompt text.
+    assert "2.9" in bundle.assembled_context
+    assert "3.5" not in bundle.assembled_context

--- a/tests/integration/test_structured_candidates.py
+++ b/tests/integration/test_structured_candidates.py
@@ -1,0 +1,266 @@
+"""End-to-end: the REAL multi-agent-memory Stripe contradiction, resolved via
+structured candidates + v2 entity-qualified claims — on real Postgres.
+
+Bloomberg seeds Stripe at 3.5% + 35c plus independent positioning/differentiator
+facts; a later source reports 2.9% + 30c. The stale pricing must be superseded
+and absent from active context (raw body, episode_summary, synthesis input)
+WITHOUT deleting the independent Bloomberg facts.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+import tests.integration.conftest as _conftest
+from server.db import repositories as repo
+from server.db.engine import set_engine_for_testing
+from server.services.backup import export_subject, import_subject
+
+_Q = {
+    "payment_method": "card",
+    "rate_type": "standard",
+    "currency": "USD",
+    "charge_unit": "transaction",
+}
+
+
+def _pricing(bp, minor, *, entity="organization:stripe", quals=None):
+    return {
+        "kind": "domain_fact",
+        "text": f"Stripe's standard card-processing rate is {bp / 100:.1f}% plus {minor} cents per transaction.",
+        "metadata": {"source": "Bloomberg"},
+        "claim": {
+            "schema_version": 2,
+            "key": "pricing.processing_rate",
+            "entity_key": entity,
+            "qualifiers": quals or dict(_Q),
+            "value": {"percentage_basis_points": bp, "fixed_minor_units": minor},
+        },
+    }
+
+
+_POSITIONING = {
+    "kind": "domain_fact",
+    "text": "Stripe is moving upmarket toward high-volume enterprise merchants.",
+    "metadata": {"source": "Bloomberg"},
+}
+_DIFFERENTIATORS = {
+    "kind": "domain_fact",
+    "text": "Stripe differentiators include developer APIs and broad global coverage.",
+    "metadata": {"source": "Bloomberg"},
+}
+
+_BLOOMBERG_RAW = (
+    "Bloomberg: Stripe's standard card-processing rate is 3.5% plus 35 cents per "
+    "transaction. Stripe is moving upmarket. Differentiators: developer APIs, global coverage."
+)
+_CURRENT_RAW = (
+    "TechCrunch: Stripe reverted its standard card rate to 2.9% plus 30 cents per transaction."
+)
+
+
+async def _episode(client, subject, raw, candidates, occurred_at):
+    r = await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": subject,
+            "source": "agent",
+            "type": "agent.analyst.findings",
+            "payload": {"text": raw, "statewave": {"memory_candidates": candidates}},
+            "occurred_at": occurred_at,
+        },
+    )
+    assert r.status_code == 201, r.text
+
+
+async def _compile(client, subject):
+    r = await client.post("/v1/memories/compile", json={"subject_id": subject, "async": False})
+    assert r.status_code == 200, r.text
+
+
+async def _timeline(client, subject):
+    return (await client.get("/v1/timeline", params={"subject_id": subject})).json()
+
+
+def _claim(m):
+    return (m.get("metadata") or {}).get("claim")
+
+
+@pytest.mark.anyio
+async def test_stripe_contradiction_resolves_end_to_end(client, subject_id):
+    # 1. Bloomberg: pricing + positioning + differentiators as atomic candidates
+    await _episode(
+        client,
+        subject_id,
+        _BLOOMBERG_RAW,
+        [_pricing(350, 35), _POSITIONING, _DIFFERENTIATORS],
+        "2025-01-01T00:00:00Z",
+    )
+    await _compile(client, subject_id)
+    tl = await _timeline(client, subject_id)
+    mems = tl["memories"]
+
+    # 2. Three atomic memories, NO catch-all episode_summary
+    assert len(mems) == 3
+    assert all(m["kind"] == "profile_fact" for m in mems)
+    assert not any(m["kind"] == "episode_summary" for m in mems)
+    pricing = [m for m in mems if _claim(m)]
+    assert len(pricing) == 1
+    # 3. pricing 3.5% initially active, claim is v2/canonical
+    assert pricing[0]["status"] == "active"
+    assert _claim(pricing[0])["schema_version"] == 2
+    assert _claim(pricing[0])["value"] == {"percentage_basis_points": 350, "fixed_minor_units": 35}
+    # candidate metadata preserved alongside the claim
+    assert pricing[0]["metadata"]["source"] == "Bloomberg"
+
+    # 4. later source: 2.9% + 30c
+    await _episode(client, subject_id, _CURRENT_RAW, [_pricing(290, 30)], "2025-06-01T00:00:00Z")
+    await _compile(client, subject_id)
+    tl = await _timeline(client, subject_id)
+    mems = tl["memories"]
+
+    pricing_mems = [m for m in mems if _claim(m)]
+    superseded = [m for m in pricing_mems if m["status"] == "superseded"]
+    active_pricing = [m for m in pricing_mems if m["status"] == "active"]
+    # 5/6/15. exactly one supersession; the stale one is superseded, current active
+    assert len(superseded) == 1
+    assert _claim(superseded[0])["value"] == {
+        "percentage_basis_points": 350,
+        "fixed_minor_units": 35,
+    }
+    assert len(active_pricing) == 1
+    assert _claim(active_pricing[0])["value"] == {
+        "percentage_basis_points": 290,
+        "fixed_minor_units": 30,
+    }
+    # 7. independent Bloomberg facts remain active
+    independents = [m for m in mems if not _claim(m)]
+    assert {m["content"] for m in independents if m["status"] == "active"} >= {
+        _POSITIONING["text"],
+        _DIFFERENTIATORS["text"],
+    }
+    assert all(m["status"] == "active" for m in independents)
+
+    # 8-11. assemble active context
+    ctx = (
+        await client.post(
+            "/v1/context",
+            json={
+                "subject_id": subject_id,
+                "task": "What is Stripe's current card processing rate?",
+                "max_tokens": 4000,
+            },
+        )
+    ).json()
+    asm = ctx["assembled_context"]
+    assert "2.9" in asm and "30 cents" in asm  # current rate present
+    assert "3.5" not in asm and "35 cents" not in asm  # stale absent — raw body, summary, fact
+    # independent facts present in active context
+    assert "upmarket" in asm and "developer apis" in asm.lower()
+    # raw mixed episode body not injected
+    assert "bloomberg:" not in asm.lower()
+    # provenance: active pricing fact links to its source episode
+    assert active_pricing[0]["source_episode_ids"]
+
+    # 12-13. timeline/admin still expose the superseded pricing memory + episodes
+    assert any(m["status"] == "superseded" for m in tl["memories"])
+    assert len(tl["episodes"]) == 2
+
+    # 16. read does not mutate
+    before = {m["id"]: m["status"] for m in (await _timeline(client, subject_id))["memories"]}
+    await client.post(
+        "/v1/context", json={"subject_id": subject_id, "task": "rate?", "max_tokens": 1000}
+    )
+    after = {m["id"]: m["status"] for m in (await _timeline(client, subject_id))["memories"]}
+    assert before == after
+
+
+# --- structured-candidate compatibility matrix --------------------------------
+
+
+@pytest.mark.anyio
+async def test_episode_without_candidates_compiles_unchanged(client, subject_id):
+    r = await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": subject_id,
+            "source": "chat",
+            "type": "message",
+            "payload": {"text": "My name is Alice. I work at Globex."},
+        },
+    )
+    assert r.status_code == 201
+    await _compile(client, subject_id)
+    mems = (await _timeline(client, subject_id))["memories"]
+    # legacy heuristic path: episode_summary + profile_facts, claims on name/employer
+    assert any(m["kind"] == "episode_summary" for m in mems)
+    assert any((_claim(m) or {}).get("key") == "employment.current_employer" for m in mems)
+
+
+@pytest.mark.anyio
+async def test_malformed_container_uses_full_legacy(client, subject_id):
+    # candidates not a list -> full legacy compile of the raw text
+    r = await client.post(
+        "/v1/episodes",
+        json={
+            "subject_id": subject_id,
+            "source": "chat",
+            "type": "message",
+            "payload": {"text": "I work at Globex", "statewave": {"memory_candidates": "nope"}},
+        },
+    )
+    assert r.status_code == 201
+    await _compile(client, subject_id)
+    mems = (await _timeline(client, subject_id))["memories"]
+    assert any(m["kind"] == "episode_summary" for m in mems)  # legacy summary emitted
+
+
+@pytest.mark.anyio
+async def test_invalid_candidate_kind_uses_full_legacy(client, subject_id):
+    await _episode(
+        client,
+        subject_id,
+        "I work at Globex",
+        [{"kind": "???", "text": "x"}],
+        "2025-01-01T00:00:00Z",
+    )
+    await _compile(client, subject_id)
+    mems = (await _timeline(client, subject_id))["memories"]
+    assert any(m["kind"] == "episode_summary" for m in mems)
+
+
+@pytest.mark.anyio
+async def test_invalid_claim_becomes_unkeyed_candidate(client, subject_id):
+    bad = {
+        "kind": "domain_fact",
+        "text": "Some fact with a broken claim.",
+        "metadata": {"source": "x"},
+        "claim": {"schema_version": 2, "key": "made.up"},
+    }
+    await _episode(client, subject_id, "raw", [bad], "2025-01-01T00:00:00Z")
+    await _compile(client, subject_id)
+    mems = (await _timeline(client, subject_id))["memories"]
+    assert len(mems) == 1 and mems[0]["content"] == "Some fact with a broken claim."
+    assert _claim(mems[0]) is None  # claim dropped, text kept
+    assert mems[0]["metadata"]["source"] == "x"  # unrelated metadata survives
+
+
+@pytest.mark.anyio
+async def test_export_import_preserves_v2_envelope(client, subject_id):
+    await _episode(client, subject_id, "raw", [_pricing(350, 35)], "2025-01-01T00:00:00Z")
+    await _compile(client, subject_id)
+    prev = set_engine_for_testing(_conftest._engine, _conftest._session_factory)
+    try:
+        doc = await export_subject(subject_id)
+        target = f"imp-{uuid.uuid4().hex[:8]}"
+        await import_subject(doc, target_subject_id=target, preserve_ids=False)
+    finally:
+        set_engine_for_testing(*prev)
+    async with _conftest._session_factory() as s:
+        rows = await repo.list_memories_by_subject(s, target, limit=50)
+    claim = [r.metadata_.get("claim") for r in rows if r.metadata_.get("claim")][0]
+    assert claim["schema_version"] == 2
+    assert claim["value"] == {"percentage_basis_points": 350, "fixed_minor_units": 35}
+    assert claim["entity_key"] == "organization:stripe"

--- a/tests/test_claims.py
+++ b/tests/test_claims.py
@@ -1,0 +1,188 @@
+"""Claim envelope: parsing, registry authority, and fail-safe validation.
+
+Every unsafe input must degrade to ``None`` (→ legacy behavior), never raise.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from server.services.claims import (
+    CLAIM_SCHEMA_VERSION,
+    SCOPE_MULTI,
+    SCOPE_SINGLE,
+    ResolvedClaim,
+    build_claim_envelope,
+    canonicalize_key,
+    intervals_overlap,
+    normalize_value,
+    resolve_claim,
+)
+
+
+def _env(**kw) -> dict:
+    base = {"schema_version": CLAIM_SCHEMA_VERSION, "key": "employment.current_employer", "value": "Globex"}
+    base.update(kw)
+    return {"claim": base}
+
+
+# --- canonicalize_key -------------------------------------------------------
+
+
+def test_registered_key_passes_through():
+    assert canonicalize_key("employment.current_employer") == "employment.current_employer"
+
+
+def test_approved_aliases_normalize():
+    for alias in ("employer", "works_at", "company", "current_employer"):
+        assert canonicalize_key(alias) == "employment.current_employer"
+
+
+def test_unknown_key_is_not_authoritative():
+    assert canonicalize_key("favorite_color") is None
+    assert canonicalize_key("") is None
+    assert canonicalize_key(None) is None
+
+
+# --- normalize_value --------------------------------------------------------
+
+
+def test_normalize_value_collapses_and_lowercases():
+    assert normalize_value("  Globex   Corp ") == "globex corp"
+
+
+def test_normalize_value_rejects_non_string_and_empty():
+    assert normalize_value(123) is None
+    assert normalize_value("   ") is None
+    assert normalize_value(None) is None
+
+
+# --- resolve_claim happy paths ----------------------------------------------
+
+
+def test_resolve_single_valued_claim():
+    rc = resolve_claim(_env()["claim"] and _env())
+    assert isinstance(rc, ResolvedClaim)
+    assert rc.canonical_key == "employment.current_employer"
+    assert rc.value == "globex"
+    assert rc.scope == SCOPE_SINGLE
+
+
+def test_resolve_multi_valued_claim():
+    rc = resolve_claim({"claim": {"schema_version": 1, "key": "payment_processors", "value": "Stripe"}})
+    assert rc is not None
+    assert rc.canonical_key == "payment.processors_used"
+    assert rc.scope == SCOPE_MULTI
+
+
+def test_resolve_uses_registry_scope_not_envelope_scope():
+    # Envelope lies and claims 'single'; registry says payment.processors_used is multi.
+    rc = resolve_claim({"claim": {"schema_version": 1, "key": "payment.processors_used",
+                                  "value": "Stripe", "scope": "single"}})
+    assert rc is not None and rc.scope == SCOPE_MULTI
+
+
+def test_resolve_alias_to_canonical():
+    rc = resolve_claim({"claim": {"schema_version": 1, "key": "company", "value": "Acme"}})
+    assert rc is not None and rc.canonical_key == "employment.current_employer"
+
+
+def test_resolve_parses_temporal():
+    rc = resolve_claim(_env(valid_from="2025-01-01T00:00:00Z"))
+    assert rc is not None and rc.valid_from == datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
+# --- resolve_claim fail-safe cases (all -> None, never raise) ----------------
+
+
+def test_missing_or_nondict_metadata():
+    assert resolve_claim(None) is None
+    assert resolve_claim({}) is None
+    assert resolve_claim("not-a-dict") is None  # type: ignore[arg-type]
+    assert resolve_claim({"claim": "not-a-dict"}) is None
+
+
+def test_unsupported_schema_version_falls_back():
+    assert resolve_claim(_env(schema_version=2)) is None
+    assert resolve_claim(_env(schema_version=999)) is None
+
+
+def test_unknown_key_falls_back():
+    assert resolve_claim({"claim": {"schema_version": 1, "key": "shoe_size", "value": "10"}}) is None
+
+
+def test_malformed_envelope_falls_back():
+    # missing required 'value'
+    assert resolve_claim({"claim": {"schema_version": 1, "key": "employer"}}) is None
+    # value wrong type
+    assert resolve_claim({"claim": {"schema_version": 1, "key": "employer", "value": 5}}) is None
+    # bad temporal
+    assert resolve_claim(_env(valid_from="not-a-date")) is None
+
+
+def test_extra_envelope_fields_are_ignored_not_rejected():
+    rc = resolve_claim(_env(future_field="whatever", another=123))
+    assert rc is not None and rc.canonical_key == "employment.current_employer"
+
+
+def test_arbitrary_user_metadata_alongside_claim_is_ignored():
+    md = {"starter_pack_id": "x", "custom": True, **_env()}
+    rc = resolve_claim(md)
+    assert rc is not None  # other keys don't interfere
+
+
+# --- build_claim_envelope ---------------------------------------------------
+
+
+def test_build_envelope_for_registered_key():
+    env = build_claim_envelope("employer", "Globex", source="heuristic")
+    assert env is not None
+    claim = env["claim"]
+    assert claim["key"] == "employment.current_employer"
+    assert claim["scope"] == SCOPE_SINGLE
+    assert claim["schema_version"] == CLAIM_SCHEMA_VERSION
+    assert claim["source"] == "heuristic"
+
+
+def test_build_envelope_returns_none_for_unknown_key():
+    assert build_claim_envelope("favorite_color", "red") is None
+
+
+def test_build_envelope_roundtrips_through_resolve():
+    env = build_claim_envelope("name", "Alice Chen")
+    assert env is not None
+    rc = resolve_claim(env)
+    assert rc is not None and rc.canonical_key == "identity.name" and rc.value == "alice chen"
+
+
+def test_build_envelope_serializes_temporal_isoformat():
+    env = build_claim_envelope("employer", "Globex", valid_from=datetime(2025, 1, 1, tzinfo=timezone.utc))
+    assert env is not None and env["claim"]["valid_from"].startswith("2025-01-01")
+
+
+# --- intervals_overlap ------------------------------------------------------
+
+_T0 = datetime(2024, 1, 1, tzinfo=timezone.utc)
+_T1 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+_T2 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def test_two_open_ended_current_facts_overlap():
+    assert intervals_overlap(_T0, None, _T1, None) is True
+
+
+def test_touching_intervals_do_not_overlap():
+    # Acme [_T0,_T1)  Globex [_T1, open) — past vs current, coexist as history.
+    assert intervals_overlap(_T0, _T1, _T1, None) is False
+
+
+def test_disjoint_intervals_do_not_overlap():
+    assert intervals_overlap(_T0, _T1, _T2, None) is False
+
+
+def test_overlapping_intervals_overlap():
+    assert intervals_overlap(_T0, _T2, _T1, None) is True
+
+
+def test_missing_from_is_open_start():
+    assert intervals_overlap(None, _T1, _T0, None) is True

--- a/tests/test_claims_v2.py
+++ b/tests/test_claims_v2.py
@@ -214,3 +214,20 @@ async def test_same_identity_same_value_not_a_contradiction():
     a = _mem("stripe a", _env(value=_V350), age=10)
     b = _mem("stripe b", _env(value=_V350), age=0)  # identical value, distinct text
     assert await _resolve([a, b]) == []  # same value -> not a contradiction (coexist)
+
+
+async def test_distinct_buckets_with_identical_text_coexist():
+    # Regression: two DIFFERENT claim identities (card vs ACH) whose memory TEXT
+    # is identical must coexist — the legacy lexical path must never supersede
+    # across distinct buckets.
+    a = _mem(
+        "Stripe rate: 2.9% + 30c",
+        _env(quals={**_BASE_Q, "payment_method": "card"}, value=_V290),
+        age=10,
+    )
+    b = _mem(
+        "Stripe rate: 2.9% + 30c",
+        _env(quals={**_BASE_Q, "payment_method": "ach"}, value=_V290),
+        age=0,
+    )
+    assert await _resolve([a, b]) == []

--- a/tests/test_claims_v2.py
+++ b/tests/test_claims_v2.py
@@ -1,0 +1,216 @@
+"""v2 external-entity, qualifier-keyed claims: identity, canonicalization, and
+generic resolver bucketing. Distinct (entity, qualifier) identities must never
+share a contradiction bucket; same identity + different value supersedes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+from server.db.tables import MemoryRow
+from server.services.claims import build_v2_envelope, resolve_claim
+from server.services.conflicts import resolve_conflicts
+
+_NOW = datetime.now(timezone.utc)
+_BASE_Q = {
+    "payment_method": "card",
+    "rate_type": "standard",
+    "currency": "USD",
+    "charge_unit": "transaction",
+}
+_V350 = {"percentage_basis_points": 350, "fixed_minor_units": 35}
+_V290 = {"percentage_basis_points": 290, "fixed_minor_units": 30}
+
+
+def _env(*, entity="organization:stripe", quals=None, value=None):
+    return {
+        "claim": {
+            "schema_version": 2,
+            "key": "pricing.processing_rate",
+            "entity_key": entity,
+            "qualifiers": quals if quals is not None else dict(_BASE_Q),
+            "value": value if value is not None else dict(_V350),
+        }
+    }
+
+
+def _rc(**kw):
+    return resolve_claim(_env(**kw))
+
+
+# --- identity / bucketing -----------------------------------------------------
+
+
+def test_v2_resolves_with_bucket_and_scope():
+    rc = _rc()
+    assert rc is not None and rc.bucket[0] == "v2" and rc.scope == "single"
+    assert rc.canonical_key == "pricing.processing_rate"
+
+
+def test_same_identity_different_value_same_bucket():
+    a, b = _rc(value=_V350), _rc(value=_V290)
+    assert a.bucket == b.bucket and a.value != b.value
+
+
+def test_distinct_identities_have_distinct_buckets():
+    base = _rc().bucket
+    assert _rc(entity="organization:square").bucket != base  # Stripe vs Square
+    assert _rc(quals={**_BASE_Q, "payment_method": "ach"}).bucket != base  # card vs ACH
+    assert _rc(quals={**_BASE_Q, "rate_type": "international"}).bucket != base  # standard vs intl
+    assert _rc(quals={**_BASE_Q, "currency": "EUR"}).bucket != base  # USD vs EUR
+    assert _rc(quals={**_BASE_Q, "charge_unit": "monthly"}).bucket != base  # txn vs monthly
+
+
+def test_optional_qualifier_is_not_a_wildcard():
+    with_region = _rc(quals={**_BASE_Q, "region": "us"})
+    without = _rc()
+    assert with_region.bucket != without.bucket  # presence of region changes identity
+
+
+def test_qualifier_object_ordering_irrelevant():
+    q1 = {
+        "payment_method": "card",
+        "rate_type": "standard",
+        "currency": "USD",
+        "charge_unit": "transaction",
+    }
+    q2 = {
+        "charge_unit": "transaction",
+        "currency": "USD",
+        "rate_type": "standard",
+        "payment_method": "card",
+    }
+    assert _rc(quals=q1).bucket == _rc(quals=q2).bucket
+
+
+def test_value_object_ordering_irrelevant_for_equality():
+    a = _rc(value={"percentage_basis_points": 350, "fixed_minor_units": 35})
+    b = _rc(value={"fixed_minor_units": 35, "percentage_basis_points": 350})
+    assert a.value == b.value
+
+
+# --- safety: malformed / missing / unsupported -> None ------------------------
+
+
+def test_missing_required_qualifier_non_authoritative():
+    q = dict(_BASE_Q)
+    q.pop("currency")
+    assert _rc(quals=q) is None
+
+
+def test_unapproved_qualifier_rejected():
+    assert _rc(quals={**_BASE_Q, "bogus": "x"}) is None
+
+
+def test_malformed_entity_non_authoritative():
+    assert _rc(entity="") is None
+    assert _rc(entity=123) is None
+
+
+def test_malformed_value_non_authoritative():
+    assert _rc(value=float("nan")) is None
+    assert _rc(value=object()) is None  # arbitrary object rejected
+
+
+def test_v2_for_v1_key_unsupported():
+    # identity.name is a v1 (string) key; a v2 envelope for it is non-authoritative.
+    assert (
+        resolve_claim(
+            {
+                "claim": {
+                    "schema_version": 2,
+                    "key": "identity.name",
+                    "entity_key": "x",
+                    "qualifiers": {},
+                    "value": {},
+                }
+            }
+        )
+        is None
+    )
+
+
+def test_unknown_key_v2_non_authoritative():
+    assert (
+        resolve_claim(
+            {
+                "claim": {
+                    "schema_version": 2,
+                    "key": "made.up",
+                    "entity_key": "x",
+                    "qualifiers": {},
+                    "value": {},
+                }
+            }
+        )
+        is None
+    )
+
+
+def test_build_v2_envelope_roundtrips():
+    env = build_v2_envelope(_env()["claim"])
+    assert env is not None
+    rc = resolve_claim(env)
+    assert rc is not None and rc.canonical_key == "pricing.processing_rate"
+    assert env["claim"]["entity_key"] == "organization:stripe"  # canonicalized
+
+
+# --- generic resolver behavior (mocked repo) ----------------------------------
+
+
+def _mem(content, env, *, age):
+    return MemoryRow(
+        id=uuid.uuid4(),
+        subject_id="s",
+        kind="profile_fact",
+        content=content,
+        summary=content,
+        confidence=0.9,
+        valid_from=_NOW - timedelta(days=age),
+        created_at=_NOW - timedelta(days=age),
+        source_episode_ids=[uuid.uuid4()],
+        metadata_=env,
+        status="active",
+    )
+
+
+async def _resolve(mems):
+    with patch("server.services.conflicts.repo") as r:
+        r.list_active_memories_by_subject = AsyncMock(return_value=mems)
+        r.mark_memories_superseded = AsyncMock()
+        return await resolve_conflicts(AsyncMock(), "s")
+
+
+async def test_stripe_rate_supersedes_same_identity():
+    old = _mem("stripe 3.5% + 35c", _env(value=_V350), age=10)
+    new = _mem("stripe 2.9% + 30c", _env(value=_V290), age=0)
+    res = await _resolve([old, new])
+    assert old.id in res and new.id not in res
+
+
+async def test_negative_controls_coexist():
+    base = _mem("stripe std card usd txn 3.5", _env(value=_V350), age=10)
+    others = [
+        _mem("square card", _env(entity="organization:square", value=_V290), age=0),
+        _mem("stripe ach", _env(quals={**_BASE_Q, "payment_method": "ach"}, value=_V290), age=0),
+        _mem(
+            "stripe intl", _env(quals={**_BASE_Q, "rate_type": "international"}, value=_V290), age=0
+        ),
+        _mem("stripe eur", _env(quals={**_BASE_Q, "currency": "EUR"}, value=_V290), age=0),
+        _mem(
+            "stripe monthly", _env(quals={**_BASE_Q, "charge_unit": "monthly"}, value=_V290), age=0
+        ),
+        _mem(
+            "stripe enterprise region", _env(quals={**_BASE_Q, "region": "eu"}, value=_V290), age=0
+        ),
+    ]
+    res = await _resolve([base, *others])
+    assert res == []  # every distinct identity coexists; nothing superseded
+
+
+async def test_same_identity_same_value_not_a_contradiction():
+    a = _mem("stripe a", _env(value=_V350), age=10)
+    b = _mem("stripe b", _env(value=_V350), age=0)  # identical value, distinct text
+    assert await _resolve([a, b]) == []  # same value -> not a contradiction (coexist)

--- a/tests/test_compiler_characterization.py
+++ b/tests/test_compiler_characterization.py
@@ -1,0 +1,64 @@
+"""Characterization of compiler OUTPUT invariants that claim emission must not
+disturb: same memory texts, kinds, count, ordering, summaries, and source
+episode links. Claim metadata is purely additive on top of these.
+
+Passes on the pre-claim compiler and must keep passing after.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from server.db.tables import EpisodeRow
+from server.services.compilers.heuristic import HeuristicCompiler, _extract_profile_facts
+
+
+def _ep(text: str) -> EpisodeRow:
+    return EpisodeRow(
+        id=uuid.uuid4(),
+        subject_id="user-1",
+        source="test",
+        type="conversation",
+        payload={"text": text},
+        metadata_={},
+        provenance={},
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_heuristic_text_kind_count_ordering_invariant():
+    ep = _ep("My name is Alice Chen. I work at Globex. I live in Berlin.")
+    mems = HeuristicCompiler().compile([ep])
+
+    # one summary + three facts, in stable order
+    assert [m.kind for m in mems] == [
+        "episode_summary",
+        "profile_fact",
+        "profile_fact",
+        "profile_fact",
+    ]
+    facts = [m.content for m in mems if m.kind == "profile_fact"]
+    assert facts == ["My name is Alice Chen", "I work at Globex", "I live in Berlin"]
+    # source links + summaries preserved
+    for m in mems:
+        assert m.source_episode_ids == [ep.id]
+    assert mems[1].summary == "My name is Alice Chen"
+
+
+def test_extract_profile_facts_public_signature_unchanged():
+    # Still returns plain strings (group(0)), order preserved.
+    facts = _extract_profile_facts("My name is Alice. I work at Globex.")
+    assert facts == ["My name is Alice", "I work at Globex"]
+
+
+def test_negative_statements_still_produce_no_profile_fact():
+    for text in [
+        "My employer is not Acme.",
+        "I might work at Acme.",
+        "Alice works at Acme.",
+        "I previously worked at Acme.",
+        "I am considering moving to Berlin.",
+    ]:
+        mems = HeuristicCompiler().compile([_ep(text)])
+        assert all(m.kind != "profile_fact" for m in mems), text

--- a/tests/test_compiler_claims.py
+++ b/tests/test_compiler_claims.py
@@ -1,0 +1,264 @@
+"""Compiler claim emission — heuristic + LLM.
+
+Optimized for near-zero wrongful authoritative claims: a memory without a
+confidently recognized claim is emitted exactly as before (no claim metadata).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from server.db.tables import EpisodeRow
+from server.services.compilers.heuristic import HeuristicCompiler
+from server.services.compilers.llm import LLMCompiler, _llm_claim_metadata, _safe_dt
+from server.services.conflicts import resolve_conflicts
+
+_NOW = datetime.now(timezone.utc)
+
+
+def _ep(text: str) -> EpisodeRow:
+    return EpisodeRow(
+        id=uuid.uuid4(),
+        subject_id="user-1",
+        source="test",
+        type="conversation",
+        payload={"text": text},
+        metadata_={},
+        provenance={},
+        created_at=_NOW,
+    )
+
+
+def _facts(text):
+    return [m for m in HeuristicCompiler().compile([_ep(text)]) if m.kind == "profile_fact"]
+
+
+def _claims(text):
+    return [m.metadata_.get("claim") for m in _facts(text)]
+
+
+# --- heuristic positives ------------------------------------------------------
+
+
+def test_heuristic_name_claim():
+    (f,) = _facts("My name is Alice Chen")
+    assert f.content == "My name is Alice Chen"  # text unchanged
+    assert f.metadata_["claim"]["key"] == "identity.name"
+    assert f.metadata_["claim"]["value"] == "alice chen"
+    assert f.metadata_["claim"]["scope"] == "single"
+    assert f.metadata_["claim"]["source"] == "heuristic"
+    assert f.metadata_["claim"]["schema_version"] == 1
+
+
+def test_heuristic_employer_claim():
+    (f,) = _facts("I work at Globex")
+    assert f.metadata_["claim"]["key"] == "employment.current_employer"
+    assert f.metadata_["claim"]["value"] == "globex"
+
+
+def test_heuristic_home_claim():
+    (f,) = _facts("I live in Berlin")
+    assert f.metadata_["claim"]["key"] == "location.current_home"
+    assert f.metadata_["claim"]["value"] == "berlin"
+
+
+def test_heuristic_no_temporal_invented():
+    (f,) = _facts("I work at Globex")
+    assert "valid_from" not in f.metadata_["claim"]
+    assert "valid_to" not in f.metadata_["claim"]
+
+
+# --- heuristic negatives: fact emitted, NO claim ------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        'She said, "I work at Acme".',  # reported speech / quoted
+        "I'm at the gym",  # i'm at -> not employer
+        "I'm from Berlin",  # origin -> not current home
+        "I am Bob",  # i am -> not a name claim
+        "I use Stripe",  # generic tool use -> unkeyed
+        "I prefer email",  # preference -> unkeyed
+        "I work at Acme but might leave soon",  # uncertain
+    ],
+)
+def test_heuristic_emits_fact_without_claim(text):
+    # The memory is still extracted (behavior unchanged); it just carries no claim.
+    facts = _facts(text)
+    assert facts, "expected the fact to still be emitted"
+    assert all(f.metadata_ == {} for f in facts)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "My employer is not Acme.",
+        "I might work at Acme.",
+        "Alice works at Acme.",
+        "I previously worked at Acme.",
+        "I am considering moving to Berlin.",
+    ],
+)
+def test_heuristic_never_claims_negated_hypothetical_historical_thirdparty(text):
+    assert all(c is None for c in _claims(text))
+
+
+def test_heuristic_generic_stripe_is_not_a_billing_claim():
+    assert all(c is None for c in _claims("I use Stripe and I prefer PayPal"))
+
+
+def test_heuristic_preserves_unrelated_nothing_lost():
+    # No claim case keeps metadata exactly {} (no spurious keys).
+    facts = _facts("I use Stripe")
+    assert facts and all(f.metadata_ == {} for f in facts)
+
+
+# --- LLM claim validation (registry is authoritative, model is untrusted) -----
+
+
+def test_llm_valid_canonical_claim():
+    md = _llm_claim_metadata({"claim": {"key": "employer", "value": "Globex"}})
+    assert md["claim"]["key"] == "employment.current_employer"
+    assert md["claim"]["value"] == "globex"
+    assert md["claim"]["source"] == "llm"
+
+
+def test_llm_alias_canonicalized():
+    md = _llm_claim_metadata({"claim": {"key": "works_at", "value": "Acme"}})
+    assert md["claim"]["key"] == "employment.current_employer"
+
+
+def test_llm_proposed_scope_overridden_by_registry():
+    # Model lies (scope=single) on a multi-valued key — registry wins.
+    md = _llm_claim_metadata(
+        {"claim": {"key": "payment.processors_used", "value": "Stripe", "scope": "single"}}
+    )
+    assert md["claim"]["scope"] == "multi"
+
+
+def test_llm_unknown_key_omitted():
+    assert _llm_claim_metadata({"claim": {"key": "shoe_size", "value": "10"}}) is None
+
+
+def test_llm_malformed_omitted():
+    assert _llm_claim_metadata({"claim": {"key": 123, "value": "x"}}) is None
+    assert _llm_claim_metadata({"claim": "nope"}) is None
+    assert _llm_claim_metadata({}) is None
+
+
+def test_llm_temporal_parsed_when_present():
+    md = _llm_claim_metadata(
+        {"claim": {"key": "employer", "value": "Globex", "valid_from": "2025-01-01"}}
+    )
+    assert md["claim"]["valid_from"].startswith("2025-01-01")
+    assert _safe_dt("not-a-date") is None
+    assert _safe_dt("2025-01-01T00:00:00Z") == datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
+# --- LLM integration: count preserved, claims validated, one bad one tolerated -
+
+
+def _compiler() -> LLMCompiler:
+    c = LLMCompiler.__new__(LLMCompiler)
+    c._model, c._api_key, c._client = "gpt-4o-mini", "k", None
+    return c
+
+
+@pytest.mark.asyncio
+async def test_llm_compile_attaches_valid_drops_invalid_keeps_count():
+    compiler = _compiler()
+    resp = [
+        {
+            "kind": "profile_fact",
+            "content": "Works at Globex",
+            "summary": "s",
+            "confidence": 0.9,
+            "episode_index": 0,
+            "claim": {"key": "employer", "value": "Globex"},
+        },
+        {
+            "kind": "profile_fact",
+            "content": "Shoe size 10",
+            "summary": "s",
+            "confidence": 0.8,
+            "episode_index": 0,
+            "claim": {"key": "shoe_size", "value": "10"},
+        },  # unknown -> dropped
+        {
+            "kind": "profile_fact",
+            "content": "Likes hiking",
+            "summary": "s",
+            "confidence": 0.7,
+            "episode_index": 0,
+            "claim": "garbage",
+        },  # malformed -> dropped
+        {
+            "kind": "episode_summary",
+            "content": "A chat happened",
+            "summary": "s",
+            "confidence": 0.8,
+            "episode_index": 0,
+        },  # no claim
+    ]
+    ep = _ep("conversation")
+    with patch.object(compiler, "_call_llm_async", new_callable=AsyncMock, return_value=resp):
+        mems = await compiler.compile_async([ep])
+
+    assert len(mems) == 4  # nothing discarded
+    by_content = {m.content: m for m in mems}
+    assert by_content["Works at Globex"].metadata_["claim"]["key"] == "employment.current_employer"
+    # compiler/model preserved everywhere; bad claims simply absent
+    assert all(
+        m.metadata_.get("compiler") == "llm" and m.metadata_.get("model") == "gpt-4o-mini"
+        for m in mems
+    )
+    assert "claim" not in by_content["Shoe size 10"].metadata_
+    assert "claim" not in by_content["Likes hiking"].metadata_
+    assert "claim" not in by_content["A chat happened"].metadata_
+
+
+# --- compiler-generated claims drive the resolver -----------------------------
+
+
+async def _resolve(memories):
+    with patch("server.services.conflicts.repo") as mock_repo:
+        mock_repo.list_active_memories_by_subject = AsyncMock(return_value=memories)
+        mock_repo.mark_memories_superseded = AsyncMock()
+        return await resolve_conflicts(AsyncMock(), "user-1")
+
+
+def _compiled_fact(text, *, created_days):
+    (f,) = _facts(text)
+    f.created_at = _NOW - __import__("datetime").timedelta(days=created_days)
+    return f
+
+
+@pytest.mark.asyncio
+async def test_compiler_claims_supersede_current_employer():
+    acme = _compiled_fact("I work at Acme", created_days=10)
+    globex = _compiled_fact("I work at Globex", created_days=0)
+    result = await _resolve([acme, globex])
+    assert acme.id in result and globex.id not in result
+
+
+@pytest.mark.asyncio
+async def test_compiler_unclaimed_memories_keep_legacy_behavior():
+    # Generic tool usage -> no claims -> distinct facts coexist.
+    a = _compiled_fact("I use Stripe", created_days=10)
+    b = _compiled_fact("I use PayPal", created_days=0)
+    assert await _resolve([a, b]) == []
+
+
+@pytest.mark.asyncio
+async def test_compiler_uncertain_text_gains_no_supersession():
+    # "I am Bob" is emitted but unkeyed; pairing it with a name claim does not
+    # let it participate in claim supersession (mixed -> legacy, low overlap).
+    bob = _compiled_fact("I am Bob", created_days=10)
+    (alice,) = _facts("My name is Alice Chen")
+    alice.created_at = _NOW
+    assert await _resolve([bob, alice]) == []

--- a/tests/test_conflicts_characterization.py
+++ b/tests/test_conflicts_characterization.py
@@ -1,0 +1,101 @@
+"""Characterization of conflict-resolution behavior that MUST survive the
+hybrid claim-keyed resolver unchanged.
+
+These pin the legacy lexical (Jaccard) path for every case the resolver is NOT
+allowed to alter: unkeyed memories, arbitrary non-claim metadata, malformed /
+unknown-key / unsupported claims, and multi-valued or mixed pairings. They pass
+on the pre-resolver code (which ignores metadata entirely) and must keep passing
+after — proving the new path is strictly additive.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+from server.db.tables import MemoryRow
+from server.services.conflicts import resolve_conflicts
+
+_NOW = datetime.now(timezone.utc)
+
+
+def _mem(content, *, kind="profile_fact", metadata=None, age_days=0, status="active"):
+    return MemoryRow(
+        id=uuid.uuid4(),
+        subject_id="user-1",
+        kind=kind,
+        content=content,
+        summary=content[:200],
+        confidence=0.8,
+        valid_from=_NOW - timedelta(days=age_days),
+        created_at=_NOW - timedelta(days=age_days),
+        source_episode_ids=[uuid.uuid4()],
+        metadata_=metadata or {},
+        status=status,
+    )
+
+
+async def _resolve(memories):
+    with patch("server.services.conflicts.repo") as mock_repo:
+        mock_repo.list_active_memories_by_subject = AsyncMock(return_value=memories)
+        mock_repo.mark_memories_superseded = AsyncMock()
+        result = await resolve_conflicts(AsyncMock(), "user-1")
+    return result
+
+
+async def test_arbitrary_non_claim_metadata_does_not_change_resolution():
+    older = _mem("my name is Alice", metadata={"foo": "bar", "n": 1}, age_days=5)
+    newer = _mem("my name is Alice Chen", metadata={"foo": "baz"}, age_days=0)
+    result = await _resolve([older, newer])
+    assert older.id in result and newer.id not in result
+
+
+async def test_malformed_claim_metadata_falls_back_to_legacy():
+    # A garbage claim must behave exactly like no claim → legacy Jaccard wins.
+    older = _mem("my name is Alice", metadata={"claim": {"garbage": True}}, age_days=5)
+    newer = _mem("my name is Alice Chen", metadata={"claim": 42}, age_days=0)
+    result = await _resolve([older, newer])
+    assert older.id in result  # superseded by legacy overlap, not by claim logic
+
+
+async def test_unknown_claim_key_falls_back_to_legacy_no_supersession():
+    # Unknown key is non-authoritative; distinct facts must coexist (legacy).
+    a = _mem("I use Stripe", metadata={"claim": {"schema_version": 1, "key": "shoe_size", "value": "10"}}, age_days=5)
+    b = _mem("I use PayPal", metadata={"claim": {"schema_version": 1, "key": "shoe_size", "value": "11"}}, age_days=0)
+    result = await _resolve([a, b])
+    assert result == []  # below Jaccard threshold, no claim authority → coexist
+
+
+async def test_distinct_facts_still_coexist():
+    a = _mem("my name is Alice", age_days=5)
+    b = _mem("I work at Globex Corporation", age_days=0)
+    assert await _resolve([a, b]) == []
+
+
+async def test_near_duplicate_still_deduped():
+    older = _mem("I use Stripe", age_days=5)
+    newer = _mem("I use Stripe.", age_days=0)
+    result = await _resolve([older, newer])
+    assert older.id in result
+
+
+async def test_stripe_paypal_coexist_even_with_multi_valued_claim():
+    # Multi-valued registry key → coexistence preserved (legacy low overlap).
+    a = _mem("I use Stripe", metadata={"claim": {"schema_version": 1, "key": "payment.processors_used", "value": "Stripe"}}, age_days=5)
+    b = _mem("I use PayPal", metadata={"claim": {"schema_version": 1, "key": "payment.processors_used", "value": "PayPal"}}, age_days=0)
+    assert await _resolve([a, b]) == []
+
+
+async def test_per_kind_grouping_preserved():
+    # Conflicts only within a kind; cross-kind never merges.
+    fact_old = _mem("my name is Alice", kind="profile_fact", age_days=5)
+    fact_new = _mem("my name is Alice Chen", kind="profile_fact", age_days=0)
+    summ = _mem("my name is Alice", kind="episode_summary", age_days=3)
+    result = await _resolve([fact_old, fact_new, summ])
+    assert fact_old.id in result
+    assert summ.id not in result  # different kind, untouched
+
+
+async def test_single_memory_no_conflict():
+    assert await _resolve([_mem("solo")]) == []

--- a/tests/test_conflicts_claim_resolution.py
+++ b/tests/test_conflicts_claim_resolution.py
@@ -179,7 +179,6 @@ async def test_keyed_bucketing_scales_and_isolates_keys():
 
     single_keys = [k for k, s in CLAIM_REGISTRY.items() if s.scope == SCOPE_SINGLE]
     memories = []
-    expected = set()
     for n in range(250):
         key = single_keys[n % len(single_keys)]
         # Disambiguate same-registry-key buckets across iterations would merge,

--- a/tests/test_conflicts_claim_resolution.py
+++ b/tests/test_conflicts_claim_resolution.py
@@ -1,0 +1,196 @@
+"""Hybrid claim-keyed conflict resolution — the new behavior + compat matrix.
+
+Covers the decision tree: single-valued + overlap + different value supersedes;
+non-overlap coexists (history); same value dedups via legacy; multi-valued and
+unknown/mixed coexist; aliases normalize; determinism is input/DB-order
+independent; and the claim path PROTECTS temporal coexistence from lexical
+overlap that would otherwise wrongly supersede.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from unittest.mock import AsyncMock, patch
+
+from server.db.tables import MemoryRow
+from server.services.conflicts import resolve_conflicts
+
+_NOW = datetime.now(timezone.utc)
+
+
+def _dt(year: int) -> datetime:
+    return datetime(year, 1, 1, tzinfo=timezone.utc)
+
+
+def _mem(
+    content,
+    *,
+    key=None,
+    value=None,
+    valid_from=None,
+    valid_to=None,
+    age_days=0,
+    created_days=None,
+    mid=None,
+    kind="profile_fact",
+):
+    metadata: dict = {}
+    if key is not None:
+        env = {"schema_version": 1, "key": key, "value": value}
+        if valid_from is not None:
+            env["valid_from"] = valid_from.isoformat()
+        if valid_to is not None:
+            env["valid_to"] = valid_to.isoformat()
+        metadata = {"claim": env}
+    cd = created_days if created_days is not None else age_days
+    return MemoryRow(
+        id=mid or uuid.uuid4(),
+        subject_id="user-1",
+        kind=kind,
+        content=content,
+        summary=content[:200],
+        confidence=0.9,
+        valid_from=_NOW - timedelta(days=age_days),
+        created_at=_NOW - timedelta(days=cd),
+        source_episode_ids=[uuid.uuid4()],
+        metadata_=metadata,
+        status="active",
+    )
+
+
+async def _resolve(memories):
+    with patch("server.services.conflicts.repo") as mock_repo:
+        mock_repo.list_active_memories_by_subject = AsyncMock(return_value=memories)
+        mock_repo.mark_memories_superseded = AsyncMock()
+        result = await resolve_conflicts(AsyncMock(), "user-1")
+        called = mock_repo.mark_memories_superseded.await_count
+    return result, called
+
+
+# --- the core win: wording-independent contradiction --------------------------
+
+
+async def test_acme_to_globex_overlapping_supersedes():
+    # Low lexical overlap — legacy Jaccard would MISS this; the claim path catches it.
+    older = _mem("Previously employed at Acme Industries", key="employment.current_employer", value="Acme", age_days=10)
+    newer = _mem("Just started a new role at Globex", key="employment.current_employer", value="Globex", age_days=0)
+    result, called = await _resolve([older, newer])
+    assert older.id in result and newer.id not in result
+    assert called == 1
+
+
+async def test_historical_and_current_employer_coexist():
+    older = _mem("worked at Acme", key="employment.current_employer", value="Acme",
+                 valid_from=_dt(2015), valid_to=_dt(2020), age_days=10)
+    newer = _mem("now at Globex", key="employment.current_employer", value="Globex",
+                 valid_from=_dt(2020), age_days=0)  # touching, non-overlapping
+    result, _ = await _resolve([older, newer])
+    assert result == []  # history preserved
+
+
+async def test_temporal_coexistence_protected_from_lexical_overlap():
+    # "I live in Berlin" vs "I live in Munich" = Jaccard 0.6 → legacy WOULD
+    # supersede. With single-valued claims and non-overlapping validity, the
+    # claim path must keep both (and stop legacy from touching them).
+    older = _mem("I live in Berlin", key="location.current_home", value="Berlin",
+                 valid_from=_dt(2018), valid_to=_dt(2020), age_days=100)
+    newer = _mem("I live in Munich", key="location.current_home", value="Munich",
+                 valid_from=_dt(2020), age_days=0)
+    result, _ = await _resolve([older, newer])
+    assert result == []
+
+
+# --- aliases ------------------------------------------------------------------
+
+
+async def test_approved_aliases_normalize_to_same_key_and_supersede():
+    older = _mem("at Acme", key="employer", value="Acme", age_days=10)
+    newer = _mem("at Globex", key="works_at", value="Globex", age_days=0)
+    result, _ = await _resolve([older, newer])
+    assert older.id in result  # employer/works_at → employment.current_employer
+
+
+async def test_unknown_alias_is_safe_and_coexists():
+    older = _mem("Acme", key="my_company", value="Acme", age_days=10)  # unregistered
+    newer = _mem("Globex", key="my_company", value="Globex", age_days=0)
+    result, _ = await _resolve([older, newer])
+    assert result == []  # non-authoritative key + low lexical overlap → coexist
+
+
+# --- cardinality --------------------------------------------------------------
+
+
+async def test_multi_valued_coexist():
+    a = _mem("I use Stripe", key="payment.processors_used", value="Stripe", age_days=10)
+    b = _mem("I use PayPal", key="payment.processors_used", value="PayPal", age_days=0)
+    result, _ = await _resolve([a, b])
+    assert result == []
+
+
+async def test_same_key_same_value_deduped_by_legacy():
+    # Same canonical key + same normalized value = duplicate, handled by legacy
+    # dedup (high text overlap), NOT treated as a contradiction.
+    older = _mem("I work at Globex", key="employer", value="Globex", age_days=10)
+    newer = _mem("I work at Globex", key="employer", value="Globex", age_days=0)
+    result, _ = await _resolve([older, newer])
+    assert older.id in result
+
+
+# --- mixed keyed / unkeyed → legacy unchanged ---------------------------------
+
+
+async def test_mixed_keyed_unkeyed_uses_legacy():
+    unkeyed = _mem("I work at Globex", age_days=10)
+    keyed = _mem("I work at Globex", key="employer", value="Globex", age_days=0)
+    result, _ = await _resolve([unkeyed, keyed])
+    assert unkeyed.id in result  # legacy dedup of near-duplicates (current behavior)
+
+
+# --- determinism --------------------------------------------------------------
+
+
+async def test_equal_timestamps_reversed_input_same_winner():
+    # Identical valid_from AND created_at → tiebreak is the stable id. The lower
+    # id is "older" and must be superseded regardless of input/DB order.
+    id_lo, id_hi = uuid.UUID(int=1), uuid.UUID(int=2)
+    a = _mem("at Acme", key="employer", value="Acme", age_days=3, created_days=3, mid=id_lo)
+    b = _mem("at Globex", key="employer", value="Globex", age_days=3, created_days=3, mid=id_hi)
+
+    forward, _ = await _resolve([a, b])
+    # rebuild (resolve mutates status in place)
+    a2 = _mem("at Acme", key="employer", value="Acme", age_days=3, created_days=3, mid=id_lo)
+    b2 = _mem("at Globex", key="employer", value="Globex", age_days=3, created_days=3, mid=id_hi)
+    reverse, _ = await _resolve([b2, a2])
+
+    assert forward == [id_lo]
+    assert reverse == [id_lo]
+
+
+# --- scale / bucketing --------------------------------------------------------
+
+
+async def test_keyed_bucketing_scales_and_isolates_keys():
+    # 250 independent single-valued keys, each with an old+new contradiction →
+    # exactly 250 supersessions, no cross-key contamination. Per-key grouping
+    # keeps this linear in the number of memories (tiny per-key groups).
+    from server.services.claims import CLAIM_REGISTRY, SCOPE_SINGLE
+
+    single_keys = [k for k, s in CLAIM_REGISTRY.items() if s.scope == SCOPE_SINGLE]
+    memories = []
+    expected = set()
+    for n in range(250):
+        key = single_keys[n % len(single_keys)]
+        # Disambiguate same-registry-key buckets across iterations would merge,
+        # so use a distinct subject-attribute only when key repeats: here we rely
+        # on distinct values per pair; repeated keys across n form one big bucket
+        # per key, where newest-wins still yields exactly one survivor per key.
+        old = _mem(f"old {n}", key=key, value=f"v-old-{n}", age_days=100 + n)
+        new = _mem(f"new {n}", key=key, value=f"v-new-{n}", age_days=n)
+        memories += [old, new]
+    result, _ = await _resolve(memories)
+    # Each of the 4 single-valued keys becomes one big overlapping bucket; within
+    # a bucket only the single newest value survives → (total - num_keys) losers.
+    survivors = len(memories) - len(result)
+    assert survivors == len(single_keys)

--- a/tests/test_repeat_issue.py
+++ b/tests/test_repeat_issue.py
@@ -75,6 +75,11 @@ def _mock_repos(episodes, *, resolved_sessions=None, resolutions=None):
             return_value=episodes,
         ),
         patch(
+            "server.services.context.repo.superseded_only_episode_ids",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch(
             "server.services.context.repo.search_memories_by_embedding",
             new_callable=AsyncMock,
             return_value=[],

--- a/tests/test_session_context.py
+++ b/tests/test_session_context.py
@@ -61,6 +61,11 @@ def _mock_repos(episodes, *, resolved_sessions=None):
             return_value=episodes,
         ),
         patch(
+            "server.services.context.repo.superseded_only_episode_ids",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch(
             "server.services.context.repo.search_memories_by_embedding",
             new_callable=AsyncMock,
             return_value=[],

--- a/tests/test_support_ranking.py
+++ b/tests/test_support_ranking.py
@@ -64,6 +64,11 @@ def _mock_repos(episodes, *, resolved_sessions=None, open_sessions=None):
             return_value=episodes,
         ),
         patch(
+            "server.services.context.repo.superseded_only_episode_ids",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch(
             "server.services.context.repo.search_memories_by_embedding",
             new_callable=AsyncMock,
             return_value=[],


### PR DESCRIPTION
## Summary

Makes contradiction resolution actually work for the cases the legacy lexical resolver could not — including the real multi-agent-memory Stripe pricing scenario — as a **generic, reusable** memory-layer capability with **no domain-specific (Stripe/pricing) resolver logic**.

> Branch note: `docs/v1.0-audit` also carries the prior v1.0 post-release audit doc commits (`10a5357`, `2d9ae45`, `9668e02`); the seven commits below are the new claim-resolution work and are the subject of this description.

## Problem

The legacy Jaccard (word-overlap) resolver collapsed four distinct relations into one scalar and so could not reliably distinguish:

- duplicates,
- unrelated facts,
- multi-valued facts,
- true contradictions.

Consequences: a stale fact could remain **active** (a reworded contradiction never crosses the overlap threshold), or unrelated facts risked **incorrect supersession**. Separately, even when a fact was correctly superseded, raw episode bodies and monolithic `episode_summary` memories could **reintroduce the stale value** into active context after the underlying atomic fact was superseded.

## Solution

Eight additive layers (one per commit, except where noted):

1. **Episode-leak fix** (`2a68fb6`) — raw episodes backed *only* by inactive (superseded/tombstoned) memories are excluded from active context. Episodes that still back an active memory, or back none, are kept.
2. **v1 claim envelope** (`072c0c3`) — optional, dormant subject-relative claim (`metadata_.claim`) + a controlled registry + non-destructive validation. Nothing reads it yet.
3. **Hybrid resolver** (`137d0c8`) — single-valued v1 claims supersede by *same key, different value, overlapping validity* (newest wins); everything else (unkeyed, malformed, multi-valued, mixed) uses the unchanged legacy path.
4. **Compiler claim emission** (`ace2899`) — conservative heuristic (3 tight triggers) + validated, optional, untrusted LLM claim proposals. No change to existing memory text/kind/count/order.
5. **v2 external-entity claims** (`61b9cf4`) — claims about arbitrary external entities with qualifier-keyed attributes, structured canonical values (basis points / minor units).
6. **Generic resolver bucketing** (`61b9cf4`) — the resolver buckets v2 claims by `canonical key + canonical entity key + canonical qualifiers` and resolves purely on bucket equality, value equality, cardinality, temporal overlap, and deterministic ordering.
7. **Structured memory candidates + non-leaking representation** (`fe509b9`) — producers may compile a multi-fact episode into **separate atomic memories**; such episodes use their **active atomic memories** as the active-context representation, so neither raw mixed text nor a monolithic summary can leak a superseded value back in.
8. **Distinct-identity protection** (`5a94d4f`) — the legacy lexical path can never supersede across **distinct authoritative claim identities** (e.g. Stripe-card vs Stripe-ACH rates with near-identical text).

There is **no Stripe-specific (or provider-specific) branch** anywhere in the resolver. The reusable definition is `pricing.processing_rate`; Stripe is only the *entity* the demo happens to use.

## Generic v2 claim identity

```
( canonical claim key, canonical entity key, canonical qualifier map )
```

- different **entities** coexist;
- different **qualifier maps** coexist;
- **missing qualifiers are not wildcards** (required qualifiers must be present, or the claim is non-authoritative);
- **different values** within the same identity with **overlapping validity** supersede (newest wins);
- **non-overlapping validity** coexists as history;
- the **registry controls cardinality** (producers/LLM cannot define it);
- the resolver contains **no pricing-specific or provider-specific branches**.

`pricing.processing_rate` definition: `entity_required`, required qualifiers `payment_method, rate_type, currency, charge_unit`, optional `region, customer_segment, channel, plan`, value normalization = canonical JSON (sorted keys, integer basis-points + minor-units, reject non-finite/arbitrary objects).

## Compatibility

- no database migration;
- no backfill;
- no startup reconciliation;
- no read-time mutation;
- no required API property;
- no response-type change;
- no new status or enum value;
- no LLM, embedding, GPU, or credential dependency;
- v1 behavior remains supported;
- unkeyed legacy memories retain existing behavior;
- malformed / unknown claims fail safe (→ legacy);
- arbitrary existing `metadata_` remains compatible (claim rides as an opaque sub-key);
- old stored memories are never rewritten;
- structured candidates are optional; episodes without them compile exactly as before.

## Validation

- **1053 passed, 1 skipped** (the 1 skip is a pre-existing self-guard in `test_list_subjects_empty` that skips against a non-empty shared dev DB; it runs+passes on a fresh CI DB).
- **Ruff clean.**
- Locked legacy conflict tests **unchanged**; v1 compatibility matrix green; v2 entity + qualifier matrix green; structured-candidate compiler tests green; context-assembly green; **export/import** green; **replay** green; **API metadata pass-through** green; **real PostgreSQL** tests green.

### Real Docker evidence (multi-agent-memory PR #1)

- Two clean-from-empty runs; local Statewave image built **directly from this branch HEAD**; the **running container source was inspected** (`pricing.processing_rate` definition, `structured` module, v2 resolve) to prove it ran the new code — not a published image.
- All containers healthy; **no migration, SQL, Pydantic, resolver, enum, or tenant errors**; API, database, SSE terminal state, and the UI/synthesis agreed on the final authoritative state.

### Real Stripe acceptance result

- Bloomberg produced **separate atomic** pricing, positioning, and differentiator memories.
- Bloomberg **3.5% + 35¢** (350 bp / 35 minor units) was initially **active**.
- the later **2.9% + 30¢** **superseded** the stale pricing claim.
- **exactly one** Stripe stale/current pricing supersession occurred.
- the stale 3.5% + 35¢ text was **absent** from active assembled context, synthesis input, **and** the final synthesis answer.
- **2.9% + 30¢ remained active**; Bloomberg **positioning and differentiator facts remained active**.
- the raw mixed Bloomberg body was **not injected** into active context; **no monolithic summary** reintroduced the stale pricing.
- historical/admin surfaces still **retained** the superseded fact and its source episode.

### Negative controls (all remained separate identities)

- Stripe vs Square; Stripe **card** vs Stripe **ACH**; Stripe **standard** vs **international**; Stripe **USD** vs **EUR**; **per-transaction** vs **monthly** → all coexist (0 superseded). Same identity + different value superseded deterministically.

### Determinism

Two clean runs produced the same semantic result: same stale/current winner, same supersession count, same active/superseded counts, same claim identities, same stale-value absence, same independent active facts. (Context **hashes** are not asserted identical across independently recreated databases — generated IDs/timestamps differ.)

## Validation notes (non-blocking)

- The multi-agent demo's `agents_done` supersession **display** count is a non-authoritative per-agent aggregation; the authoritative **API/database** result was verified directly.
- Python and TypeScript SDK repository suites were **not executed**. No SDK model, enum, required field, or response type changed; opaque `metadata` pass-through was verified server-side.

## Dependency

The companion demo change is **smaramwbc/statewave-multi-agent-memory#1** (it consumes this server's structured-candidate + v2-claim contract). Merge this server PR first.
