### PR TITLE
docs(README): bump version surfaces to v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Statewave is the open-source memory runtime that gives AI agents reproducible, p
 
 _If Statewave is useful to you, a ⭐ on the repo helps others discover it._
 
-> **v1.0.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
+> **v1.1.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
 
 ## 🎯 Try it
 
@@ -279,7 +279,7 @@ pytest tests/ -v
 
 ## Current limitations
 
-Statewave is in active development (v1.0.0). Honest status:
+Statewave is in active development (v1.1.0). Honest status:
 
 - **Rate limiting is per-IP** — distributed (Postgres-backed), but keyed by IP only, not per-tenant or per-API-key yet
 - **Multi-tenant is app-layer** — query-scoped data isolation (v0.5) + per-tenant config / policy bundles / receipts (v0.8) + HMAC-signed audit + tenant region pin (v0.9), but no Postgres RLS yet


### PR DESCRIPTION
Mechanical README version-string bumps to match pyproject 1.1.0 (release version-consistency gate). Pairs with the statewave-docs banner bumps. Re-tag of v1.1.0 follows this merge.