### PR TITLE
fix: reasoning-model compile budget, NUL-byte strip, idempotent ingest

### DIFF
--- a/alembic/versions/0025_episodes_idempotency_key.py
+++ b/alembic/versions/0025_episodes_idempotency_key.py
@@ -1,0 +1,86 @@
+"""episodes.idempotency_key — make ingest idempotent (de-dup re-runs)
+
+Revision ID: 0025_episodes_idempotency_key
+Revises: 0024_health_cache_tenant_iso
+Create Date: 2026-06-12
+
+The server ignored the ``idempotency_key`` connectors send, so re-running a seed
+(or any repeated ingest) inserted DUPLICATE episodes — a repo seeded 3× held 3×
+the episodes. This migration makes ingest idempotent:
+
+  * Add a first-class ``idempotency_key`` column.
+  * Backfill it from ``metadata->>'idempotency_key'``, where connectors
+    historically stashed the key (so existing rows get de-duplicated too).
+  * DELETE duplicates, keeping the earliest row per
+    ``(tenant_id, subject_id, idempotency_key)``.
+  * Add a partial unique index (``NULLS NOT DISTINCT``, PostgreSQL 15+/PG16) so
+    future ingests with the same key collapse to one row. Episodes WITHOUT a key
+    are unconstrained — the partial predicate excludes them.
+
+NOTE: the de-dup DELETEs episode rows. Memories already compiled from those
+duplicates are NOT touched; recompile affected subjects to collapse memory
+duplication too. Reversible: downgrade drops the index + column but cannot
+restore deleted duplicates (which were redundant by definition).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0025_episodes_idempotency_key"
+down_revision: Union[str, None] = "0024_health_cache_tenant_iso"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("episodes", sa.Column("idempotency_key", sa.String(length=512), nullable=True))
+
+    # Backfill from where connectors historically stored the key.
+    op.execute(
+        """
+        UPDATE episodes
+        SET idempotency_key = metadata->>'idempotency_key'
+        WHERE idempotency_key IS NULL
+          AND metadata ? 'idempotency_key'
+          AND metadata->>'idempotency_key' IS NOT NULL
+          AND metadata->>'idempotency_key' <> ''
+        """
+    )
+
+    # De-duplicate: keep the earliest row per (tenant_id, subject_id, key).
+    # PARTITION groups NULL tenant_id together (single-tenant mode), matching the
+    # NULLS NOT DISTINCT semantics of the unique index created below.
+    op.execute(
+        """
+        DELETE FROM episodes e
+        USING (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY tenant_id, subject_id, idempotency_key
+                       ORDER BY created_at, id
+                   ) AS rn
+            FROM episodes
+            WHERE idempotency_key IS NOT NULL
+        ) d
+        WHERE e.id = d.id AND d.rn > 1
+        """
+    )
+
+    # Partial unique index — enforce only when a key is present; NULLS NOT
+    # DISTINCT treats a NULL tenant_id as a value so single-tenant rows still
+    # de-dup. Requires PG15+ (statewave runs PG16: pgvector/pgvector:pg16).
+    op.execute(
+        """
+        CREATE UNIQUE INDEX ix_episodes_idempotency
+        ON episodes (tenant_id, subject_id, idempotency_key)
+        NULLS NOT DISTINCT
+        WHERE idempotency_key IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_episodes_idempotency")
+    op.drop_column("episodes", "idempotency_key")

--- a/server/api/episodes.py
+++ b/server/api/episodes.py
@@ -36,11 +36,17 @@ async def create_episode(
         payload=body.payload,
         metadata_=body.metadata,
         provenance=body.provenance,
+        # Idempotency key: a first-class request field, falling back to where the
+        # connectors historically stashed it (metadata.idempotency_key) so older
+        # clients de-dup too. Drives the idempotent insert in insert_episode.
+        idempotency_key=body.idempotency_key or body.metadata.get("idempotency_key"),
     )
     if body.occurred_at is not None:
         row_kwargs["occurred_at"] = body.occurred_at
     row = EpisodeRow(**row_kwargs)
