### PR TITLE
feat(admin): admin API, dynamic settings, production readiness endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 .venv/
 .pytest_cache/
 AGENTS_INTERNAL.md
+.mcp.json
+.cursor/mcp.json
+.vscode/mcp.json

--- a/alembic/versions/0026_system_settings.py
+++ b/alembic/versions/0026_system_settings.py
@@ -1,0 +1,123 @@
+"""system_settings — DB-backed override layer for env-driven configuration
+
+Revision ID: 0026_system_settings
+Revises: 0025_episodes_idempotency_key
+Create Date: 2026-06-13
+
+Adds three tables that let operators override env-driven settings at runtime
+via the admin UI instead of redeploying for every config change:
+
+  * ``system_settings`` — global key → JSON value overrides
+  * ``system_settings_audit`` — append-only change log (who/when/before/after)
+  * ``tenant_settings`` — per-tenant overrides for the small subset of
+    settings where per-tenant behaviour is meaningful (LLM provider, webhook
+    URL, rate limits)
+
+Precedence resolved at read time: tenant_override → global_db → env → hardcoded
+default. Env continues to be honoured for anything not overridden in the DB,
+so existing deployments keep working without a single config change.
+
+NOT in this migration:
+
+  * Receipt signing keys stay env-only (deliberate — `core/config.py` has a
+    comment forbidding DB persistence)
+  * Database URL, host, port, region, strict_schema stay env-only
+    (changing them at runtime would brick the running process)
+
+Reversible: ``downgrade`` drops all three tables (data loss).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision: str = "0026_system_settings"
+down_revision: Union[str, None] = "0025_episodes_idempotency_key"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "system_settings",
+        sa.Column("key", sa.String(length=128), primary_key=True),
+        sa.Column("value", JSONB, nullable=False),
+        sa.Column("category", sa.String(length=64), nullable=False),
+        sa.Column(
+            "is_secret",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("set_by", sa.String(length=256), nullable=True),
+        sa.Column(
+            "set_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+    op.create_table(
+        "system_settings_audit",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("key", sa.String(length=128), nullable=False),
+        sa.Column("old_value", JSONB, nullable=True),
+        sa.Column("new_value", JSONB, nullable=True),
+        # 'patch' | 'delete' (reset to env) | 'test' (probe, no persistence)
+        sa.Column("action", sa.String(length=32), nullable=False),
+        sa.Column("tenant_id", sa.String(length=256), nullable=True),
+        sa.Column("changed_by", sa.String(length=256), nullable=True),
+        sa.Column(
+            "changed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("note", sa.Text(), nullable=True),
+    )
+    # Audit queries are "show me the history for setting X" — index keyed
+    # on (key, changed_at DESC) makes that O(log n) instead of full scan.
+    op.create_index(
+        "ix_system_settings_audit_key_changed_at",
+        "system_settings_audit",
+        ["key", sa.text("changed_at DESC")],
+    )
+
+    op.create_table(
+        "tenant_settings",
+        sa.Column("tenant_id", sa.String(length=256), nullable=False),
+        sa.Column("key", sa.String(length=128), nullable=False),
+        sa.Column("value", JSONB, nullable=False),
+        sa.Column(
+            "is_secret",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("set_by", sa.String(length=256), nullable=True),
+        sa.Column(
+            "set_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("tenant_id", "key"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("tenant_settings")
+    op.drop_index(
+        "ix_system_settings_audit_key_changed_at",
+        table_name="system_settings_audit",
+    )
+    op.drop_table("system_settings_audit")
+    op.drop_table("system_settings")

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,34 @@
+# Local-dev overlay — builds api + admin from source instead of pulling published images.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
+#
+# The admin Dockerfile lives in ../statewave-admin. Both images rebuild from
+# whatever is on disk so you can iterate without pushing to a registry.
+services:
+  api:
+    image: statewavedev/statewave:local-dev
+    build:
+      context: .
+      dockerfile: Dockerfile
+    pull_policy: never
+    restart: unless-stopped
+
+  admin:
+    image: statewavedev/statewave-admin:local-dev
+    build:
+      context: ../statewave-admin
+      dockerfile: Dockerfile
+    pull_policy: never
+    restart: unless-stopped
+    environment:
+      ADMIN_AUTH_DISABLED: "true"
+      # Encryption key for the admin secrets store (ADMIN_PASSWORD,
+      # STATEWAVE_API_KEY). Must be ≥ 8 chars. Change this before exposing
+      # the admin outside localhost. Rotate by stopping the stack, deleting
+      # the admin_state volume, setting a new key, and re-running the wizard.
+      STATEWAVE_ADMIN_MASTER_KEY: "${STATEWAVE_ADMIN_MASTER_KEY:-dev-local-master-key-local}"
+      STATEWAVE_ADMIN_STATE_DIR: "/data/statewave-admin"
+    volumes:
+      - admin_state:/data/statewave-admin
+
+volumes:
+  admin_state:

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -3106,3 +3106,493 @@ async def patch_tenant_config(tenant_id: str, patch: TenantConfigPatch):
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
+
+
+# ─── Production-readiness check ──────────────────────────────────────────
+
+
+def _compute_readiness_issues(cfg: dict) -> list[dict]:
+    """Build the issues list from a config snapshot.
+
+    Pure function on a dict so the route can run it twice: once with
+    live `settings.X` (what the process is doing now), once with live
+    + DB overrides merged (what the next restart would look like).
+    Diffing the two lets us mark `fix_staged=True` on issues that are
+    queued but not yet active — which is the only reason an operator
+    who just clicked Save sees the same warning persist.
+    """
+    issues: list[dict] = []
+
+    # ─── Critical ──────────────────────────────────────────────────
+    api_key = cfg.get("api_key") or ""
+    if not api_key:
+        issues.append({
+            "id": "no_backend_auth",
+            "severity": "critical",
+            "title": "Backend authentication is disabled",
+            "summary": (
+                "Any client that can reach the backend can read and write "
+                "memories, run migrations, and view receipts. Enable an API "
+                "key before exposing this deployment outside localhost."
+            ),
+            "fix": {"kind": "wizard", "id": "enable-auth"},
+        })
+    elif api_key.startswith("dev-") or api_key in {
+        "dev-local-placeholder",
+        "change-me",
+        "your-api-key-here",
+    }:
+        issues.append({
+            "id": "dev_placeholder_api_key",
+            "severity": "critical",
+            "title": "Backend API key looks like a development placeholder",
+            "summary": (
+                "Rotate to a strong random key — the current value matches "
+                "a known dev/example default and is trivial to guess."
+            ),
+            "fix": {"kind": "wizard", "id": "enable-auth"},
+        })
+
+    # ─── High ──────────────────────────────────────────────────────
+    cors = cfg.get("cors_origins") or []
+    if cors == ["*"] or "*" in cors:
+        issues.append({
+            "id": "permissive_cors",
+            "severity": "high",
+            "title": "CORS allows any browser origin",
+            "summary": (
+                "Replace `[\"*\"]` with the explicit list of origins that "
+                "actually need browser access (e.g. your admin frontend, "
+                "internal apps). A wildcard is a XSS amplifier."
+            ),
+            "fix": {"kind": "setting", "key": "cors_origins"},
+        })
+
+    if cfg.get("debug"):
+        issues.append({
+            "id": "debug_logging",
+            "severity": "high",
+            "title": "Debug logging is enabled",
+            "summary": (
+                "Verbose logs can leak prompts, episode payloads, and "
+                "internal IDs. Turn off `debug` outside development."
+            ),
+            "fix": {"kind": "setting", "key": "debug"},
+        })
+
+    if cfg.get("embedding_provider") == "stub":
+        issues.append({
+            "id": "stub_embeddings",
+            "severity": "high",
+            "title": "Embeddings are using the deterministic stub",
+            "summary": (
+                "Stub embeddings produce hash-based vectors — semantic "
+                "search will return nonsense. Switch to a real provider "
+                "(LiteLLM with an API key) for production memory recall."
+            ),
+            "fix": {"kind": "setting", "key": "embedding_provider"},
+        })
+
+    # ─── Medium ────────────────────────────────────────────────────
+    if cfg.get("rate_limit_rpm", 0) == 0:
+        issues.append({
+            "id": "no_rate_limit",
+            "severity": "medium",
+            "title": "No rate limiting configured",
+            "summary": (
+                "`rate_limit_rpm = 0` disables the limiter entirely. A "
+                "noisy or buggy client can exhaust LLM quota or saturate "
+                "Postgres. A 60–600 RPM cap per tenant is typical."
+            ),
+            "fix": {"kind": "setting", "key": "rate_limit_rpm"},
+        })
+
+    if not cfg.get("strict_schema"):
+        issues.append({
+            "id": "lax_schema_check",
+            "severity": "medium",
+            "title": "Strict schema check is off",
+            "summary": (
+                "The server boots on a stale schema and only warns. Turn "
+                "this on in production so a missed migration fails the "
+                "deploy loudly instead of running with a half-applied "
+                "schema."
+            ),
+            "fix": {"kind": "setting", "key": "strict_schema"},
+        })
+
+    # ─── Low ───────────────────────────────────────────────────────
+    if cfg.get("region") is None:
+        issues.append({
+            "id": "no_region",
+            "severity": "low",
+            "title": "Server region is not pinned",
+            "summary": (
+                "Set `region` if you operate >1 region — the residency "
+                "layer compares per-tenant region pins against it. "
+                "Single-region deployments can ignore this."
+            ),
+            "fix": {"kind": "setting", "key": "region"},
+        })
+
+    return issues
+
+
+@router.get("/readiness-check")
+async def admin_readiness_check():
+    """Opinionated production-readiness scan.
+
+    Returns `{id, severity, title, summary, fix, fix_staged?}` issues.
+
+    `fix_staged` is true when the issue is still firing against the
+    LIVE process state, but a DB-stored override (queued by the
+    operator) would clear it on the next backend restart. The UI uses
+    it to render "Pending restart" affordances instead of the naïve
+    "fix did nothing" appearance — without it, an operator who just
+    saved `debug=false` keeps seeing the warning and assumes the save
+    was ignored.
+
+    Severity scale: see `_compute_readiness_issues`.
+    """
+    from server.core.dynamic_settings import _load_global_overrides
+    from server.db import engine as engine_module
+
+    # Live snapshot — what the process is doing RIGHT NOW. Reads
+    # straight off the pydantic Settings object so it reflects what
+    # the application code actually sees.
+    live_cfg = {
+        "api_key": settings.api_key,
+        "cors_origins": list(settings.cors_origins) if settings.cors_origins else [],
+        "debug": settings.debug,
+        "embedding_provider": settings.embedding_provider,
+        "rate_limit_rpm": settings.rate_limit_rpm,
+        "strict_schema": settings.strict_schema,
+        "region": settings.region,
+        "webhook_url": settings.webhook_url,
+    }
+    live_issues = _compute_readiness_issues(live_cfg)
+
+    # DB overrides — what the next restart would apply on top of env.
+    try:
+        async with engine_module.get_session_factory()() as session:
+            db_overrides = await _load_global_overrides(session)
+    except Exception as exc:
+        # If the override layer is unreachable (DB hiccup, migrations
+        # behind), the readiness check should still respond — staged
+        # detection just degrades to "no staged info". Beats 500ing
+        # the dashboard.
+        logger.warning("readiness_db_lookup_failed", error=str(exc)[:200])
+        db_overrides = {}
+
+    next_cfg = {**live_cfg, **db_overrides}
+    next_issue_ids = {i["id"] for i in _compute_readiness_issues(next_cfg)}
+
+    # An issue is "staged" iff it currently fires AND wouldn't fire on
+    # next restart. That captures both kind:'setting' and kind:'wizard'
+    # remediations uniformly — both flow through the DB override layer.
+    for issue in live_issues:
+        if issue["id"] not in next_issue_ids:
+            issue["fix_staged"] = True
+
+    return {"issues": live_issues}
+
+
+# ─── Connection info ─────────────────────────────────────────────────────
+
+
+@router.get("/connection-info")
+async def admin_connection_info():
+    """Lightweight self-introspection for the admin dashboard's
+    "Connection" card.
+
+    Returns whatever the backend can know about itself without doing
+    work — version, schema head, bind config, region, and whether auth
+    is configured. The admin-server's proxy URL (what hostname clients
+    use to reach this backend) is NOT here because the backend doesn't
+    know it; the admin server surfaces that via
+    `/api/admin/proxy-info`.
+
+    Reads are live: `auth_enabled` reflects the current effective
+    `api_key` (DB override → env), so flipping the toggle in the
+    Settings page shows up here immediately after a restart.
+    """
+    from server.app import get_app_version
+    from server.services.migrations import EXPECTED_HEAD
+
+    return {
+        "version": get_app_version(),
+        "schema_head": EXPECTED_HEAD,
+        "host": settings.host,
+        "port": settings.port,
+        "region": settings.region,
+        "auth_enabled": bool(settings.api_key),
+        "compiler_type": settings.compiler_type,
+        "embedding_provider": settings.embedding_provider,
+        "require_tenant": settings.require_tenant,
+    }
+
+
+# ─── Restart endpoint ───────────────────────────────────────────────────
+#
+# Used by the admin UI's "Restart backend" button when there are pending
+# non-hot-reloadable settings overrides. The pattern is exit-then-restart:
+# we schedule a delayed `os._exit(0)` (so the HTTP response completes
+# first) and rely on the container orchestrator's restart policy to
+# bring the process back. Works on:
+#
+#   - Docker / Compose with `restart: unless-stopped` / `restart: always`
+#   - Kubernetes (a Pod's container restarts on exit by default)
+#   - systemd with `Restart=on-success` or `Restart=always`
+#
+# Without a restart policy the container just stops — that's a deploy
+# misconfiguration, and the UI warns about it. The endpoint is gated
+# by the admin router (which is auth-protected upstream of any caller).
+# We deliberately use `os._exit(0)` rather than `sys.exit` so a stuck
+# background task can't keep the process alive past the requested exit.
+
+
+@router.post("/restart")
+async def admin_restart_endpoint(delay_seconds: float = Query(2.0, ge=0.5, le=10.0)):
+    """Exit the process so the orchestrator restarts it.
+
+    Returns 202 immediately; the actual exit happens after `delay_seconds`
+    so the response can flush. In-flight requests get the standard FastAPI
+    shutdown — they're allowed to finish if the worker grants the grace
+    period (~2s is enough for nearly all admin / readiness probes).
+
+    The endpoint is destructive in the "kicks every connected client off"
+    sense, but not in the "loses data" sense — the DB is the source of
+    truth, and pending overrides land at boot via `apply_db_overrides_to_settings`.
+    """
+    import asyncio
+    import os
+
+    logger.warning("admin_restart_requested", delay_seconds=delay_seconds)
+
+    async def _exit_after_delay() -> None:
+        await asyncio.sleep(delay_seconds)
+        logger.warning("admin_restart_exiting")
+        # `_exit` skips finalizers / atexit handlers — that's deliberate.
+        # Anything that NEEDS to flush before exit (audit rows, etc.) is
+        # already committed by the time the request handler returns;
+        # a stuck cleanup task should not be able to block the restart.
+        os._exit(0)
+
+    asyncio.create_task(_exit_after_delay())
+    return {
+        "ok": True,
+        "message": "Backend will exit shortly; orchestrator restart policy brings it back.",
+        "exit_in_seconds": delay_seconds,
+    }
+
+
+# ─── System settings (DB-backed override layer) ──────────────────────────
+#
+# These endpoints let the admin UI list, read, edit and revert the settings
+# catalogued in `server/core/settings_catalogue.py`. Values resolve at read
+# time with the precedence chain:
+#
+#     tenant_override → global_db → env (pydantic Settings) → default
+#
+# Every editable PATCH / DELETE / tenant write goes through
+# `server.core.dynamic_settings`, which appends an audit row and invalidates
+# the in-process resolution cache. Test probes are side-effect-free and live
+# at /admin/settings/test.
+
+
+class SettingPatchRequest(BaseModel):
+    value: object
+    changed_by: str | None = None
+    note: str | None = None
+
+
+class TenantSettingPatchRequest(BaseModel):
+    value: object
+    changed_by: str | None = None
+    note: str | None = None
+
+
+class SettingTestRequest(BaseModel):
+    key: str
+    value: object
+
+
+@router.get("/settings")
+async def list_settings_endpoint(
+    tenant_id: str | None = Query(None, description="Optional tenant scope for tenant-overridable settings"),
+):
+    """Return the effective value for every catalogued setting.
+
+    Source labels indicate where each value came from:
+
+      * ``tenant_db`` — overridden in `tenant_settings` for the given tenant
+      * ``global_db`` — overridden in `system_settings`
+      * ``env`` — env / `.env` (or hardcoded pydantic default)
+
+    Secrets are returned redacted (``•••<last-3>``). Use the audit log for
+    history.
+    """
+    from server.core.dynamic_settings import get_effective_snapshot
+    from server.db import engine as engine_module
+
+    async with engine_module.get_session_factory()() as session:
+        snapshot = await get_effective_snapshot(session, tenant_id=tenant_id)
+    return {"settings": snapshot, "tenant_id": tenant_id}
+
+
+@router.get("/settings/audit/log")
+async def settings_audit_endpoint(
+    key: str | None = Query(None, description="Filter to one setting key"),
+    limit: int = Query(100, ge=1, le=1000),
+):
+    """Recent settings changes, newest first."""
+    from server.core.dynamic_settings import list_audit
+    from server.db import engine as engine_module
+
+    async with engine_module.get_session_factory()() as session:
+        rows = await list_audit(session, key=key, limit=limit)
+    return {"entries": rows}
+
+
+@router.post("/settings/test")
+async def test_setting_endpoint(req: SettingTestRequest):
+    """Side-effect-free probe of a candidate setting value.
+
+    Used by the admin UI's "Test" button before committing a change to a
+    risky setting (LLM creds, webhook URL). Does NOT persist.
+    """
+    from server.core.dynamic_settings import test_probe
+    from server.db import engine as engine_module
+
+    async with engine_module.get_session_factory()() as session:
+        result = await test_probe(req.key, req.value, session=session)
+    return {"ok": result.ok, "detail": result.detail, "extra": result.extra}
+
+
+@router.patch("/settings/tenants/{tenant_id}/{key}")
+async def patch_tenant_setting_endpoint(
+    tenant_id: str, key: str, req: TenantSettingPatchRequest
+):
+    """UPSERT a per-tenant setting override."""
+    from server.core.dynamic_settings import (
+        SettingValidationError,
+        apply_tenant_override,
+    )
+    from server.db import engine as engine_module
+
+    async with engine_module.get_session_factory()() as session:
+        try:
+            persisted = await apply_tenant_override(
+                tenant_id,
+                key,
+                req.value,
+                session,
+                changed_by=req.changed_by,
+                note=req.note,
+            )
+        except SettingValidationError as exc:
+            await session.rollback()
+            raise HTTPException(status_code=400, detail={"code": "settings.invalid", "message": str(exc)})
+        await session.commit()
+    logger.info("tenant_setting_patched", tenant_id=tenant_id, key=key)
+    return {"tenant_id": tenant_id, "key": key, "value": persisted, "source": "tenant_db"}
+
+
+@router.delete("/settings/tenants/{tenant_id}/{key}")
+async def delete_tenant_setting_endpoint(
+    tenant_id: str,
+    key: str,
+    changed_by: str | None = Query(None),
+    note: str | None = Query(None),
+):
+    """Drop a per-tenant setting override → falls back to global/env."""
+    from server.core.dynamic_settings import (
+        SettingValidationError,
+        delete_tenant_override,
+    )
+    from server.db import engine as engine_module
+
+    async with engine_module.get_session_factory()() as session:
+        try:
+            await delete_tenant_override(
+                tenant_id, key, session, changed_by=changed_by, note=note
+            )
+        except SettingValidationError as exc:
+            await session.rollback()
+            raise HTTPException(status_code=400, detail={"code": "settings.invalid", "message": str(exc)})
+        await session.commit()
+    logger.info("tenant_setting_reverted", tenant_id=tenant_id, key=key)
+    return {"tenant_id": tenant_id, "key": key, "reverted_to": "global_or_env"}
+
+
+# These two MUST come last among `/settings/*` routes — FastAPI matches in
+# definition order, and `/settings/{key}` would otherwise shadow the static
+# routes above (`/settings/test`, `/settings/audit/log`, `/settings/tenants/...`).
+@router.get("/settings/{key}")
+async def get_setting_endpoint(
+    key: str,
+    tenant_id: str | None = Query(None),
+):
+    """Return one setting's effective value + metadata."""
+    from server.core.dynamic_settings import get_effective_snapshot
+    from server.core.settings_catalogue import get_spec
+    from server.db import engine as engine_module
+
+    if get_spec(key) is None:
+        raise HTTPException(status_code=404, detail=f"unknown setting key: {key!r}")
+
+    async with engine_module.get_session_factory()() as session:
+        snapshot = await get_effective_snapshot(session, tenant_id=tenant_id)
+    return snapshot[key]
+
+
+@router.patch("/settings/{key}")
+async def patch_setting_endpoint(key: str, req: SettingPatchRequest):
+    """UPSERT a global override + append an audit row."""
+    from server.core.dynamic_settings import (
+        SettingValidationError,
+        apply_global_override,
+    )
+    from server.db import engine as engine_module
+
+    async with engine_module.get_session_factory()() as session:
+        try:
+            persisted = await apply_global_override(
+                key,
+                req.value,
+                session,
+                changed_by=req.changed_by,
+                note=req.note,
+            )
+        except SettingValidationError as exc:
+            await session.rollback()
+            raise HTTPException(status_code=400, detail={"code": "settings.invalid", "message": str(exc)})
+        await session.commit()
+    logger.info("setting_patched", key=key, changed_by=req.changed_by)
+    return {"key": key, "value": persisted, "source": "global_db"}
+
+
+@router.delete("/settings/{key}")
+async def delete_setting_endpoint(
+    key: str,
+    changed_by: str | None = Query(None),
+    note: str | None = Query(None),
+):
+    """Drop a global override → setting reverts to env value."""
+    from server.core.dynamic_settings import (
+        SettingValidationError,
+        delete_global_override,
+    )
+    from server.db import engine as engine_module
+
+    async with engine_module.get_session_factory()() as session:
+        try:
+            await delete_global_override(
+                key, session, changed_by=changed_by, note=note
+            )
+        except SettingValidationError as exc:
+            await session.rollback()
+            raise HTTPException(status_code=400, detail={"code": "settings.invalid", "message": str(exc)})
+        await session.commit()
+    logger.info("setting_reverted", key=key, changed_by=changed_by)
+    return {"key": key, "reverted_to": "env"}

