### PR TITLE
release: 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "statewave"
-version = "1.0.0"
+version = "1.1.0"
 description = "Open-source memory runtime for AI agents — durable, structured context with provenance."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump to 1.1.0 for the compile-budget / NUL / idempotent-ingest fixes (already on main via #240). Tag v1.1.0 follows this merge to cut the versioned Docker image + GitHub release.