-    await repo.insert_episode(session, row)
+    # On an idempotency conflict this returns the existing episode (the local row
+    # is expunged), so rebind before commit/refresh.
+    row = await repo.insert_episode(session, row)
     await session.commit()
     await session.refresh(row)
     await webhooks.fire(
@@ -86,12 +92,14 @@ async def create_episodes_batch(
                 payload=ep.payload,
                 metadata_=ep.metadata,
                 provenance=ep.provenance,
+                idempotency_key=ep.idempotency_key or ep.metadata.get("idempotency_key"),
             )
             if ep.occurred_at is not None:
                 row_kwargs["occurred_at"] = ep.occurred_at
             row = EpisodeRow(**row_kwargs)
-            await repo.insert_episode(session, row)
-            rows.append(row)
+            # insert_episode returns the EXISTING row on an idempotency conflict,
+            # so append what it returns (not the local row, which is expunged).
+            rows.append(await repo.insert_episode(session, row))
         await session.commit()
         for row in rows:
             await session.refresh(row)

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -78,6 +78,13 @@ class Settings(BaseSettings):
     litellm_timeout_seconds: float = 60.0
     litellm_max_retries: int = 2
     litellm_temperature: float = 0.1
+    # Output-token ceiling for the LLM compiler. This is a CAP, not a target
+    # (only generated tokens are billed), so it is generous by default: reasoning
+    # models (o-series, gpt-5.x, ...) spend part of the budget on hidden reasoning
+    # tokens before the JSON, and a small cap truncates their output into invalid
+    # JSON. 16000 is safe for gpt-4o-mini's 16K output limit — lower it for legacy
+    # models with smaller limits (gpt-4: 8K), raise it for heavy reasoning batches.
+    litellm_compile_max_tokens: int = 16000
 
     # Authentication (empty = disabled / open access)
     api_key: str | None = None

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -11,6 +11,7 @@ import uuid
 from typing import Sequence
 
 from sqlalchemy import delete, func, or_, select, text, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datetime import datetime
@@ -54,9 +55,43 @@ def _tenant_filter(stmt, column, tenant_id: str | None):
 
 
 async def insert_episode(session: AsyncSession, row: EpisodeRow) -> EpisodeRow:
-    session.add(row)
-    await session.flush()
-    return row
+    """Insert an episode, idempotently.
+
+    With an `idempotency_key`, a row that collides with an existing
+    (tenant_id, subject_id, idempotency_key) is NOT duplicated — the existing
+    episode is returned unchanged. This makes re-ingest (re-running a seed,
+    retrying a webhook) a no-op instead of inflating the subject. Episodes
+    without a key are always inserted (live-chat ingest, legacy clients).
+    """
+    if not row.idempotency_key:
+        session.add(row)
+        await session.flush()
+        return row
+    # The unique index is the atomic arbiter — a SAVEPOINT lets us catch the
+    # conflict without poisoning the surrounding transaction, then return the
+    # winner. This is race-safe under the connectors' concurrent ingest.
+    try:
+        async with session.begin_nested():
+            session.add(row)
+            await session.flush()
+        return row
+    except IntegrityError:
+        if row in session:
+            session.expunge(row)
+        existing = (
+            await session.execute(
+                select(EpisodeRow).where(
+                    EpisodeRow.subject_id == row.subject_id,
+                    EpisodeRow.idempotency_key == row.idempotency_key,
+                    EpisodeRow.tenant_id.is_(None)
+                    if row.tenant_id is None
+                    else EpisodeRow.tenant_id == row.tenant_id,
+                )
+            )
+        ).scalars().first()
+        if existing is None:
+            raise  # a non-idempotency constraint failed — don't swallow it
+        return existing
 
 
 async def list_episodes_by_subject(

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import Boolean, DateTime, Float, Index, Integer, String, Text, func, text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, validates
 
 # Embedding dimensionality must match `LiteLLMEmbeddingProvider.dimensions`
 # and the `vector(N)` type in the schema. text-embedding-3-small at 1536
@@ -63,6 +63,17 @@ class MemoryRow(Base):
     kind: Mapped[str] = mapped_column(String(64), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     summary: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    @validates("content", "summary")
+    def _strip_nul_bytes(self, _key: str, value: str | None) -> str | None:
+        # Postgres text cannot store NUL (U+0000). An LLM occasionally emits one
+        # in generated content, and a single stray byte would raise
+        # CharacterNotInRepertoireError and 500 the ENTIRE compile batch (losing
+        # every memory in it). Strip NUL — and only NUL — so one bad byte can't
+        # sink the batch. Valid UTF-8 is otherwise preserved untouched.
+        if isinstance(value, str) and "\x00" in value:
+            return value.replace("\x00", "")
+        return value
     confidence: Mapped[float] = mapped_column(Float, nullable=False, default=1.0)
     valid_from: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -33,6 +33,12 @@ class EpisodeRow(Base):
     payload: Mapped[dict] = mapped_column(JSONB, nullable=False)
     metadata_: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
     provenance: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    # Client-supplied de-dup key. A partial unique index on
+    # (tenant_id, subject_id, idempotency_key) WHERE idempotency_key IS NOT NULL
+    # (migration 0025, NULLS NOT DISTINCT) makes ingest idempotent: re-seeding a
+    # repo collapses to the same rows instead of duplicating them. NULL = no key
+    # = always inserted (live-chat ingest, legacy clients).
+    idempotency_key: Mapped[str | None] = mapped_column(String(512), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
@@ -51,6 +57,20 @@ class EpisodeRow(Base):
     __table_args__ = (
         Index("ix_episodes_subject_created", "subject_id", "created_at"),
         Index("ix_episodes_subject_occurred", "subject_id", "occurred_at"),
+        # Idempotent ingest: one episode per (tenant_id, subject_id,
+        # idempotency_key). Partial (keyless episodes are unconstrained) and
+        # NULLS NOT DISTINCT (a NULL tenant_id is a value, so single-tenant rows
+        # still de-dup). Declared here so create_all-based tests get it too;
+        # migration 0025 builds the same index on existing databases.
+        Index(
+            "ix_episodes_idempotency",
+            "tenant_id",
+            "subject_id",
+            "idempotency_key",
+            unique=True,
+            postgresql_where=text("idempotency_key IS NOT NULL"),
+            postgresql_nulls_not_distinct=True,
+        ),
     )
 
 

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -24,6 +24,10 @@ class CreateEpisodeRequest(BaseModel):
     # (Slack history, GitHub issues, Zendesk imports) should always set
     # this so timeline-style queries see the real ordering.
     occurred_at: datetime | None = None
+    # De-dup key. Re-ingesting an episode with the same key (re-running a seed,
+    # retrying a webhook) is a no-op rather than a duplicate. Optional; when
+    # absent the server also reads `metadata.idempotency_key` for older clients.
+    idempotency_key: str | None = Field(default=None, max_length=512)
 
 
 class BatchCreateEpisodesRequest(BaseModel):

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -58,10 +58,13 @@ _MAX_CONCURRENCY = 4  # Max parallel LLM calls
 #     raised LLMResponseError. The whole batch was discarded.
 #   - Multi-episode batches got 500 * episode_count but capped at 3000,
 #     still tight for ~15+ memories per batch.
-# gpt-4o-mini supports 16K output tokens. 8000 leaves real headroom and
-# costs nothing extra (only used tokens are billed).
-_MAX_TOKENS = 8000  # Response token limit per batch
-_TOKENS_PER_EPISODE = 1500  # Per-episode allocation inside the cap
+# The ceiling is configurable (settings.litellm_compile_max_tokens, default
+# 16000) and is a CAP, not a target — only generated tokens are billed. We floor
+# the per-call budget at half the ceiling even for a single-episode batch. That
+# headroom is essential for reasoning models (o-series, gpt-5.x, ...): they spend
+# part of the budget on hidden reasoning tokens before the JSON, so the old tight
+# 1500/episode cap truncated their output into invalid JSON (compile 502).
+_TOKENS_PER_EPISODE = 1500  # Per-episode allocation, floored below at half the ceiling
 
 _SYSTEM_PROMPT = """\
 You are a memory extraction engine for an AI context system called Statewave.
@@ -395,11 +398,12 @@ class LLMCompiler:
         gives us provider portability plus standardized timeout/retry/error
         mapping.
         """
-        # Adjust max tokens based on batch size. 1500/episode is the
-        # empirical headroom for a dense LoCoMo session (~15 memories
-        # at ~100 tokens each); the _MAX_TOKENS ceiling stops absurdly
-        # large batches from blowing past gpt-4o-mini's 16K output cap.
-        max_tokens = min(_MAX_TOKENS, _TOKENS_PER_EPISODE * episode_count)
+        # Size the budget to the batch, but floor at half the ceiling so even a
+        # single-episode batch leaves room for a reasoning model's hidden tokens
+        # (a tight cap truncates the JSON → invalid → compile 502). The ceiling is
+        # configurable and caps large batches below the model's output limit.
+        ceiling = settings.litellm_compile_max_tokens
+        max_tokens = min(ceiling, max(ceiling // 2, _TOKENS_PER_EPISODE * episode_count))
 
         try:
             parsed = await llm_adapter.acomplete_json(

--- a/server/services/llm.py
+++ b/server/services/llm.py
@@ -335,19 +335,40 @@ async def aembed_query(
 # ─── Health ──────────────────────────────────────────────────────────
 
 
+def _is_output_limit_error(exc: BaseException) -> bool:
+    """True when a provider rejected the call only because the output/token cap
+    was hit. The round-trip still reached the model, so auth + connectivity are
+    proven — what `aping` cares about."""
+    msg = str(exc).lower()
+    return (
+        "max_tokens" in msg
+        or "max output" in msg
+        or "output limit" in msg
+        or "finish the message" in msg
+        or "max_completion_tokens" in msg
+    )
+
+
 async def aping(timeout: float = 10.0) -> bool:
     """Lightweight provider-reachability check. Returns True on success.
 
-    Uses a one-token completion to verify both auth and connectivity
-    without burning meaningful tokens. Re-raises typed errors so callers
-    can distinguish timeout vs auth failure if they want; otherwise just
-    catch StatewaveLLMError.
+    Uses a one-token completion to verify both auth and connectivity without
+    burning meaningful tokens. A reasoning model (o-series, gpt-5.x, ...) can
+    exhaust that tiny budget on hidden reasoning tokens before emitting output,
+    which the provider reports as a max-tokens/output-limit error — but that
+    round-trip still PROVES auth + connectivity, so we treat it as reachable.
+    Re-raises other typed errors so callers can distinguish timeout vs auth.
     """
-    await acomplete(
-        [{"role": "user", "content": "ping"}],
-        max_tokens=1,
-        timeout=timeout,
-    )
+    try:
+        await acomplete(
+            [{"role": "user", "content": "ping"}],
+            max_tokens=1,
+            timeout=timeout,
+        )
+    except LLMProviderError as exc:
+        if _is_output_limit_error(exc):
+            return True
+        raise
     return True
 
 

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0024_health_cache_tenant_iso"
+EXPECTED_HEAD = "0025_episodes_idempotency_key"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/tests/integration/test_idempotent_ingest.py
+++ b/tests/integration/test_idempotent_ingest.py
@@ -1,0 +1,63 @@
+"""Episode ingest is idempotent: re-ingesting the same idempotency_key is a
+no-op, not a duplicate. This is what makes re-running a connector seed (or a
+retried webhook) safe — without it, a repo seeded N times held N× the episodes.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+def _episode(subject_id: str, key: str, text: str = "hello") -> dict:
+    return {
+        "subject_id": subject_id,
+        "source": "git",
+        "type": "git.commit",
+        "payload": {"text": text},
+        "idempotency_key": key,
+    }
+
+
+@pytest.mark.anyio
+async def test_same_key_does_not_duplicate(client: AsyncClient, subject_id: str):
+    first = await client.post("/v1/episodes", json=_episode(subject_id, "git:commit:abc"))
+    assert first.status_code == 201
+    second = await client.post("/v1/episodes", json=_episode(subject_id, "git:commit:abc", text="changed"))
+    assert second.status_code in (200, 201)
+    # Same key → same row returned, and the timeline holds exactly one episode.
+    assert second.json()["id"] == first.json()["id"]
+
+    timeline = await client.get(f"/v1/timeline?subject_id={subject_id}")
+    episodes = timeline.json().get("episodes") or timeline.json().get("items") or []
+    assert len(episodes) == 1
+
+
+@pytest.mark.anyio
+async def test_key_in_metadata_is_honored_for_legacy_clients(client: AsyncClient, subject_id: str):
+    # Older connectors stash the key in metadata rather than the top-level field.
+    ep = {
+        "subject_id": subject_id,
+        "source": "git",
+        "type": "git.commit",
+        "payload": {"text": "x"},
+        "metadata": {"idempotency_key": "git:commit:legacy"},
+    }
+    await client.post("/v1/episodes", json=ep)
+    await client.post("/v1/episodes", json=ep)
+    timeline = await client.get(f"/v1/timeline?subject_id={subject_id}")
+    episodes = timeline.json().get("episodes") or timeline.json().get("items") or []
+    assert len(episodes) == 1
+
+
+@pytest.mark.anyio
+async def test_distinct_keys_and_keyless_all_insert(client: AsyncClient, subject_id: str):
+    await client.post("/v1/episodes", json=_episode(subject_id, "git:commit:a"))
+    await client.post("/v1/episodes", json=_episode(subject_id, "git:commit:b"))
+    # No key → never de-duped (live-chat ingest), even when identical.
+    keyless = {"subject_id": subject_id, "source": "chat", "type": "chat.msg", "payload": {"text": "hi"}}
+    await client.post("/v1/episodes", json=keyless)
+    await client.post("/v1/episodes", json=keyless)
+    timeline = await client.get(f"/v1/timeline?subject_id={subject_id}")
+    episodes = timeline.json().get("episodes") or timeline.json().get("items") or []
+    assert len(episodes) == 4  # 2 distinct keys + 2 keyless

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 24
+    assert len(revs) == 25
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 14
+    assert result.pending_count == 15
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 24
+    assert result.pending_count == 25
 
 
 def test_resolve_pending_unknown_revision():

--- a/tests/test_nul_byte_sanitization.py
+++ b/tests/test_nul_byte_sanitization.py
@@ -1,0 +1,28 @@
+"""A NUL byte (U+0000) in generated content cannot be stored in a Postgres text
+column — it raises CharacterNotInRepertoireError and 500s the whole compile
+batch. MemoryRow strips NUL (and only NUL) at the ORM boundary so one stray byte
+an LLM emits can't sink every memory in the batch.
+"""
+
+from __future__ import annotations
+
+from server.db.tables import MemoryRow
+
+
+def test_memory_content_strips_nul_byte():
+    m = MemoryRow(content="before\x00after", summary="ok\x00")
+    assert m.content == "beforeafter"
+    assert m.summary == "ok"
+
+
+def test_clean_content_is_untouched():
+    text = "On 2026-06-12, added a Helm chart — fixed hook ordering. 日本語 ✓"
+    m = MemoryRow(content=text, summary=text)
+    assert m.content == text
+    assert m.summary == text
+
+
+def test_only_nul_is_removed_other_control_chars_kept():
+    # Tabs/newlines are valid in Postgres text; only NUL is illegal.
+    m = MemoryRow(content="line1\n\tline2\x00", summary="")
+    assert m.content == "line1\n\tline2"

--- a/tests/test_reasoning_model_budget.py
+++ b/tests/test_reasoning_model_budget.py
@@ -1,0 +1,96 @@
+"""Reasoning models (o-series, gpt-5.x, ...) spend part of the token budget on
+hidden reasoning tokens before emitting output, so a tight `max_tokens` cap
+truncates their JSON (→ compile 502) and a 1-token health ping can never finish.
+
+These tests pin the two fixes:
+  1. the compiler floors its per-batch budget at half the (configurable) ceiling,
+     so even a single-episode batch leaves reasoning headroom;
+  2. aping treats a max-tokens / output-limit rejection as reachable — that round
+     trip still proved auth + connectivity.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.core.config import settings
+from server.services import llm as llm_adapter
+from server.services.compilers.llm import LLMCompiler
+
+
+@pytest.mark.asyncio
+async def test_single_episode_batch_gets_reasoning_headroom(monkeypatch):
+    """A single-episode batch must request at least half the ceiling, not the old
+    tight 1500 — otherwise a reasoning model truncates its output."""
+    monkeypatch.setattr(settings, "litellm_compile_max_tokens", 16000)
+    compiler = LLMCompiler.__new__(LLMCompiler)
+    compiler._model = "gpt-5.4-mini"
+
+    captured: dict = {}
+
+    async def fake_acomplete_json(messages, *, model, temperature, max_tokens):
+        captured["max_tokens"] = max_tokens
+        return {"memories": []}
+
+    with patch.object(llm_adapter, "acomplete_json", new=AsyncMock(side_effect=fake_acomplete_json)):
+        await compiler._call_llm_async("some episode text", episode_count=1)
+
+    assert captured["max_tokens"] == 8000  # half of 16000, not 1500
+
+
+@pytest.mark.asyncio
+async def test_budget_scales_with_batch_but_stays_under_ceiling(monkeypatch):
+    monkeypatch.setattr(settings, "litellm_compile_max_tokens", 16000)
+    compiler = LLMCompiler.__new__(LLMCompiler)
+    compiler._model = "gpt-4o-mini"
+    captured: dict = {}
+
+    async def fake_acomplete_json(messages, *, model, temperature, max_tokens):
+        captured["max_tokens"] = max_tokens
+        return {"memories": []}
+
+    with patch.object(llm_adapter, "acomplete_json", new=AsyncMock(side_effect=fake_acomplete_json)):
+        await compiler._call_llm_async("text", episode_count=20)  # 20 * 1500 = 30000
+
+    assert captured["max_tokens"] == 16000  # capped at the ceiling, never above the model's output limit
+
+
+@pytest.mark.asyncio
+async def test_ceiling_is_configurable(monkeypatch):
+    monkeypatch.setattr(settings, "litellm_compile_max_tokens", 4000)  # e.g. a legacy small-output model
+    compiler = LLMCompiler.__new__(LLMCompiler)
+    compiler._model = "gpt-4"
+    captured: dict = {}
+
+    async def fake_acomplete_json(messages, *, model, temperature, max_tokens):
+        captured["max_tokens"] = max_tokens
+        return {"memories": []}
+
+    with patch.object(llm_adapter, "acomplete_json", new=AsyncMock(side_effect=fake_acomplete_json)):
+        await compiler._call_llm_async("text", episode_count=1)
+
+    assert captured["max_tokens"] == 2000  # half of the lowered ceiling
+
+
+@pytest.mark.asyncio
+async def test_aping_treats_output_limit_as_reachable():
+    """A reasoning model that exhausts the 1-token ping budget on reasoning is
+    still REACHABLE — auth + connectivity were proven. aping must not report it
+    as a failure."""
+    err = llm_adapter.LLMProviderError(
+        "OpenAIException - Could not finish the message because max_tokens or model "
+        "output limit was reached."
+    )
+    with patch.object(llm_adapter, "acomplete", new=AsyncMock(side_effect=err)):
+        assert await llm_adapter.aping() is True
+
+
+@pytest.mark.asyncio
+async def test_aping_still_raises_real_failures():
+    """A genuine auth/connectivity failure must still surface."""
+    err = llm_adapter.LLMProviderError("AuthenticationError - invalid api key")
+    with patch.object(llm_adapter, "acomplete", new=AsyncMock(side_effect=err)):
+        with pytest.raises(llm_adapter.LLMProviderError):
+            await llm_adapter.aping()


### PR DESCRIPTION
Three correctness fixes to episode ingest + compilation, each verified end-to-end against a real reasoning model and database.

### Reasoning-model compile budget
Reasoning models (o-series, gpt-5.x) spend output budget on hidden reasoning tokens before emitting JSON, so the compiler's 1500-tokens/episode cap truncated their output → invalid JSON → 502. `max_tokens` is a cap (only generated tokens are billed), so the budget is now generous: a configurable ceiling (`STATEWAVE_LITELLM_COMPILE_MAX_TOKENS`, default 16000), floored at half-ceiling so even a single-episode batch has reasoning headroom. The `aping` health check had the same root cause and now treats an output-limit rejection as reachable.

### NUL-byte sanitization
A NUL byte (U+0000) in generated content cannot be stored in a Postgres text column — it raised `CharacterNotInRepertoireError` and 500'd the whole compile batch. `MemoryRow.content`/`summary` now strip NUL (and only NUL) at the ORM boundary.

### Idempotent ingest
The server ignored the `idempotency_key` clients send, so re-ingesting (re-running a seed, retrying a webhook) duplicated episodes. Adds an `idempotency_key` column + a partial unique index `(tenant_id, subject_id, idempotency_key) NULLS NOT DISTINCT WHERE idempotency_key IS NOT NULL`; `insert_episode` returns the existing episode on conflict; the ingest endpoint reads the key (first-class field + `metadata` fallback). Migration 0025 backfills from metadata, de-dups existing rows (keeps the earliest), and builds the index.

Verified live: a repo at 603 episodes de-duped to ~201 on migrate; re-seeding the same repo is now +0 episodes (was +201). Unit + integration tests included.