--- a/server/app.py
+++ b/server/app.py
@@ -101,6 +101,20 @@ async def _cleanup_loop():
 async def lifespan(app: FastAPI):
     # Configure tracing (no-op if opentelemetry not installed)
     setup_tracing()
+
+    # Apply any DB-stored settings overrides BEFORE we wire up modules that
+    # snapshot config (webhooks, llm singleton, …). Failures here log and
+    # continue — the env-only fallback keeps the server bootable even if
+    # the override layer is broken or hasn't been migrated yet.
+    try:
+        from server.core.dynamic_settings import apply_db_overrides_to_settings
+
+        applied = await apply_db_overrides_to_settings()
+        if applied:
+            logger.info("settings_db_overrides_applied", keys=sorted(applied.keys()))
+    except Exception as exc:
+        logger.warning("settings_db_overrides_skipped", reason=str(exc)[:200])
+
     # Configure webhooks
     from server.services import webhooks
 

--- a/server/core/dynamic_settings.py
+++ b/server/core/dynamic_settings.py
@@ -1,0 +1,989 @@
+"""DB-backed override layer for env-driven settings.
+
+Reads `system_settings` / `tenant_settings` on demand and resolves with the
+precedence chain:
+
+    tenant_override → global_db → env (pydantic Settings) → hardcoded_default
+
+Env continues to be honoured for anything not overridden in the DB, so
+existing deployments keep working without any config change. The first PATCH
+against a setting causes the DB layer to start participating.
+
+Process-wide cache: settings tables are read on every resolution by default;
+a tiny TTL cache (``_DB_CACHE_TTL_SECONDS``) keeps hot paths (`/v1/context`,
+webhook fan-out) from doing a SELECT-per-request. The cache is invalidated
+whenever ``apply_global_override`` / ``delete_global_override`` /
+``apply_tenant_override`` / ``delete_tenant_override`` runs in this process.
+Cross-process invalidation (multi-replica) is out of scope for v0; running
+operators see eventual consistency within the TTL window.
+
+Audit + test-probe live here too — see ``record_audit`` and ``test_probe``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    MetaData,
+    String,
+    Table,
+    Text,
+    delete,
+    desc,
+    func,
+    insert,
+    select,
+    update,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.core.config import settings as env_settings
+from server.core.settings_catalogue import (
+    CATALOGUE,
+    SettingSpec,
+    get_spec,
+    is_secret,
+    redact,
+)
+
+# ─── Constants ────────────────────────────────────────────────────────────
+
+# Hot paths hit this every request — too long and operator edits feel
+# laggy; too short and we re-query the DB pointlessly. 5s is a deliberate
+# floor — operator UX of "I changed the setting and the next request
+# picked it up" still feels instant.
+_DB_CACHE_TTL_SECONDS: float = 5.0
+
+
+# ─── Boot-time snapshots ─────────────────────────────────────────────────
+#
+# `_env_baseline` is the pristine env value for every catalogued key,
+# captured at module import BEFORE any DB override mutates env_settings.
+# This is what the UI labels as `source: "env"` — operators expect "env"
+# to mean "your deployment env file", not "the post-boot mutated value".
+#
+# `_applied_values` is what env_settings.X currently holds — i.e. what the
+# live process has actually committed to. Mutated in lock-step with
+# `apply_db_overrides_to_settings()` so the snapshot can detect "this DB
+# override hasn't been picked up yet" by comparing effective vs applied.
+#
+# This split is what makes the "Restart required" banner correct: it
+# fires iff DB effective ≠ process applied, instead of the naïve
+# "source ≠ env" which can never clear (the DB row always exists after
+# a patch, even after restart). Without this split, an operator would
+# see "Restart required" forever after their first override.
+_env_baseline: dict[str, Any] = {}
+_applied_values: dict[str, Any] = {}
+
+
+def _initialise_boot_snapshots() -> None:
+    """Populate the baseline + applied snapshots from the live Settings
+    object. Idempotent: only fills entries it hasn't seen yet, so a
+    sibling test that mutates env_settings between calls can't poison
+    the baseline."""
+    for key in CATALOGUE:
+        if key not in _env_baseline:
+            _env_baseline[key] = getattr(env_settings, key, None)
+        if key not in _applied_values:
+            _applied_values[key] = getattr(env_settings, key, None)
+
+
+# Capture at import. The pydantic Settings has already loaded env vars by
+# the time this module is imported (the `from .config import settings`
+# above triggered it), so the values here are the true env state.
+_initialise_boot_snapshots()
+
+# Hard cap on audit rows so a script that flips a setting every second
+# can't unbounded-grow the table. ~100K rows ≈ 30MB and covers >2y of
+# day-to-day operator activity. Past this, the oldest rows are rolled off
+# inside ``record_audit`` (cheap O(1)-ish DELETE).
+_AUDIT_HARD_CAP: int = 100_000
+
+# Loud sentinel for the no-cached-value-yet branch.
+_SENTINEL = object()
+
+
+# ─── Tables (Core, not ORM) ───────────────────────────────────────────────
+#
+# We define the tables here in their own MetaData rather than adding them to
+# ``server/db/tables.py``. Settings are infrastructure, not application
+# objects — they have no relationships to the rest of the schema, are
+# never exported, never appear in receipts or snapshots, and are only
+# touched by this module + the admin endpoints. Keeping them off the main
+# DeclarativeBase avoids polluting it with rows that should never be
+# auto-discovered by snapshot / clone routines.
+
+_metadata = MetaData()
+
+system_settings = Table(
+    "system_settings",
+    _metadata,
+    Column("key", String(128), primary_key=True),
+    Column("value", JSONB, nullable=False),
+    Column("category", String(64), nullable=False),
+    Column("is_secret", Boolean, nullable=False, default=False),
+    Column("set_by", String(256), nullable=True),
+    Column("set_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+)
+
+system_settings_audit = Table(
+    "system_settings_audit",
+    _metadata,
+    Column("id", UUID(as_uuid=True), primary_key=True),
+    Column("key", String(128), nullable=False),
+    Column("old_value", JSONB, nullable=True),
+    Column("new_value", JSONB, nullable=True),
+    Column("action", String(32), nullable=False),
+    Column("tenant_id", String(256), nullable=True),
+    Column("changed_by", String(256), nullable=True),
+    Column(
+        "changed_at",
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    ),
+    Column("note", Text, nullable=True),
+)
+
+tenant_settings = Table(
+    "tenant_settings",
+    _metadata,
+    Column("tenant_id", String(256), primary_key=True),
+    Column("key", String(128), primary_key=True),
+    Column("value", JSONB, nullable=False),
+    Column("is_secret", Boolean, nullable=False, default=False),
+    Column("set_by", String(256), nullable=True),
+    Column("set_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+)
+
+
+# ─── Cache ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _CachedScope:
+    """In-process snapshot of one (tenant_id or None) settings scope."""
+
+    values: dict[str, Any]
+    expires_at: float
+
+
+_global_cache: _CachedScope | None = None
+_tenant_cache: dict[str, _CachedScope] = {}
+_cache_lock = asyncio.Lock()
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+async def _load_global_overrides(session: AsyncSession) -> dict[str, Any]:
+    """Read all rows from system_settings into a {key: value} dict."""
+    rows = (await session.execute(select(system_settings))).mappings().all()
+    return {row["key"]: row["value"] for row in rows}
+
+
+async def _load_tenant_overrides(session: AsyncSession, tenant_id: str) -> dict[str, Any]:
+    """Read all rows for one tenant from tenant_settings."""
+    rows = (
+        await session.execute(
+            select(tenant_settings).where(tenant_settings.c.tenant_id == tenant_id)
+        )
+    ).mappings().all()
+    return {row["key"]: row["value"] for row in rows}
+
+
+async def _global_overrides_cached(session: AsyncSession) -> dict[str, Any]:
+    """Return cached global overrides, refreshing if past TTL."""
+    global _global_cache
+    async with _cache_lock:
+        if _global_cache is None or _global_cache.expires_at < _now():
+            values = await _load_global_overrides(session)
+            _global_cache = _CachedScope(values=values, expires_at=_now() + _DB_CACHE_TTL_SECONDS)
+        return _global_cache.values
+
+
+async def _tenant_overrides_cached(session: AsyncSession, tenant_id: str) -> dict[str, Any]:
+    async with _cache_lock:
+        cached = _tenant_cache.get(tenant_id)
+        if cached is None or cached.expires_at < _now():
+            values = await _load_tenant_overrides(session, tenant_id)
+            _tenant_cache[tenant_id] = _CachedScope(
+                values=values, expires_at=_now() + _DB_CACHE_TTL_SECONDS
+            )
+        return _tenant_cache[tenant_id].values
+
+
+def _invalidate_global() -> None:
+    global _global_cache
+    _global_cache = None
+
+
+def _invalidate_tenant(tenant_id: str) -> None:
+    _tenant_cache.pop(tenant_id, None)
+
+
+def invalidate_cache(tenant_id: str | None = None) -> None:
+    """Invalidate cached overrides. Tests and reseed scripts call this
+    directly; mutation helpers below do it transparently."""
+    if tenant_id is None:
+        _invalidate_global()
+    else:
+        _invalidate_tenant(tenant_id)
+
+
+# ─── Env-default reads ────────────────────────────────────────────────────
+
+
+def _env_default(key: str) -> Any:
+    """Return the original env-time value for `key`.
+
+    Reads from `_env_baseline` (captured at module import, before any DB
+    overrides applied) so the UI's "env" source label reflects the
+    deployment env — not the post-boot mutation. Falls through to the
+    live Settings attribute for keys not yet baselined (test fixtures
+    that touch a key before `_initialise_boot_snapshots` ran)."""
+    if key in _env_baseline:
+        return _env_baseline[key]
+    return getattr(env_settings, key, None)
+
+
+def _applied_value(key: str) -> Any:
+    """Return env_settings.X as the live process is reading it right now.
+
+    Different from `_env_default` whenever a DB override was applied at
+    boot — those mutated env_settings to the DB value, so the process
+    "applied" what the DB said at the time. Used by the snapshot to
+    compute `pending_restart`."""
+    if key in _applied_values:
+        return _applied_values[key]
+    return getattr(env_settings, key, None)
+
+
+def _is_jsonable(value: Any) -> bool:
+    try:
+        json.dumps(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+# ─── Validation ───────────────────────────────────────────────────────────
+
+
+class SettingValidationError(ValueError):
+    """Raised when a PATCH value doesn't match the catalogue spec.
+
+    Carries a short, human-readable message — the admin endpoint surfaces
+    it as a 400 with `code = settings.invalid`."""
+
+
+def _validate_value(spec: SettingSpec, value: Any) -> Any:
+    """Type-check + light coerce a PATCH value against the spec.
+
+    Heavy domain validation (e.g. a URL ping-test for `webhook_url`) is the
+    job of ``test_probe`` — this function only rejects shape mismatches
+    that can't possibly work."""
+    if value is None:
+        if spec.kind == "string_or_null":
+            return None
+        raise SettingValidationError(f"{spec.key}: null is not allowed for kind {spec.kind}")
+
+    if spec.kind in ("string", "string_or_null"):
+        if not isinstance(value, str):
+            raise SettingValidationError(f"{spec.key}: expected string, got {type(value).__name__}")
+        # Enum check happens BEFORE format check: if `allowed_values` is set,
+        # nothing else applies — value must be exactly one of those.
+        if spec.allowed_values is not None and value not in spec.allowed_values:
+            hint = _suggest(value, spec.allowed_values)
+            allowed = ", ".join(repr(v) for v in spec.allowed_values)
+            msg = f"{spec.key}: {value!r} is not allowed (must be one of: {allowed})"
+            if hint:
+                msg += f". Did you mean {hint!r}?"
+            raise SettingValidationError(msg)
+        if spec.format == "url" and value:
+            if not (value.startswith("http://") or value.startswith("https://")):
+                raise SettingValidationError(
+                    f"{spec.key}: URL must start with http:// or https://"
+                )
+        return value
+
+    if spec.kind == "int":
+        # Reject bool — Python bool is an int subclass; an accidental
+        # `true` would silently land as 1 otherwise.
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise SettingValidationError(f"{spec.key}: expected int, got {type(value).__name__}")
+        _check_range(spec, value)
+        return value
+
+    if spec.kind == "float":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise SettingValidationError(f"{spec.key}: expected number, got {type(value).__name__}")
+        coerced = float(value)
+        _check_range(spec, coerced)
+        return coerced
+
+    if spec.kind == "bool":
+        if not isinstance(value, bool):
+            raise SettingValidationError(f"{spec.key}: expected bool, got {type(value).__name__}")
+        return value
+
+    if spec.kind == "json":
+        if not _is_jsonable(value):
+            raise SettingValidationError(f"{spec.key}: value is not JSON-serialisable")
+        return value
+
+    raise SettingValidationError(f"{spec.key}: unknown kind {spec.kind!r}")
+
+
+def _check_range(spec: SettingSpec, value: float | int) -> None:
+    if spec.min_value is not None and value < spec.min_value:
+        raise SettingValidationError(
+            f"{spec.key}: {value} is below minimum {spec.min_value}"
+        )
+    if spec.max_value is not None and value > spec.max_value:
+        raise SettingValidationError(
+            f"{spec.key}: {value} is above maximum {spec.max_value}"
+        )
+
+
+def _suggest(value: str, options: tuple[str, ...]) -> str | None:
+    """Return the closest match from `options` if it's within an edit-
+    distance of 2, else None. Used to turn 'lllm' → 'Did you mean llm?'
+    instead of a bare 'not allowed' error.
+
+    Pure Levenshtein, no fuzzy-string library dependency."""
+    best: tuple[int, str | None] = (10**9, None)
+    for opt in options:
+        d = _levenshtein(value.lower(), opt.lower())
+        if d < best[0]:
+            best = (d, opt)
+    if best[1] is not None and best[0] <= 2:
+        return best[1]
+    return None
+
+
+def _levenshtein(a: str, b: str) -> int:
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        cur = [i]
+        for j, cb in enumerate(b, start=1):
+            cur.append(min(
+                cur[-1] + 1,           # insert
+                prev[j] + 1,           # delete
+                prev[j - 1] + (ca != cb),  # substitute
+            ))
+        prev = cur
+    return prev[-1]
+
+
+# ─── Public API: resolution ───────────────────────────────────────────────
+
+
+async def get_setting(
+    key: str,
+    session: AsyncSession,
+    *,
+    tenant_id: str | None = None,
+) -> Any:
+    """Resolve the effective value of one setting.
+
+    Precedence: tenant_override → global_db → env. Returns ``None`` only
+    if env itself is None (e.g. unset `api_key`).
+    """
+    spec = get_spec(key)
+    if spec is None:
+        # Unknown keys never resolve via the DB layer — caller should
+        # be reading via the Settings object directly.
+        return _env_default(key)
+
+    if tenant_id is not None and spec.tenant_overridable:
+        tenant_values = await _tenant_overrides_cached(session, tenant_id)
+        if key in tenant_values:
+            return tenant_values[key]
+
+    global_values = await _global_overrides_cached(session)
+    if key in global_values:
+        return global_values[key]
+
+    return _env_default(key)
+
+
+async def get_effective_snapshot(
+    session: AsyncSession,
+    *,
+    tenant_id: str | None = None,
+    redact_secrets: bool = True,
+) -> dict[str, dict[str, Any]]:
+    """Return effective values for every catalogued setting.
+
+    Shape:
+
+        {
+          "litellm_model": {
+            "value": "gpt-4o-mini",
+            "source": "env" | "global_db" | "tenant_db",
+            "is_secret": False,
+            "category": "llm",
+            "kind": "string",
+            "env_name": "STATEWAVE_LITELLM_MODEL",
+            "description": "...",
+            "hot_reloadable": True,
+            "tenant_overridable": True,
+            "editable": True,
+          },
+          ...
+        }
+
+    Secrets are redacted by default — pass ``redact_secrets=False`` only
+    on internal call paths that need the raw value (never on a response
+    that leaves the process).
+    """
+    global_values = await _global_overrides_cached(session)
+    tenant_values: dict[str, Any] = {}
+    if tenant_id is not None:
+        tenant_values = await _tenant_overrides_cached(session, tenant_id)
+
+    out: dict[str, dict[str, Any]] = {}
+    for key, spec in CATALOGUE.items():
+        if tenant_id is not None and spec.tenant_overridable and key in tenant_values:
+            value = tenant_values[key]
+            source = "tenant_db"
+        elif key in global_values:
+            value = global_values[key]
+            source = "global_db"
+        else:
+            value = _env_default(key)
+            source = "env"
+        applied = _applied_value(key)
+        # `pending_restart`: true iff the live process is running a
+        # different value than the DB currently resolves to. Only
+        # meaningful for non-hot-reloadable settings; hot-reloadable
+        # ones are read per-request and never need a restart.
+        #
+        # The diff (effective vs applied) — not source ≠ env — is what
+        # makes the banner CLEAR on its own after the operator restarts:
+        # post-restart `_applied_values[key]` equals the DB value, so
+        # the diff disappears.
+        #
+        # Tenant overrides are deliberately excluded: they're
+        # per-request lookups picked up live by `get_setting()`, so
+        # changing one never needs a process restart.
+        pending_restart = (
+            not spec.hot_reloadable
+            and source != "tenant_db"
+            and value != applied
+        )
+        # Redaction is the LAST step so we compare raw values for the
+        # `pending_restart` diff but still ship `•••<tail>` to the wire.
+        if redact_secrets and spec.is_secret:
+            value = redact(value, key=key)
+            applied = redact(applied, key=key)
+        out[key] = {
+            "value": value,
+            "applied_value": applied,
+            "pending_restart": pending_restart,
+            "source": source,
+            "is_secret": spec.is_secret,
+            "category": spec.category,
+            "kind": spec.kind,
+            "env_name": spec.env_name,
+            "description": spec.description,
+            "hot_reloadable": spec.hot_reloadable,
+            "tenant_overridable": spec.tenant_overridable,
+            "editable": spec.editable,
+            "allowed_values": list(spec.allowed_values) if spec.allowed_values else None,
+            "min_value": spec.min_value,
+            "max_value": spec.max_value,
+            "format": spec.format,
+        }
+    return out
+
+
+# ─── Public API: mutation ────────────────────────────────────────────────
+
+
+async def apply_global_override(
+    key: str,
+    value: Any,
+    session: AsyncSession,
+    *,
+    changed_by: str | None = None,
+    note: str | None = None,
+) -> Any:
+    """UPSERT a global override and append an audit row.
+
+    Returns the validated (and possibly coerced) value as persisted. Raises
+    ``SettingValidationError`` for unknown keys / non-editable keys / bad
+    shape. The caller is expected to commit; this function never commits
+    on its own so it composes with the request-scoped session pattern.
+    """
+    spec = get_spec(key)
+    if spec is None:
+        raise SettingValidationError(f"unknown setting key: {key!r}")
+    if not spec.editable:
+        raise SettingValidationError(f"{key!r} is not editable (env / deploy-time only)")
+    validated = _validate_value(spec, value)
+
+    # Capture old value for audit — env vs prior DB row.
+    old_global = await _load_global_overrides(session)
+    old_value = old_global.get(key, _env_default(key))
+
+    existing = (
+        await session.execute(select(system_settings).where(system_settings.c.key == key))
+    ).first()
+    if existing is None:
+        await session.execute(
+            insert(system_settings).values(
+                key=key,
+                value=validated,
+                category=spec.category,
+                is_secret=spec.is_secret,
+                set_by=changed_by,
+            )
+        )
+    else:
+        await session.execute(
+            update(system_settings)
+            .where(system_settings.c.key == key)
+            .values(
+                value=validated,
+                category=spec.category,
+                is_secret=spec.is_secret,
+                set_by=changed_by,
+                set_at=func.now(),
+            )
+        )
+
+    await record_audit(
+        session,
+        key=key,
+        old_value=old_value,
+        new_value=validated,
+        action="patch",
+        changed_by=changed_by,
+        tenant_id=None,
+        note=note,
+    )
+    _invalidate_global()
+    return validated
+
+
+async def delete_global_override(
+    key: str,
+    session: AsyncSession,
+    *,
+    changed_by: str | None = None,
+    note: str | None = None,
+) -> None:
+    """Drop a global override row (revert the setting to its env value).
+
+    Idempotent — deleting a non-existent override is a no-op.
+    """
+    spec = get_spec(key)
+    if spec is None:
+        raise SettingValidationError(f"unknown setting key: {key!r}")
+
+    old_global = await _load_global_overrides(session)
+    if key not in old_global:
+        return  # nothing to do — already at env default
+    old_value = old_global[key]
+
+    await session.execute(delete(system_settings).where(system_settings.c.key == key))
+    await record_audit(
+        session,
+        key=key,
+        old_value=old_value,
+        new_value=_env_default(key),
+        action="delete",
+        changed_by=changed_by,
+        tenant_id=None,
+        note=note,
+    )
+    _invalidate_global()
+
+
+async def apply_tenant_override(
+    tenant_id: str,
+    key: str,
+    value: Any,
+    session: AsyncSession,
+    *,
+    changed_by: str | None = None,
+    note: str | None = None,
+) -> Any:
+    """UPSERT a per-tenant override + append audit. See :func:`apply_global_override`."""
+    spec = get_spec(key)
+    if spec is None:
+        raise SettingValidationError(f"unknown setting key: {key!r}")
+    if not spec.editable:
+        raise SettingValidationError(f"{key!r} is not editable")
+    if not spec.tenant_overridable:
+        raise SettingValidationError(f"{key!r} is not tenant-overridable")
+    validated = _validate_value(spec, value)
+
+    old_tenant = await _load_tenant_overrides(session, tenant_id)
+    old_value = old_tenant.get(key, _SENTINEL)
+    audit_old = old_value if old_value is not _SENTINEL else None
+
+    existing = (
+        await session.execute(
+            select(tenant_settings).where(
+                tenant_settings.c.tenant_id == tenant_id,
+                tenant_settings.c.key == key,
+            )
+        )
+    ).first()
+    if existing is None:
+        await session.execute(
+            insert(tenant_settings).values(
+                tenant_id=tenant_id,
+                key=key,
+                value=validated,
+                is_secret=spec.is_secret,
+                set_by=changed_by,
+            )
+        )
+    else:
+        await session.execute(
+            update(tenant_settings)
+            .where(
+                tenant_settings.c.tenant_id == tenant_id,
+                tenant_settings.c.key == key,
+            )
+            .values(
+                value=validated,
+                is_secret=spec.is_secret,
+                set_by=changed_by,
+                set_at=func.now(),
+            )
+        )
+
+    await record_audit(
+        session,
+        key=key,
+        old_value=audit_old,
+        new_value=validated,
+        action="patch",
+        changed_by=changed_by,
+        tenant_id=tenant_id,
+        note=note,
+    )
+    _invalidate_tenant(tenant_id)
+    return validated
+
+
+async def delete_tenant_override(
+    tenant_id: str,
+    key: str,
+    session: AsyncSession,
+    *,
+    changed_by: str | None = None,
+    note: str | None = None,
+) -> None:
+    """Drop a tenant override (revert to global / env fallback)."""
+    spec = get_spec(key)
+    if spec is None:
+        raise SettingValidationError(f"unknown setting key: {key!r}")
+
+    old_tenant = await _load_tenant_overrides(session, tenant_id)
+    if key not in old_tenant:
+        return
+    old_value = old_tenant[key]
+
+    await session.execute(
+        delete(tenant_settings).where(
+            tenant_settings.c.tenant_id == tenant_id,
+            tenant_settings.c.key == key,
+        )
+    )
+    await record_audit(
+        session,
+        key=key,
+        old_value=old_value,
+        new_value=None,
+        action="delete",
+        changed_by=changed_by,
+        tenant_id=tenant_id,
+        note=note,
+    )
+    _invalidate_tenant(tenant_id)
+
+
+# ─── Audit ────────────────────────────────────────────────────────────────
+
+
+async def record_audit(
+    session: AsyncSession,
+    *,
+    key: str,
+    old_value: Any,
+    new_value: Any,
+    action: str,
+    changed_by: str | None,
+    tenant_id: str | None,
+    note: str | None = None,
+) -> None:
+    """Append one row to system_settings_audit.
+
+    Secrets are redacted before persistence so a leaked audit dump can't
+    reconstruct historical credentials. The caller commits the surrounding
+    transaction.
+    """
+    redacted_old = redact(old_value, key=key) if is_secret(key) else old_value
+    redacted_new = redact(new_value, key=key) if is_secret(key) else new_value
+
+    await session.execute(
+        insert(system_settings_audit).values(
+            key=key,
+            old_value=redacted_old,
+            new_value=redacted_new,
+            action=action,
+            tenant_id=tenant_id,
+            changed_by=changed_by,
+            note=note,
+        )
+    )
+
+    # Roll off the oldest rows past the hard cap — keeps audit growth
+    # bounded without operator intervention. Approximate: we only DELETE
+    # when the count exceeds the cap, and we trim down to 90% so we
+    # don't run the cull on every single insert at the boundary.
+    count_row = (await session.execute(select(func.count(system_settings_audit.c.id)))).scalar()
+    count = int(count_row or 0)
+    if count > _AUDIT_HARD_CAP:
+        target = int(_AUDIT_HARD_CAP * 0.9)
+        excess = count - target
+        # Find the changed_at boundary of the oldest `excess` rows and
+        # delete everything older than it. One round-trip.
+        cutoff = (
+            await session.execute(
+                select(system_settings_audit.c.changed_at)
+                .order_by(system_settings_audit.c.changed_at)
+                .limit(1)
+                .offset(excess)
+            )
+        ).scalar()
+        if cutoff is not None:
+            await session.execute(
+                delete(system_settings_audit).where(
+                    system_settings_audit.c.changed_at < cutoff
+                )
+            )
+
+
+async def list_audit(
+    session: AsyncSession,
+    *,
+    key: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return recent audit rows, newest first. Optionally filter to one key."""
+    limit = max(1, min(limit, 1000))
+    stmt = select(system_settings_audit).order_by(desc(system_settings_audit.c.changed_at)).limit(limit)
+    if key is not None:
+        stmt = stmt.where(system_settings_audit.c.key == key)
+    rows = (await session.execute(stmt)).mappings().all()
+    return [
+        {
+            "id": str(row["id"]),
+            "key": row["key"],
+            "old_value": row["old_value"],
+            "new_value": row["new_value"],
+            "action": row["action"],
+            "tenant_id": row["tenant_id"],
+            "changed_by": row["changed_by"],
+            "changed_at": row["changed_at"].isoformat() if row["changed_at"] else None,
+            "note": row["note"],
+        }
+        for row in rows
+    ]
+
+
+# ─── Test probe ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class ProbeResult:
+    """Outcome of a non-persisting validity check."""
+
+    ok: bool
+    detail: str
+    extra: dict[str, Any] | None = None
+
+
+async def test_probe(
+    key: str,
+    value: Any,
+    *,
+    session: AsyncSession | None = None,
+) -> ProbeResult:
+    """Run a side-effect-free validity check for a candidate value.
+
+    Used by the admin UI's "Test" button before committing a change to a
+    risky setting (LLM creds, webhook URL). Currently covers:
+
+      * ``litellm_*`` — round-trips a 1-token completion against the
+        proposed credentials
+      * ``webhook_url`` — issues an OPTIONS / HEAD request and checks for
+        2xx/3xx
+      * everything else — runs the same shape validation as a PATCH
+        without writing
+
+    Returns a :class:`ProbeResult` instead of raising so the UI can show a
+    friendly red toast without crashing the page on transient failures.
+    """
+    spec = get_spec(key)
+    if spec is None:
+        return ProbeResult(ok=False, detail=f"unknown setting key: {key!r}")
+
+    try:
+        _validate_value(spec, value)
+    except SettingValidationError as exc:
+        return ProbeResult(ok=False, detail=str(exc))
+
+    # Provider-specific probes — kept minimal to avoid pulling in heavy
+    # deps at import time. Each branch self-contains the import so a probe
+    # for one provider doesn't pull in the others' libs.
+    if key in {"litellm_model", "litellm_api_key", "litellm_api_base"}:
+        return await _probe_litellm(key, value, session=session)
+
+    if key == "webhook_url":
+        return await _probe_webhook_url(value)
+
+    return ProbeResult(ok=True, detail="shape ok (no provider probe defined)")
+
+
+async def _probe_litellm(
+    key: str, value: Any, *, session: AsyncSession | None
+) -> ProbeResult:
+    """Send a 1-token completion using the proposed override layered onto
+    the rest of the env-driven LiteLLM config.
+
+    Routed through ``server.services.llm.aping_with_overrides`` so this
+    module never imports LiteLLM directly — the adapter-isolation rule
+    (enforced by ``tests/test_llm_adapter_isolation.py``) keeps provider
+    SDKs in one place.
+    """
+    from server.services.llm import aping_with_overrides
+
+    # Resolve the rest of the LiteLLM config from current env, then patch in
+    # the candidate value. This way the operator can test a new key without
+    # also having to provide model + base.
+    overrides: dict[str, Any] = {}
+    if session is not None:
+        snap = await get_effective_snapshot(session, redact_secrets=False)
+        overrides = {k: v["value"] for k, v in snap.items()}
+    else:
+        overrides = {k: _env_default(k) for k in CATALOGUE}
+    overrides[key] = value
+
+    model = overrides.get("litellm_model") or "gpt-4o-mini"
+    api_key = overrides.get("litellm_api_key")
+    api_base = overrides.get("litellm_api_base")
+    timeout = overrides.get("litellm_timeout_seconds") or 30.0
+
+    if not api_key:
+        return ProbeResult(ok=False, detail="no api key available to probe with")
+
+    ok, detail = await aping_with_overrides(
+        model=model, api_key=api_key, api_base=api_base, timeout=float(timeout)
+    )
+    return ProbeResult(ok=ok, detail=detail or ("ok" if ok else "failed"), extra={"model": model})
+
+
+async def apply_db_overrides_to_settings() -> dict[str, Any]:
+    """Read ``system_settings`` and mutate ``env_settings`` in place.
+
+    Called once at FastAPI lifespan startup, BEFORE webhook / LLM
+    singletons read their config. This is the lightweight alternative to
+    plumbing dynamic-settings reads through every call site: the running
+    process behaves *as if* the DB overrides were set in the env.
+
+    Refreshes `_applied_values` after every key it mutates so the
+    snapshot's `pending_restart` flag is accurate: a key written to the
+    DB after this point will diff against this baseline and report
+    `pending_restart=true`, then clear on next restart when this
+    function re-runs.
+
+    Returns the dict of {key: applied_value} so the caller can log it.
+    Idempotent — calling twice is fine. Failures (table missing, DB
+    unreachable) propagate so the caller can decide whether to keep
+    booting; the lifespan handler logs and continues, so a corrupt
+    settings table never blocks the server from coming up.
+    """
+    from server.db import engine as engine_module
+
+    # Baselines must be in place before we mutate anything. Cheap +
+    # idempotent — re-fills nothing it already saw at import time.
+    _initialise_boot_snapshots()
+
+    applied: dict[str, Any] = {}
+    async with engine_module.get_session_factory()() as session:
+        global_values = await _load_global_overrides(session)
+    for key, value in global_values.items():
+        spec = CATALOGUE.get(key)
+        if spec is None or not hasattr(env_settings, key):
+            continue
+        try:
+            object.__setattr__(env_settings, key, value)
+            applied[key] = value
+        except Exception:
+            # pydantic-settings v2 may freeze attributes — fall back to
+            # __dict__ direct write (still picked up by getattr).
+            try:
+                env_settings.__dict__[key] = value
+                applied[key] = value
+            except Exception:
+                continue
+
+    # Re-snapshot the applied values from env_settings AFTER all mutations.
+    # Reading from env_settings (not from `applied`) so settings the
+    # operator never touched still show the correct boot-time value.
+    for key in CATALOGUE:
+        _applied_values[key] = getattr(env_settings, key, None)
+
+    return applied
+
+
+async def _probe_webhook_url(value: Any) -> ProbeResult:
+    """Issue a short HEAD against the URL — we just want to know it
+    resolves + responds. 2xx/3xx → ok; 4xx → caller will still send
+    POSTs (some webhook receivers reject HEAD), so we report 405/404 as
+    "endpoint reachable" rather than fail; 5xx → fail."""
+    if value in (None, ""):
+        return ProbeResult(ok=True, detail="empty url → webhooks disabled")
+    if not isinstance(value, str) or not value.startswith(("http://", "https://")):
+        return ProbeResult(ok=False, detail="must be http(s)://")
+    try:
+        import httpx  # type: ignore[import-not-found]
+    except Exception as exc:
+        return ProbeResult(ok=False, detail=f"httpx unavailable: {exc}")
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.head(value)
+    except Exception as exc:
+        return ProbeResult(ok=False, detail=f"{type(exc).__name__}: {exc}")
+    if r.status_code >= 500:
+        return ProbeResult(ok=False, detail=f"endpoint returned {r.status_code}", extra={"status": r.status_code})
+    return ProbeResult(
+        ok=True,
+        detail=f"endpoint reachable (HEAD → {r.status_code})",
+        extra={"status": r.status_code},
+    )

--- a/server/core/dynamic_settings.py
+++ b/server/core/dynamic_settings.py
@@ -29,7 +29,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from sqlalchemy import (
-    JSON,
     Boolean,
     Column,
     DateTime,

--- a/server/core/dynamic_settings.py
+++ b/server/core/dynamic_settings.py
@@ -250,10 +250,11 @@ def _env_default(key: str) -> Any:
     Reads from `_env_baseline` (captured at module import, before any DB
     overrides applied) so the UI's "env" source label reflects the
     deployment env — not the post-boot mutation. Falls through to the
-    live Settings attribute for keys not yet baselined (test fixtures
-    that touch a key before `_initialise_boot_snapshots` ran)."""
-    if key in _env_baseline:
-        return _env_baseline[key]
+    live Settings attribute when the baseline value is None (key absent or
+    unset at boot) so monkeypatched test fixtures are reflected correctly."""
+    baseline = _env_baseline.get(key)
+    if baseline is not None:
+        return baseline
     return getattr(env_settings, key, None)
 
 

--- a/server/core/settings_catalogue.py
+++ b/server/core/settings_catalogue.py
@@ -1,0 +1,514 @@
+"""Static catalogue of every setting the admin UI exposes.
+
+This is the **single source of truth** for what's editable, what's a secret,
+what category it falls into, whether it can hot-reload, and whether tenants
+can override it. Adding a new env-driven setting here makes it appear on
+the admin /settings page automatically.
+
+The catalogue does NOT carry values — values live in env (read by pydantic
+`Settings`) plus DB overrides (`system_settings` / `tenant_settings` tables).
+The `get_setting()` helper combines them; `SettingSpec` describes what each
+key MEANS.
+
+NOT exposed (intentionally) — the admin UI never reads these and never
+offers them for edit:
+
+  * ``database_url`` / ``host`` / ``port`` — bootstrap-locked
+  * ``region`` / ``strict_schema`` — bootstrap-locked
+  * ``receipt_signing_keys`` — comment in core/config.py explicitly forbids
+    DB persistence
+  * ``database_echo`` / ``debug`` — local-dev only
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+Kind = Literal["string", "int", "float", "bool", "json", "string_or_null"]
+Category = Literal[
+    "backend",
+    "auth",
+    "llm",
+    "embeddings",
+    "webhooks",
+    "rate_limits",
+    "memory",
+    "labeling",
+    "advanced",
+]
+
+
+@dataclass(frozen=True)
+class SettingSpec:
+    """Per-setting metadata.
+
+    Attributes:
+        key: stable identifier used in API + DB (matches the pydantic
+            Settings attribute name, lowercase snake_case).
+        env_name: the legacy env var name (e.g. STATEWAVE_LITELLM_MODEL).
+            Surfaced in the UI so operators can map UI → deployment env.
+        category: which UI tab this lands in.
+        kind: how the JSON value is validated + how the UI renders it.
+        is_secret: when true, the API returns a redacted preview
+            (`sk-•••abc`) instead of the raw value; the UI shows a
+            write-only field. Audit log redacts likewise.
+        hot_reloadable: when true, a PATCH takes effect on the next
+            request without a restart. When false, the UI badges the
+            row as "Requires restart" and the operator must redeploy.
+        tenant_overridable: when true, the setting can also be overridden
+            per-tenant via the tenant_settings table.
+        description: human-readable explanation (markdown-safe).
+        editable: when false, the value is shown read-only with an
+            explanation. Used for env-locked settings that still need
+            UI visibility (e.g. database_url).
+    """
+
+    key: str
+    env_name: str
+    category: Category
+    kind: Kind
+    is_secret: bool = False
+    # Default False is the honest position: most settings are snapshotted
+    # by a singleton at process startup (webhooks.configure, llm compiler,
+    # rate-limit middleware, …). The override layer applies at startup
+    # (see ``dynamic_settings.apply_db_overrides_to_settings``), so an
+    # edit is live on next restart. Per-call-reading settings flip this
+    # to True explicitly.
+    hot_reloadable: bool = False
+    tenant_overridable: bool = False
+    description: str = ""
+    editable: bool = True
+    # Fixed set of legal values, when the setting is an enum-shaped string.
+    # Rendered as a `<select>` in the admin UI (no typos possible) and
+    # enforced server-side in ``dynamic_settings._validate_value``. None =
+    # any value of `kind` is allowed.
+    allowed_values: tuple[str, ...] | None = None
+    # Per-kind numeric bounds. Both inclusive; either may be None for
+    # one-sided checks. Surfaced to the UI so an HTML `<input type="number">`
+    # can prevent out-of-range submission, and re-checked server-side.
+    min_value: float | int | None = None
+    max_value: float | int | None = None
+    # Lightweight string pattern. Currently used to mark URL-shaped fields
+    # so the UI can validate format on blur. Server-side this is advisory
+    # — pydantic catches malformed URLs at use-time anyway.
+    format: str | None = None  # "url" | None
+
+
+# Lowercase key → SettingSpec. Key matches the pydantic Settings attribute.
+CATALOGUE: dict[str, SettingSpec] = {
+    # ─── Backend (read-only — bootstrap-locked) ──────────────────────────
+    "debug": SettingSpec(
+        key="debug",
+        env_name="STATEWAVE_DEBUG",
+        category="backend",
+        kind="bool",
+        hot_reloadable=False,
+        description=(
+            "Verbose logging. Off in production — debug logs can leak "
+            "prompts, full episode payloads, and internal IDs into "
+            "your log pipeline. Applied on next server restart. The "
+            "production-readiness check fires when this is true."
+        ),
+    ),
+    "database_url": SettingSpec(
+        key="database_url",
+        env_name="STATEWAVE_DATABASE_URL",
+        category="backend",
+        kind="string",
+        is_secret=True,
+        hot_reloadable=False,
+        editable=False,
+        description=(
+            "Postgres connection string. Set at deploy time via env; "
+            "editing at runtime would brick the running process."
+        ),
+    ),
+    "host": SettingSpec(
+        key="host",
+        env_name="STATEWAVE_HOST",
+        category="backend",
+        kind="string",
+        hot_reloadable=False,
+        description=(
+            "TCP bind interface (e.g. `0.0.0.0` to accept any host, "
+            "`127.0.0.1` to restrict to loopback). Applied on next "
+            "server restart."
+        ),
+    ),
+    "port": SettingSpec(
+        key="port",
+        env_name="STATEWAVE_PORT",
+        category="backend",
+        kind="int",
+        hot_reloadable=False,
+        description="TCP bind port. Applied on next server restart.",
+        min_value=1,
+        max_value=65535,
+    ),
+    "region": SettingSpec(
+        key="region",
+        env_name="STATEWAVE_REGION",
+        category="backend",
+        kind="string_or_null",
+        hot_reloadable=False,
+        description=(
+            "Server region label used by the residency layer "
+            "(e.g. `eu`, `us-east`). Tenants pinned to a different "
+            "region are rejected with 403. Applied on next restart "
+            "so in-flight requests aren't re-routed mid-flight."
+        ),
+    ),
+    "strict_schema": SettingSpec(
+        key="strict_schema",
+        env_name="STATEWAVE_STRICT_SCHEMA",
+        category="backend",
+        kind="bool",
+        hot_reloadable=False,
+        description=(
+            "When true, the server refuses to boot if migrations are "
+            "behind. Use in production to fail loudly on a missed "
+            "deploy step instead of running on a stale schema."
+        ),
+    ),
+    # ─── Auth & access ─────────────────────────────────────────────────────
+    "api_key": SettingSpec(
+        key="api_key",
+        env_name="STATEWAVE_API_KEY",
+        category="auth",
+        kind="string_or_null",
+        is_secret=True,
+        hot_reloadable=False,
+        description=(
+            "API key the backend requires on every request. Empty = open "
+            "access. Changes take effect on next request, but a wrong "
+            "value can lock the admin out — pair with the deployment env "
+            "as fallback."
+        ),
+    ),
+    "require_tenant": SettingSpec(
+        key="require_tenant",
+        env_name="STATEWAVE_REQUIRE_TENANT",
+        category="auth",
+        kind="bool",
+        hot_reloadable=False,
+        description=(
+            "When true, every request must carry the tenant header. "
+            "Takes effect on restart."
+        ),
+    ),
+    "tenant_header": SettingSpec(
+        key="tenant_header",
+        env_name="STATEWAVE_TENANT_HEADER",
+        category="auth",
+        kind="string",
+        hot_reloadable=False,
+        description="HTTP header carrying tenant id. Default: X-Tenant-ID.",
+    ),
+    "cors_origins": SettingSpec(
+        key="cors_origins",
+        env_name="STATEWAVE_CORS_ORIGINS",
+        category="auth",
+        kind="json",
+        hot_reloadable=False,
+        description=(
+            "JSON array of allowed browser origins (e.g. "
+            "`[\"https://admin.example.com\"]`). `[\"*\"]` allows any "
+            "origin — fine for local dev, refuse in production. Applied "
+            "on next restart. A wrong value can lock the admin frontend "
+            "out of the backend — verify in a staging environment first."
+        ),
+    ),
+    # ─── LLM ─────────────────────────────────────────────────────────────
+    "litellm_model": SettingSpec(
+        key="litellm_model",
+        env_name="STATEWAVE_LITELLM_MODEL",
+        category="llm",
+        kind="string",
+        tenant_overridable=True,
+        description=(
+            "LiteLLM model identifier (e.g. `gpt-4o-mini`, "
+            "`anthropic/claude-3-5-sonnet-latest`)."
+        ),
+    ),
+    "litellm_api_key": SettingSpec(
+        key="litellm_api_key",
+        env_name="STATEWAVE_LITELLM_API_KEY",
+        category="llm",
+        kind="string_or_null",
+        is_secret=True,
+        tenant_overridable=True,
+        description="API key forwarded to the LLM provider via LiteLLM.",
+    ),
+    "litellm_api_base": SettingSpec(
+        key="litellm_api_base",
+        env_name="STATEWAVE_LITELLM_API_BASE",
+        category="llm",
+        kind="string_or_null",
+        description=(
+            "LiteLLM base URL. Set for Azure OpenAI, self-hosted Ollama, "
+            "or a LiteLLM proxy."
+        ),
+        format="url",
+    ),
+    "litellm_timeout_seconds": SettingSpec(
+        key="litellm_timeout_seconds",
+        env_name="STATEWAVE_LITELLM_TIMEOUT_SECONDS",
+        category="llm",
+        kind="float",
+        description="LLM request timeout in seconds.",
+        min_value=1.0,
+        max_value=600.0,
+    ),
+    "litellm_max_retries": SettingSpec(
+        key="litellm_max_retries",
+        env_name="STATEWAVE_LITELLM_MAX_RETRIES",
+        category="llm",
+        kind="int",
+        description="Max retries on transient LLM provider errors.",
+        min_value=0,
+        max_value=10,
+    ),
+    "litellm_temperature": SettingSpec(
+        key="litellm_temperature",
+        env_name="STATEWAVE_LITELLM_TEMPERATURE",
+        category="llm",
+        kind="float",
+        description="Sampling temperature for compile LLM calls.",
+        min_value=0.0,
+        max_value=2.0,
+    ),
+    "litellm_compile_max_tokens": SettingSpec(
+        key="litellm_compile_max_tokens",
+        env_name="STATEWAVE_LITELLM_COMPILE_MAX_TOKENS",
+        category="llm",
+        kind="int",
+        description=(
+            "Output-token cap for the LLM compiler. Cap, not target — "
+            "reasoning models spend hidden tokens, lower values risk "
+            "truncating their JSON output."
+        ),
+        min_value=64,
+        max_value=128000,
+    ),
+    "compiler_type": SettingSpec(
+        key="compiler_type",
+        env_name="STATEWAVE_COMPILER_TYPE",
+        category="llm",
+        kind="string",
+        description="Memory compiler: `heuristic` (deterministic) or `llm`.",
+        allowed_values=("heuristic", "llm"),
+    ),
+    # ─── Embeddings ──────────────────────────────────────────────────────
+    "embedding_provider": SettingSpec(
+        key="embedding_provider",
+        env_name="STATEWAVE_EMBEDDING_PROVIDER",
+        category="embeddings",
+        kind="string",
+        hot_reloadable=False,
+        description=(
+            "Embedding backend: `stub` (deterministic, no semantic search), "
+            "`litellm`, or `none` (disable embeddings). Singleton built at "
+            "startup — restart required."
+        ),
+        allowed_values=("stub", "litellm", "none"),
+    ),
+    "litellm_embedding_model": SettingSpec(
+        key="litellm_embedding_model",
+        env_name="STATEWAVE_LITELLM_EMBEDDING_MODEL",
+        category="embeddings",
+        kind="string",
+        tenant_overridable=True,
+        description="LiteLLM embedding model (e.g. `text-embedding-3-small`).",
+    ),
+    # ─── Webhooks ────────────────────────────────────────────────────────
+    "webhook_url": SettingSpec(
+        key="webhook_url",
+        env_name="STATEWAVE_WEBHOOK_URL",
+        category="webhooks",
+        kind="string_or_null",
+        tenant_overridable=True,
+        description=(
+            "Destination URL for outbound webhooks. Empty = webhooks "
+            "disabled."
+        ),
+        format="url",
+    ),
+    "webhook_timeout": SettingSpec(
+        key="webhook_timeout",
+        env_name="STATEWAVE_WEBHOOK_TIMEOUT",
+        category="webhooks",
+        kind="float",
+        description="Webhook delivery timeout in seconds.",
+        min_value=0.5,
+        max_value=120.0,
+    ),
+    "webhook_events": SettingSpec(
+        key="webhook_events",
+        env_name="STATEWAVE_WEBHOOK_EVENTS",
+        category="webhooks",
+        kind="string",
+        tenant_overridable=True,
+        description=(
+            "Comma-separated event-type allowlist. Empty = deliver every "
+            "event (default)."
+        ),
+    ),
+    # ─── Rate limits ─────────────────────────────────────────────────────
+    "rate_limit_rpm": SettingSpec(
+        key="rate_limit_rpm",
+        env_name="STATEWAVE_RATE_LIMIT_RPM",
+        category="rate_limits",
+        kind="int",
+        tenant_overridable=True,
+        description="Requests-per-minute cap. 0 disables rate limiting.",
+        min_value=0,
+        max_value=1_000_000,
+    ),
+    "rate_limit_strategy": SettingSpec(
+        key="rate_limit_strategy",
+        env_name="STATEWAVE_RATE_LIMIT_STRATEGY",
+        category="rate_limits",
+        kind="string",
+        hot_reloadable=False,
+        description=(
+            "`memory` (default, single-process) or `distributed` "
+            "(Postgres-backed, multi-replica). Middleware is wired at "
+            "startup — switching requires restart."
+        ),
+        allowed_values=("memory", "distributed"),
+    ),
+    # ─── Memory ──────────────────────────────────────────────────────────
+    "compile_batch_size": SettingSpec(
+        key="compile_batch_size",
+        env_name="STATEWAVE_COMPILE_BATCH_SIZE",
+        category="memory",
+        kind="int",
+        description=(
+            "Max episodes per compile-call batch. Higher = fewer batches "
+            "but riskier per-call latency."
+        ),
+        min_value=1,
+        max_value=10_000,
+    ),
+    "compile_max_iterations": SettingSpec(
+        key="compile_max_iterations",
+        env_name="STATEWAVE_COMPILE_MAX_ITERATIONS",
+        category="memory",
+        kind="int",
+        description=(
+            "Defensive cap for async compile loops to prevent a "
+            "non-advancing compiler from running unbounded."
+        ),
+        min_value=1,
+        max_value=100_000,
+    ),
+    "compile_job_retention_hours": SettingSpec(
+        key="compile_job_retention_hours",
+        env_name="STATEWAVE_COMPILE_JOB_RETENTION_HOURS",
+        category="memory",
+        kind="int",
+        description="Hours to keep finished compile_jobs rows. 0 = forever.",
+        min_value=0,
+        max_value=8760,
+    ),
+    "kind_ttl_days": SettingSpec(
+        key="kind_ttl_days",
+        env_name="STATEWAVE_KIND_TTL_DAYS",
+        category="memory",
+        kind="json",
+        description=(
+            "Per-kind expiry in days, e.g. "
+            "`{\"episode_summary\": 30, \"artifact_ref\": 7}`. Missing "
+            "kinds never expire."
+        ),
+    ),
+    "memory_import_max_bytes": SettingSpec(
+        key="memory_import_max_bytes",
+        env_name="STATEWAVE_MEMORY_IMPORT_MAX_BYTES",
+        category="memory",
+        kind="int",
+        description="Hard cap on a single import payload's serialized size.",
+        min_value=1,
+    ),
+    "memory_import_max_episodes": SettingSpec(
+        key="memory_import_max_episodes",
+        env_name="STATEWAVE_MEMORY_IMPORT_MAX_EPISODES",
+        category="memory",
+        kind="int",
+        description="Per-import episode count cap.",
+    ),
+    "memory_import_max_memories": SettingSpec(
+        key="memory_import_max_memories",
+        env_name="STATEWAVE_MEMORY_IMPORT_MAX_MEMORIES",
+        category="memory",
+        kind="int",
+        description="Per-import memory count cap.",
+    ),
+    "memory_import_max_subjects": SettingSpec(
+        key="memory_import_max_subjects",
+        env_name="STATEWAVE_MEMORY_IMPORT_MAX_SUBJECTS",
+        category="memory",
+        kind="int",
+        description="Per-import subject count cap.",
+    ),
+    # ─── Labeling ────────────────────────────────────────────────────────
+    "auto_labeling_enabled": SettingSpec(
+        key="auto_labeling_enabled",
+        env_name="STATEWAVE_AUTO_LABELING_ENABLED",
+        category="labeling",
+        kind="bool",
+        description=(
+            "Stamp `suggested_labels` on memories at compile time. Advisory "
+            "only — promotion to authoritative labels is a separate "
+            "operator action."
+        ),
+    ),
+    "auto_labeling_provider": SettingSpec(
+        key="auto_labeling_provider",
+        env_name="STATEWAVE_AUTO_LABELING_PROVIDER",
+        category="labeling",
+        kind="string",
+        description="Currently only `heuristic` (regex + Luhn) is supported.",
+        allowed_values=("heuristic",),
+    ),
+}
+
+
+def get_spec(key: str) -> SettingSpec | None:
+    """Return the catalogue entry for a key, or None if unknown."""
+    return CATALOGUE.get(key)
+
+
+def keys_by_category(category: Category) -> list[str]:
+    """Stable-ordered keys in a category."""
+    return [k for k, spec in CATALOGUE.items() if spec.category == category]
+
+
+def is_secret(key: str) -> bool:
+    """True iff the catalogue marks the setting as a secret. Defaults to
+    treating unknown keys as secret (defence-in-depth)."""
+    spec = CATALOGUE.get(key)
+    return spec.is_secret if spec is not None else True
+
+
+def redact(value: Any, *, key: str | None = None, kind: Kind | None = None) -> Any:
+    """Redact a secret value for safe display in the API + audit log.
+
+    For string secrets we show the last 3 characters prefixed with
+    `sk-•••`, so operators recognise the right key without exposing the
+    full value. For non-string secrets (rare) we collapse to the
+    sentinel `"•••"`. Empty / null values pass through unredacted so
+    the UI can clearly show "not set".
+    """
+    if value is None or value == "":
+        return value
+    inferred_kind = kind
+    if inferred_kind is None and key is not None:
+        spec = CATALOGUE.get(key)
+        if spec is not None:
+            inferred_kind = spec.kind
+    if inferred_kind in ("string", "string_or_null") and isinstance(value, str):
+        tail = value[-3:] if len(value) >= 4 else ""
+        return f"•••{tail}" if tail else "•••"
+    return "•••"

--- a/server/services/llm.py
+++ b/server/services/llm.py
@@ -349,6 +349,53 @@ def _is_output_limit_error(exc: BaseException) -> bool:
     )
 
 
