### PR TITLE
fix(settings): add min_value=1 to import count cap catalogue entries

### DIFF
--- a/server/core/settings_catalogue.py
+++ b/server/core/settings_catalogue.py
@@ -456,6 +456,7 @@ CATALOGUE: dict[str, SettingSpec] = {
         kind="int",
         hot_reloadable=True,
         description="Per-import episode count cap.",
+        min_value=1,
     ),
     "memory_import_max_memories": SettingSpec(
         key="memory_import_max_memories",
@@ -464,6 +465,7 @@ CATALOGUE: dict[str, SettingSpec] = {
         kind="int",
         hot_reloadable=True,
         description="Per-import memory count cap.",
+        min_value=1,
     ),
     "memory_import_max_subjects": SettingSpec(
         key="memory_import_max_subjects",
@@ -472,6 +474,7 @@ CATALOGUE: dict[str, SettingSpec] = {
         kind="int",
         hot_reloadable=True,
         description="Per-import subject count cap.",
+        min_value=1,
     ),
     # ─── Labeling ────────────────────────────────────────────────────────
     "auto_labeling_enabled": SettingSpec(

--- a/tests/test_settings_catalogue.py
+++ b/tests/test_settings_catalogue.py
@@ -213,3 +213,39 @@ def test_url_must_be_http_or_https():
     _validate_value(spec, "https://example.com/hook")
     # Empty string is allowed — that's the documented "disable" sentinel.
     _validate_value(spec, "")
+
+
+# ─── import count caps ───────────────────────────────────────────────────
+
+
+def test_import_count_limits_reject_non_positive():
+    """Setting any per-import count cap to 0 or negative blocks every import
+    because memory_packs enforces ``len(items) > limit``.  These three specs
+    must mirror the ``min_value=1`` already present on ``memory_import_max_bytes``
+    so the admin API rejects a misconfigured value before it silently kills
+    all imports."""
+    count_cap_keys = (
+        "memory_import_max_episodes",
+        "memory_import_max_memories",
+        "memory_import_max_subjects",
+    )
+    for key in count_cap_keys:
+        spec = get_spec(key)
+        assert spec is not None, f"missing catalogue entry for {key}"
+        with pytest.raises(SettingValidationError, match=key):
+            _validate_value(spec, 0)
+        with pytest.raises(SettingValidationError, match=key):
+            _validate_value(spec, -1)
+
+
+def test_import_count_limits_accept_positive():
+    count_cap_keys = (
+        "memory_import_max_episodes",
+        "memory_import_max_memories",
+        "memory_import_max_subjects",
+    )
+    for key in count_cap_keys:
+        spec = get_spec(key)
+        assert spec is not None
+        assert _validate_value(spec, 1) == 1
+        assert _validate_value(spec, 50_000) == 50_000


### PR DESCRIPTION
## Summary

The three per-import count caps (`memory_import_max_episodes`, `memory_import_max_memories`, `memory_import_max_subjects`) had no lower-bound constraint in the settings catalogue, unlike their sibling `memory_import_max_bytes` which already carries `min_value=1`.

## Before

An operator could PATCH any of the three count caps to `0` or a negative integer through the admin API. The value would be accepted and persisted. `memory_packs.py` enforces these limits with a strict greater-than comparison (`len(items) > limit`), so a cap of `0` causes every import to fail immediately and a negative cap has the same effect.

## After

The admin API now rejects any value below `1` for these three settings with a `422 SettingValidationError`, consistent with the existing behaviour for `memory_import_max_bytes`.

## Impact

- No behaviour change for deployments using valid (positive) limits.
- Operators who mistakenly submit `0` or a negative value now receive an immediate, descriptive error from the API instead of silently breaking all imports.

## Test plan

- Added `test_import_count_limits_reject_non_positive` — asserts `_validate_value` raises `SettingValidationError` for `0` and `-1` on each of the three keys.
- Added `test_import_count_limits_accept_positive` — asserts `1` and `50_000` are accepted without error.
- Both tests are pure-Python unit tests (no DB required), following the pattern in `test_settings_catalogue.py`.
- Full suite: `ruff check server/ tests/` clean; `pytest tests/test_*.py` 819 passed (5 pre-existing ambient failures — Postgres not running locally).