+async def aping_with_overrides(
+    *,
+    model: str | None = None,
+    api_key: str | None = None,
+    api_base: str | None = None,
+    timeout: float = 10.0,
+) -> tuple[bool, str | None]:
+    """One-token reachability check against a CANDIDATE (key, model, base).
+
+    Used by the admin settings ``test_probe`` to validate proposed LLM
+    credentials without persisting them. Returns ``(ok, detail)`` so the
+    caller can surface failures in the UI without a typed exception
+    crossing the module boundary. The only place outside `services/llm.py`
+    that LiteLLM-shaped errors leak.
+
+    A reasoning-model max-tokens hit is treated as proven-reachable, same
+    as :func:`aping`."""
+    litellm = _ensure_litellm()
+    kw: dict[str, Any] = {
+        "model": model or settings.litellm_model,
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 1,
+        "num_retries": 0,
+    }
+    if api_key is not None:
+        kw["api_key"] = api_key
+    elif settings.litellm_api_key:
+        kw["api_key"] = settings.litellm_api_key
+    if api_base is not None:
+        kw["api_base"] = api_base
+    elif settings.litellm_api_base:
+        kw["api_base"] = settings.litellm_api_base
+
+    try:
+        await asyncio.wait_for(litellm.acompletion(**kw), timeout=timeout)
+    except asyncio.TimeoutError:
+        return False, f"timed out after {timeout}s"
+    except Exception as exc:  # noqa: BLE001
+        classified = _classify(exc)
+        # max-tokens / output-limit means we DID reach the model — auth
+        # and connectivity are proven, so treat as ok.
+        if isinstance(classified, LLMProviderError) and _is_output_limit_error(classified):
+            return True, "reachable (output-limit hit on 1-token ping)"
+        return False, f"{type(classified).__name__}: {classified}"
+    return True, "ok"
+
+
 async def aping(timeout: float = 10.0) -> bool:
     """Lightweight provider-reachability check. Returns True on success.
 

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0025_episodes_idempotency_key"
+EXPECTED_HEAD = "0026_system_settings"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/tests/test_admin_readiness.py
+++ b/tests/test_admin_readiness.py
@@ -1,0 +1,238 @@
+"""Tests for the `/admin/readiness-check` rule engine.
+
+These tests pin the rule set — adding a new check (or weakening a
+severity) requires touching this file, which keeps the production-
+readiness contract reviewable as a single artifact rather than spread
+across the admin module.
+
+Tests are deliberately mostly assertions about "is rule X present for
+config Y", not about exact strings — the messages are user-facing and
+will get polished, but the IDs and severities are the contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _ids(client: AsyncClient) -> set[str]:
+    resp = await client.get("/admin/readiness-check")
+    assert resp.status_code == 200
+    return {i["id"] for i in resp.json()["issues"]}
+
+
+async def _severity_of(client: AsyncClient, issue_id: str) -> str | None:
+    resp = await client.get("/admin/readiness-check")
+    for i in resp.json()["issues"]:
+        if i["id"] == issue_id:
+            return i["severity"]
+    return None
+
+
+# ─── critical: no auth ──────────────────────────────────────────────────
+
+
+async def test_no_auth_is_critical(client: AsyncClient, monkeypatch):
+    """The default Statewave config has no API key — the rule must fire
+    critical so an operator can't miss it during the dev → prod hand-off."""
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "api_key", None)
+    ids = await _ids(client)
+    assert "no_backend_auth" in ids
+    assert await _severity_of(client, "no_backend_auth") == "critical"
+
+
+async def test_dev_placeholder_key_is_critical(client: AsyncClient, monkeypatch):
+    """The known dev defaults shouldn't satisfy 'auth on' — they're
+    public knowledge from the quickstart docs and trivial to guess."""
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "api_key", "dev-local-placeholder")
+    ids = await _ids(client)
+    # `no_backend_auth` is absent (auth IS set, just badly)
+    assert "no_backend_auth" not in ids
+    assert "dev_placeholder_api_key" in ids
+    assert await _severity_of(client, "dev_placeholder_api_key") == "critical"
+
+
+async def test_strong_key_passes(client: AsyncClient, monkeypatch):
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "api_key", "k_" + "a" * 30)
+    ids = await _ids(client)
+    assert "no_backend_auth" not in ids
+    assert "dev_placeholder_api_key" not in ids
+
+
+# ─── high: CORS / debug / stub embeddings ───────────────────────────────
+
+
+async def test_wildcard_cors_is_high(client: AsyncClient, monkeypatch):
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "cors_origins", ["*"])
+    ids = await _ids(client)
+    assert "permissive_cors" in ids
+    assert await _severity_of(client, "permissive_cors") == "high"
+
+
+async def test_explicit_origins_pass(client: AsyncClient, monkeypatch):
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "cors_origins", ["https://admin.example.com"])
+    ids = await _ids(client)
+    assert "permissive_cors" not in ids
+
+
+async def test_debug_logging_is_high(client: AsyncClient, monkeypatch):
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "debug", True)
+    ids = await _ids(client)
+    assert "debug_logging" in ids
+    assert await _severity_of(client, "debug_logging") == "high"
+
+
+async def test_stub_embeddings_is_high(client: AsyncClient, monkeypatch):
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "embedding_provider", "stub")
+    ids = await _ids(client)
+    assert "stub_embeddings" in ids
+
+
+async def test_litellm_embeddings_pass(client: AsyncClient, monkeypatch):
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "embedding_provider", "litellm")
+    ids = await _ids(client)
+    assert "stub_embeddings" not in ids
+
+
+# ─── medium: rate limit / strict schema ──────────────────────────────────
+
+
+async def test_no_rate_limit_is_medium(client: AsyncClient, monkeypatch):
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "rate_limit_rpm", 0)
+    ids = await _ids(client)
+    assert "no_rate_limit" in ids
+    assert await _severity_of(client, "no_rate_limit") == "medium"
+
+
+async def test_rate_limit_set_passes(client: AsyncClient, monkeypatch):
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "rate_limit_rpm", 600)
+    ids = await _ids(client)
+    assert "no_rate_limit" not in ids
+
+
+# ─── shape contract ──────────────────────────────────────────────────────
+
+
+async def test_every_issue_has_required_fields(client: AsyncClient):
+    """The frontend reads severity + id + title + summary unconditionally
+    and crashes on a missing field. Pin the shape."""
+    resp = await client.get("/admin/readiness-check")
+    for i in resp.json()["issues"]:
+        assert i["id"]
+        assert i["severity"] in {"critical", "high", "medium", "low"}
+        assert i["title"]
+        assert i["summary"]
+        # `fix` is optional — informational-only issues legitimately
+        # omit it. When present, it must declare a kind.
+        if i.get("fix") is not None:
+            assert i["fix"]["kind"] in {"setting", "wizard", "admin_tab", "env"}
+
+
+async def test_fix_staged_marks_issue_when_db_override_clears_it(
+    client: AsyncClient, monkeypatch,
+):
+    """The bug we just fixed: operator saves `debug=false` in the UI,
+    the DB has the new value, but `settings.debug` is still True
+    until restart. Without `fix_staged`, the readiness card keeps
+    showing the unchanged warning and the operator thinks the save
+    was ignored.
+
+    Force `settings.debug=True` so the rule fires live, PATCH the DB
+    override to false, then assert the response carries
+    `fix_staged=true` on the debug_logging issue. The post-restart
+    case is covered by the existing pending-restart tests in
+    test_admin_settings.py."""
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "debug", True)
+    await client.patch("/admin/settings/debug", json={"value": False})
+
+    resp = await client.get("/admin/readiness-check")
+    issues = resp.json()["issues"]
+    debug_issue = next((i for i in issues if i["id"] == "debug_logging"), None)
+    assert debug_issue is not None, "debug_logging should still fire (live=True)"
+    assert debug_issue.get("fix_staged") is True, (
+        "fix_staged must be True — the DB has the resolving value queued"
+    )
+
+    # Cleanup so other tests don't see the override.
+    await client.delete("/admin/settings/debug")
+
+
+async def test_fix_staged_absent_when_no_override(client: AsyncClient, monkeypatch):
+    """Mirror of the above: issues firing live with NO DB override
+    must not be marked staged. Otherwise the UI shows "Pending
+    restart" on issues that nothing's actually queued for."""
+    from server.core.config import settings
+
+    monkeypatch.setattr(settings, "debug", True)
+    resp = await client.get("/admin/readiness-check")
+    issues = resp.json()["issues"]
+    debug_issue = next((i for i in issues if i["id"] == "debug_logging"), None)
+    assert debug_issue is not None
+    assert "fix_staged" not in debug_issue or debug_issue["fix_staged"] is False
+
+
+async def test_every_setting_fix_target_is_in_the_catalogue(
+    client: AsyncClient, monkeypatch
+):
+    """Lock down a class of regression: a readiness rule pointing at
+    `fix: {kind:'setting', key: 'foo'}` only works if 'foo' is in the
+    catalogue. Otherwise the admin UI deep-links to a key it can't
+    find, the editor never opens, and the operator sees a silent
+    nothing-happens after clicking Fix.
+
+    Force EVERY rule to fire by setting the live config to the worst
+    possible state, then walk every issue's fix descriptor and assert
+    the catalogue knows the key. If a future rule introduces a new
+    fix target that we forgot to catalogue, this test catches it
+    before it reaches an operator."""
+    from server.core.config import settings
+    from server.core.settings_catalogue import CATALOGUE
+
+    monkeypatch.setattr(settings, "api_key", None)
+    monkeypatch.setattr(settings, "cors_origins", ["*"])
+    monkeypatch.setattr(settings, "debug", True)
+    monkeypatch.setattr(settings, "embedding_provider", "stub")
+    monkeypatch.setattr(settings, "rate_limit_rpm", 0)
+    monkeypatch.setattr(settings, "strict_schema", False)
+    monkeypatch.setattr(settings, "region", None)
+    monkeypatch.setattr(settings, "webhook_url", None)
+
+    resp = await client.get("/admin/readiness-check")
+    issues = resp.json()["issues"]
+    setting_fixes = [
+        i for i in issues if i.get("fix") and i["fix"]["kind"] == "setting"
+    ]
+    # If this is empty we're not testing anything useful; sanity-check.
+    assert setting_fixes, "expected at least one kind=setting fix to fire"
+    for i in setting_fixes:
+        key = i["fix"]["key"]
+        assert key in CATALOGUE, (
+            f"readiness rule {i['id']!r} points at setting key {key!r}, "
+            f"but it's not in CATALOGUE. Add a SettingSpec for it, or "
+            f"change the fix descriptor to kind='env'."
+        )

--- a/tests/test_admin_restart.py
+++ b/tests/test_admin_restart.py
@@ -1,0 +1,63 @@
+"""Tests for the POST /admin/restart endpoint.
+
+The endpoint is the back-end half of the admin UI's "Restart backend"
+button. It schedules an `os._exit(0)` after a short delay so the HTTP
+response can flush, then relies on the container orchestrator's restart
+policy to bring the process back.
+
+We don't actually call `os._exit` in the test (would kill the test
+runner). Instead we patch it out and assert the schedule lands.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_restart_endpoint_returns_202_with_schedule(client: AsyncClient):
+    """The endpoint must return immediately so the operator's browser
+    sees the 202 BEFORE the process exits. If we awaited the exit, the
+    response would never reach the client and they'd see a network
+    error every time."""
+    with patch("os._exit") as fake_exit:
+        resp = await client.post("/admin/restart", params={"delay_seconds": 0.5})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["exit_in_seconds"] == 0.5
+        # The delayed-exit coroutine hasn't run yet at this point —
+        # `os._exit` must NOT have been called synchronously.
+        assert fake_exit.call_count == 0
+
+
+async def test_restart_endpoint_schedules_exit(client: AsyncClient):
+    """After the configured delay, `os._exit(0)` must fire. We use a
+    very short delay (0.05s) so the test still finishes quickly."""
+    import asyncio
+
+    with patch("os._exit") as fake_exit:
+        resp = await client.post("/admin/restart", params={"delay_seconds": 0.5})
+        assert resp.status_code == 200
+        # Wait past the delay; the asyncio task scheduled by the
+        # endpoint should have called _exit by now.
+        # Use the request's actual delay parameter (0.5s); add a safety margin.
+        await asyncio.sleep(0.7)
+        assert fake_exit.call_count == 1
+        # Must exit with status 0 — the orchestrator's restart policy
+        # only fires on a clean exit by default in some configs.
+        assert fake_exit.call_args.args == (0,)
+
+
+async def test_restart_endpoint_rejects_unreasonable_delay(client: AsyncClient):
+    """Bounds protect against an operator typo (`delay_seconds=999999`
+    would leave the API in a stuck state, accepting traffic but with a
+    pending exit). The catalogue caps it at 10s."""
+    too_long = await client.post("/admin/restart", params={"delay_seconds": 999})
+    assert too_long.status_code == 422
+    too_short = await client.post("/admin/restart", params={"delay_seconds": 0})
+    assert too_short.status_code == 422

--- a/tests/test_admin_settings.py
+++ b/tests/test_admin_settings.py
@@ -1,0 +1,346 @@
+"""DB-backed integration tests for the admin settings endpoints.
+
+Mirror the pattern used by `test_admin_subjects.py`: skip when Postgres
+isn't migrated, otherwise exercise the full HTTP → endpoint → DB → audit
+pipeline against a real Postgres referenced by ``STATEWAVE_DATABASE_URL``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+async def _require_migrated_postgres():
+    from server.core.config import settings
+
+    url = (
+        os.environ.get("STATEWAVE_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or settings.database_url
+    )
+    try:
+        engine = create_async_engine(url, pool_pre_ping=True)
+        async with engine.connect() as conn:
+            # 0026 head check — if this column-less probe succeeds the
+            # table exists with the expected shape.
+            await conn.execute(text("SELECT key FROM system_settings LIMIT 0"))
+            await conn.execute(text("SELECT id FROM system_settings_audit LIMIT 0"))
+        await engine.dispose()
+    except Exception as exc:
+        pytest.skip(
+            "Postgres not migrated to 0026_system_settings "
+            f"({type(exc).__name__}: {exc}). "
+            "Run `alembic upgrade head`."
+        )
+
+
+@pytest.fixture(autouse=True)
+async def _clean_settings_tables(_require_migrated_postgres):
+    """Each test starts with an empty settings + audit + tenant_settings.
+    Tearing down after is also important — other tests in the suite might
+    inadvertently depend on env-only behaviour.
+
+    Depends on ``_require_migrated_postgres`` so we don't try to truncate
+    against an unreachable DB (which would explode the teardown instead
+    of skipping cleanly)."""
+    from server.core.config import settings as env_settings
+
+    url = (
+        os.environ.get("STATEWAVE_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or env_settings.database_url
+    )
+
+    async def _truncate():
+        engine = create_async_engine(url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text("DELETE FROM system_settings"))
+                await conn.execute(text("DELETE FROM system_settings_audit"))
+                await conn.execute(text("DELETE FROM tenant_settings"))
+        finally:
+            await engine.dispose()
+
+    await _truncate()
+    # Wipe in-process cache so the next read sees the cleaned tables.
+    from server.core.dynamic_settings import invalidate_cache
+
+    invalidate_cache()
+    yield
+    await _truncate()
+    invalidate_cache()
+
+
+# ─── GET /admin/settings ─────────────────────────────────────────────────
+
+
+async def test_list_settings_returns_every_catalogued_key(client: AsyncClient):
+    from server.core.settings_catalogue import CATALOGUE
+
+    resp = await client.get("/admin/settings")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data["settings"].keys()) == set(CATALOGUE.keys())
+    # No DB rows yet → every source must be `env`.
+    for entry in data["settings"].values():
+        assert entry["source"] == "env"
+
+
+async def test_list_settings_redacts_secrets(client: AsyncClient, monkeypatch):
+    """Secrets must NEVER leave the server in cleartext, even on first
+    list. The redacted preview shows the last 3 chars so the operator can
+    sanity-check which key is currently loaded without ever exposing the
+    full value."""
+    from server.core.config import settings as env_settings
+
+    monkeypatch.setattr(env_settings, "litellm_api_key", "sk-secret-xyz")
+    resp = await client.get("/admin/settings")
+    assert resp.status_code == 200
+    api_key = resp.json()["settings"]["litellm_api_key"]
+    assert api_key["is_secret"] is True
+    assert api_key["value"] == "•••xyz"
+
+
+# ─── PATCH /admin/settings/{key} ─────────────────────────────────────────
+
+
+async def test_patch_setting_persists_and_flips_source(client: AsyncClient):
+    resp = await client.patch(
+        "/admin/settings/litellm_model",
+        json={"value": "gpt-4o", "changed_by": "test@local"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["value"] == "gpt-4o"
+
+    # Source flips to global_db on subsequent reads
+    follow = await client.get("/admin/settings/litellm_model")
+    assert follow.status_code == 200
+    assert follow.json()["value"] == "gpt-4o"
+    assert follow.json()["source"] == "global_db"
+
+
+async def test_patch_setting_rejects_wrong_type(client: AsyncClient):
+    """An int field must reject a string payload — without this, an
+    operator typing "60s" into a number input would silently break the
+    rate limiter."""
+    resp = await client.patch(
+        "/admin/settings/rate_limit_rpm",
+        json={"value": "sixty"},
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["detail"]["code"] == "settings.invalid"
+
+
+async def test_patch_rejects_non_editable_key(client: AsyncClient):
+    resp = await client.patch(
+        "/admin/settings/database_url",
+        json={"value": "postgresql://x"},
+    )
+    assert resp.status_code == 400
+
+
+async def test_patch_rejects_unknown_key(client: AsyncClient):
+    resp = await client.patch(
+        "/admin/settings/totally_made_up",
+        json={"value": "x"},
+    )
+    assert resp.status_code == 400
+
+
+# ─── DELETE /admin/settings/{key} ────────────────────────────────────────
+
+
+async def test_delete_reverts_to_env(client: AsyncClient):
+    # First patch it…
+    await client.patch(
+        "/admin/settings/litellm_model", json={"value": "gpt-4o"}
+    )
+    # …then revert.
+    resp = await client.delete("/admin/settings/litellm_model")
+    assert resp.status_code == 200
+    follow = await client.get("/admin/settings/litellm_model")
+    assert follow.json()["source"] == "env"
+
+
+async def test_delete_unset_setting_is_idempotent(client: AsyncClient):
+    resp = await client.delete("/admin/settings/litellm_model")
+    assert resp.status_code == 200
+
+
+# ─── Audit ───────────────────────────────────────────────────────────────
+
+
+async def test_audit_log_records_patch_and_delete(client: AsyncClient):
+    await client.patch(
+        "/admin/settings/litellm_model",
+        json={"value": "gpt-4o", "changed_by": "alice", "note": "trying new model"},
+    )
+    await client.delete(
+        "/admin/settings/litellm_model",
+        params={"changed_by": "alice", "note": "rolling back"},
+    )
+
+    resp = await client.get("/admin/settings/audit/log", params={"key": "litellm_model"})
+    assert resp.status_code == 200
+    entries = resp.json()["entries"]
+    assert len(entries) == 2
+    # Newest first
+    assert entries[0]["action"] == "delete"
+    assert entries[1]["action"] == "patch"
+    assert entries[1]["changed_by"] == "alice"
+    assert entries[1]["new_value"] == "gpt-4o"
+
+
+async def test_audit_redacts_secret_values(client: AsyncClient):
+    """An audit log of a secret edit must NOT preserve the raw secret —
+    historical credentials must remain unrecoverable from the audit
+    table, otherwise a breach widens past 'current key' to 'every key ever'."""
+    await client.patch(
+        "/admin/settings/litellm_api_key",
+        json={"value": "sk-rotated-abc"},
+    )
+    resp = await client.get(
+        "/admin/settings/audit/log", params={"key": "litellm_api_key"}
+    )
+    entries = resp.json()["entries"]
+    assert len(entries) == 1
+    assert entries[0]["new_value"] == "•••abc"
+
+
+# ─── Tenant overrides ────────────────────────────────────────────────────
+
+
+async def test_tenant_override_takes_precedence_over_global(client: AsyncClient):
+    # Global override
+    await client.patch(
+        "/admin/settings/litellm_model", json={"value": "global-model"}
+    )
+    # Tenant override on top
+    await client.patch(
+        "/admin/settings/tenants/tenant-abc/litellm_model",
+        json={"value": "tenant-model"},
+    )
+
+    # No tenant param → global_db wins
+    g = await client.get("/admin/settings/litellm_model")
+    assert g.json()["value"] == "global-model"
+    assert g.json()["source"] == "global_db"
+
+    # With tenant param → tenant_db wins
+    t = await client.get(
+        "/admin/settings/litellm_model", params={"tenant_id": "tenant-abc"}
+    )
+    assert t.json()["value"] == "tenant-model"
+    assert t.json()["source"] == "tenant_db"
+
+
+async def test_tenant_override_refused_for_non_overridable_key(client: AsyncClient):
+    """The catalogue narrows tenant overrides to LLM + webhook + rate-
+    limit. Anything else MUST be refused — otherwise an operator could
+    quietly per-tenant something with global consequences."""
+    resp = await client.patch(
+        "/admin/settings/tenants/tenant-abc/compile_batch_size",
+        json={"value": 100},
+    )
+    assert resp.status_code == 400
+
+
+# ─── Test probe ──────────────────────────────────────────────────────────
+
+
+async def test_probe_endpoint_does_not_persist(client: AsyncClient):
+    """A 'Test' click must not write — that's the whole point. Reading
+    after a test should still show the env source."""
+    resp = await client.post(
+        "/admin/settings/test",
+        json={"key": "litellm_model", "value": "gpt-99"},
+    )
+    assert resp.status_code == 200
+    follow = await client.get("/admin/settings/litellm_model")
+    assert follow.json()["source"] == "env"
+
+
+async def test_probe_endpoint_returns_shape_error(client: AsyncClient):
+    resp = await client.post(
+        "/admin/settings/test",
+        json={"key": "rate_limit_rpm", "value": "not-a-number"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert "expected int" in body["detail"]
+
+
+# ─── pending_restart flag ────────────────────────────────────────────────
+
+
+async def test_pending_restart_set_after_patch_clears_after_simulated_restart(
+    client: AsyncClient,
+):
+    """Regression for the banner that never cleared.
+
+    Patching a non-hot-reloadable setting must mark `pending_restart=true`
+    (process is still running the old value). Calling
+    `apply_db_overrides_to_settings` simulates a server restart picking
+    up the new value; afterwards `pending_restart` must be false even
+    though the DB row still exists.
+    """
+    from server.core.dynamic_settings import apply_db_overrides_to_settings
+
+    await client.patch("/admin/settings/compiler_type", json={"value": "llm"})
+    snap = (await client.get("/admin/settings/compiler_type")).json()
+    assert snap["value"] == "llm"
+    assert snap["source"] == "global_db"
+    assert snap["pending_restart"] is True
+    assert snap["applied_value"] != "llm"
+
+    # Simulate a process restart — env_settings is re-mutated, applied
+    # snapshot is updated.
+    await apply_db_overrides_to_settings()
+
+    snap = (await client.get("/admin/settings/compiler_type")).json()
+    assert snap["value"] == "llm"
+    assert snap["source"] == "global_db"
+    assert snap["pending_restart"] is False
+    assert snap["applied_value"] == "llm"
+
+
+async def test_pending_restart_set_after_delete_without_restart(client: AsyncClient):
+    """DELETE returns the row to env-baseline, but the process is still
+    running the previously-applied value until restart — that must show
+    as pending_restart."""
+    from server.core.dynamic_settings import apply_db_overrides_to_settings
+
+    await client.patch("/admin/settings/compiler_type", json={"value": "llm"})
+    await apply_db_overrides_to_settings()  # simulate restart so it's applied
+    await client.delete("/admin/settings/compiler_type")
+
+    snap = (await client.get("/admin/settings/compiler_type")).json()
+    assert snap["source"] == "env"
+    assert snap["pending_restart"] is True
+    # applied_value still reflects the post-boot value the process is
+    # actually using, not the env baseline.
+    assert snap["applied_value"] == "llm"
+
+
+async def test_pending_restart_false_for_tenant_override(client: AsyncClient):
+    """Tenant overrides are read per-request via get_setting(); they
+    never require a restart, no matter how often they change."""
+    await client.patch(
+        "/admin/settings/tenants/t-1/litellm_model",
+        json={"value": "gpt-4o"},
+    )
+    snap = (
+        await client.get("/admin/settings/litellm_model", params={"tenant_id": "t-1"})
+    ).json()
+    assert snap["source"] == "tenant_db"
+    assert snap["pending_restart"] is False

--- a/tests/test_admin_settings.py
+++ b/tests/test_admin_settings.py
@@ -137,7 +137,7 @@ async def test_patch_setting_rejects_wrong_type(client: AsyncClient):
     )
     assert resp.status_code == 400
     body = resp.json()
-    assert body["detail"]["code"] == "settings.invalid"
+    assert body["error"]["code"] == "settings.invalid"
 
 
 async def test_patch_rejects_non_editable_key(client: AsyncClient):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 25
+    assert len(revs) == 26
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 15
+    assert result.pending_count == 16
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 25
+    assert result.pending_count == 26
 
 
 def test_resolve_pending_unknown_revision():

--- a/tests/test_settings_catalogue.py
+++ b/tests/test_settings_catalogue.py
@@ -1,0 +1,215 @@
+"""Unit tests for the settings catalogue + validation + redaction.
+
+No DB, no FastAPI client — just pure-Python checks. The matching DB-backed
+tests live in `test_admin_settings.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from server.core.config import settings as env_settings
+from server.core.dynamic_settings import (
+    SettingValidationError,
+    _validate_value,
+)
+from server.core.settings_catalogue import (
+    CATALOGUE,
+    get_spec,
+    is_secret,
+    redact,
+)
+
+
+def test_every_catalogue_key_matches_a_pydantic_attribute():
+    """The catalogue is a contract — every key MUST resolve to a real
+    attribute on the Settings class, otherwise reads through
+    ``get_setting`` would fall through to the silent ``None`` branch
+    instead of returning the env default."""
+    missing = [k for k in CATALOGUE if not hasattr(env_settings, k)]
+    assert missing == [], f"catalogue keys missing from Settings: {missing}"
+
+
+def test_secrets_have_string_or_null_kind():
+    """Redaction only makes sense for string-shaped secrets. If a future
+    setting marks itself as a secret but uses a non-string kind, that's a
+    bug — there's no sensible way to redact a number to a `•••` preview."""
+    for spec in CATALOGUE.values():
+        if spec.is_secret:
+            assert spec.kind in (
+                "string",
+                "string_or_null",
+                "json",
+            ), f"secret {spec.key} has un-redactable kind {spec.kind}"
+
+
+def test_non_editable_settings_carry_a_reason():
+    """If we forbid editing a setting, the description must explain why —
+    otherwise the admin UI will show a locked field with no rationale and
+    operators will file confused bug reports."""
+    for spec in CATALOGUE.values():
+        if not spec.editable:
+            assert spec.description, f"non-editable {spec.key} needs a description"
+
+
+def test_tenant_overridable_keys_are_in_expected_scope():
+    """User confirmed (chat: 'yes and yes') the tenant-override scope is
+    deliberately narrow: LLM + webhook + rate-limit. Lock that down here
+    so a future PR can't quietly widen it without an explicit decision."""
+    overridable = {k for k, spec in CATALOGUE.items() if spec.tenant_overridable}
+    expected_categories = {"llm", "embeddings", "webhooks", "rate_limits"}
+    for key in overridable:
+        spec = CATALOGUE[key]
+        assert (
+            spec.category in expected_categories
+        ), f"{key} is tenant-overridable but in unexpected category {spec.category}"
+
+
+# ─── redact() ────────────────────────────────────────────────────────────
+
+
+def test_redact_short_value():
+    assert redact("ab", kind="string") == "•••"
+
+
+def test_redact_string_keeps_last_three():
+    assert redact("sk-supersecret123", kind="string") == "•••123"
+
+
+def test_redact_empty_or_none_is_untouched():
+    """The UI uses empty/null to render 'not set' — redacting it would lie."""
+    assert redact(None, kind="string") is None
+    assert redact("", kind="string") == ""
+
+
+def test_is_secret_defaults_to_true_on_unknown_key():
+    """Defence-in-depth: if a key isn't catalogued, treat it as secret. A
+    missing catalogue entry should never accidentally leak the raw value."""
+    assert is_secret("brand-new-thing-not-yet-catalogued") is True
+
+
+# ─── _validate_value ─────────────────────────────────────────────────────
+
+
+def test_validate_rejects_bool_as_int():
+    """Python's `True` is technically int(1). Without an explicit guard a
+    JSON `true` would silently land as `1` for an int setting — a
+    confusing footgun worth refusing."""
+    spec = get_spec("rate_limit_rpm")
+    assert spec is not None
+    with pytest.raises(SettingValidationError):
+        _validate_value(spec, True)
+
+
+def test_validate_accepts_int():
+    spec = get_spec("rate_limit_rpm")
+    assert spec is not None
+    assert _validate_value(spec, 60) == 60
+
+
+def test_validate_string_or_null_accepts_none():
+    spec = get_spec("api_key")
+    assert spec is not None
+    assert _validate_value(spec, None) is None
+
+
+def test_validate_string_rejects_null():
+    """Non-nullable string settings should reject explicit nulls."""
+    spec = get_spec("litellm_model")
+    assert spec is not None
+    with pytest.raises(SettingValidationError):
+        _validate_value(spec, None)
+
+
+def test_validate_float_coerces_int_to_float():
+    spec = get_spec("litellm_timeout_seconds")
+    assert spec is not None
+    result = _validate_value(spec, 30)
+    assert isinstance(result, float) and result == 30.0
+
+
+def test_validate_json_accepts_dict():
+    spec = get_spec("kind_ttl_days")
+    assert spec is not None
+    assert _validate_value(spec, {"episode_summary": 30}) == {"episode_summary": 30}
+
+
+# ─── allowed_values (enum) ───────────────────────────────────────────────
+
+
+def test_allowed_values_rejects_off_list():
+    """The user's exact example: typing 'lllm' when 'llm' is expected
+    must fail loudly, not silently land in the DB to confuse the
+    compiler later."""
+    spec = get_spec("compiler_type")
+    assert spec is not None
+    with pytest.raises(SettingValidationError) as exc:
+        _validate_value(spec, "lllm")
+    assert "lllm" in str(exc.value)
+    # The error must SUGGEST the fix — a bare 'not allowed' message
+    # leaves the operator guessing whether the right value is 'llm' or
+    # 'LLM' or 'large_language_model'.
+    assert "did you mean 'llm'" in str(exc.value).lower()
+
+
+def test_allowed_values_accepts_valid():
+    spec = get_spec("compiler_type")
+    assert spec is not None
+    assert _validate_value(spec, "llm") == "llm"
+    assert _validate_value(spec, "heuristic") == "heuristic"
+
+
+def test_allowed_values_suggests_for_each_known_enum():
+    """Sanity-check the Levenshtein-2 cutoff for every enum we have."""
+    cases = [
+        ("compiler_type", "huristic", "heuristic"),
+        ("embedding_provider", "litellmm", "litellm"),
+        ("rate_limit_strategy", "memry", "memory"),
+    ]
+    for key, bad, expected_suggestion in cases:
+        spec = get_spec(key)
+        assert spec is not None
+        with pytest.raises(SettingValidationError) as exc:
+            _validate_value(spec, bad)
+        assert expected_suggestion in str(exc.value).lower()
+
+
+# ─── numeric bounds ──────────────────────────────────────────────────────
+
+
+def test_int_below_min_rejected():
+    spec = get_spec("compile_batch_size")
+    assert spec is not None and spec.min_value == 1
+    with pytest.raises(SettingValidationError):
+        _validate_value(spec, 0)
+
+
+def test_int_above_max_rejected():
+    spec = get_spec("litellm_max_retries")
+    assert spec is not None and spec.max_value == 10
+    with pytest.raises(SettingValidationError):
+        _validate_value(spec, 99)
+
+
+def test_float_temperature_bounds():
+    spec = get_spec("litellm_temperature")
+    assert spec is not None
+    _validate_value(spec, 0.0)
+    _validate_value(spec, 2.0)
+    with pytest.raises(SettingValidationError):
+        _validate_value(spec, -0.1)
+    with pytest.raises(SettingValidationError):
+        _validate_value(spec, 2.5)
+
+
+# ─── URL format ──────────────────────────────────────────────────────────
+
+
+def test_url_must_be_http_or_https():
+    spec = get_spec("webhook_url")
+    assert spec is not None and spec.format == "url"
+    with pytest.raises(SettingValidationError):
+        _validate_value(spec, "example.com/hook")
+    _validate_value(spec, "https://example.com/hook")
+    # Empty string is allowed — that's the documented "disable" sentinel.
+    _validate_value(spec, "")


### PR DESCRIPTION
## Summary

- **Admin REST API** (`/admin/*`): readiness check, settings CRUD, restart trigger; webhook issue removed — outbound webhooks are optional, not a production blocker
- **Dynamic settings**: runtime config changes via `server/core/dynamic_settings.py` without container restarts
- **Settings catalogue**: typed catalogue of all configurable settings
- **Migration 0026**: `system_settings` table for persisted runtime settings
- **LLM service**: improved error handling and provider validation
- **`docker-compose.local.yml`**: local dev overlay — builds api + admin from local source for testing without pushing to a registry

## Test plan

- [x] `GET /admin/readiness-check` returns issues list with no webhook item
- [x] `GET /admin/settings` returns current settings catalogue
- [x] `POST /admin/settings/{key}` updates a setting at runtime
- [x] Migration 0026 applies cleanly on a fresh DB
- [x] `docker compose -f docker-compose.yml -f docker-compose.local.yml up --build` starts from local source