### PR TITLE
fix(admin): escape LIKE metacharacters in admin search and prefix filters

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -19,6 +19,17 @@ logger = structlog.stdlib.get_logger()
 router = APIRouter(prefix="/admin", tags=["admin"])
 
 
+def _like_escape(s: str) -> str:
+    """Escape SQL LIKE metacharacters in *s* so it matches literally.
+
+    ``%`` and ``_`` are wildcards in SQL LIKE patterns; ``\\`` is the escape
+    prefix.  Callers must also pass ``escape="\\\\"`` to the SQLAlchemy
+    ``.ilike()`` / ``.like()`` / ``.not_like()`` call so the DB knows which
+    character introduces an escape sequence.
+    """
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 # ─── Response Models ─────────────────────────────────────────────────────────
 
 
@@ -391,13 +402,15 @@ async def list_subjects_admin(
             .outerjoin(health_cache, _same_subject_and_tenant(health_cache))
         )
 
-        # Exclude internal subjects
-        stmt = stmt.where(ep_stats.c.subject_id.not_like("_snapshot/%"))
-        stmt = stmt.where(ep_stats.c.subject_id.not_like("_bootstrap_tmp/%"))
+        # Exclude internal subjects — escape the leading ``_`` so it is
+        # matched literally, not as the single-character SQL wildcard.
+        stmt = stmt.where(ep_stats.c.subject_id.not_like(r"\_snapshot/%", escape="\\"))
+        stmt = stmt.where(ep_stats.c.subject_id.not_like(r"\_bootstrap_tmp/%", escape="\\"))
 
         # Apply filters
         if search:
-            stmt = stmt.where(ep_stats.c.subject_id.ilike(f"%{search}%"))
+            escaped = _like_escape(search)
+            stmt = stmt.where(ep_stats.c.subject_id.ilike(f"%{escaped}%", escape="\\"))
 
         if tenant_id:
             stmt = stmt.where(ep_stats.c.tenant_id == tenant_id)
@@ -711,12 +724,12 @@ async def list_subject_memories(
         if kind:
             base = base.where(MemoryRow.kind == kind)
         if search:
-            search_pattern = f"%{search}%"
+            search_pattern = f"%{_like_escape(search)}%"
             base = base.where(
                 or_(
-                    MemoryRow.content.ilike(search_pattern),
-                    MemoryRow.summary.ilike(search_pattern),
-                    MemoryRow.kind.ilike(search_pattern),
+                    MemoryRow.content.ilike(search_pattern, escape="\\"),
+                    MemoryRow.summary.ilike(search_pattern, escape="\\"),
+                    MemoryRow.kind.ilike(search_pattern, escape="\\"),
                 )
             )
 
@@ -781,14 +794,14 @@ async def list_subject_episodes(
         if type:
             base = base.where(EpisodeRow.type == type)
         if search:
-            search_pattern = f"%{search}%"
+            search_pattern = f"%{_like_escape(search)}%"
             # Cast payload to text for searching
             base = base.where(
                 or_(
-                    EpisodeRow.payload.cast(JSONB).astext.ilike(search_pattern),
-                    EpisodeRow.type.ilike(search_pattern),
-                    EpisodeRow.source.ilike(search_pattern),
-                    EpisodeRow.session_id.ilike(search_pattern),
+                    EpisodeRow.payload.cast(JSONB).astext.ilike(search_pattern, escape="\\"),
+                    EpisodeRow.type.ilike(search_pattern, escape="\\"),
+                    EpisodeRow.source.ilike(search_pattern, escape="\\"),
+                    EpisodeRow.session_id.ilike(search_pattern, escape="\\"),
                 )
             )
 

--- a/tests/test_admin_like_escape.py
+++ b/tests/test_admin_like_escape.py
@@ -1,0 +1,44 @@
+"""Unit tests for the LIKE-pattern escape helper used by admin search endpoints.
+
+SQL LIKE treats ``%`` (any sequence) and ``_`` (any single character) as
+metacharacters.  User-supplied search strings must have those characters
+escaped before they are interpolated into a LIKE pattern, otherwise a search
+for ``user_123`` also matches ``userX123``, and ``100%`` matches any string
+starting with ``100``.  Likewise, the hardcoded internal-subject prefix
+filters (``_snapshot/``, ``_bootstrap_tmp/``) must escape the leading ``_``
+so they do not accidentally exclude user subjects whose IDs happen to match
+the wildcard (e.g. ``Xsnapshot/foo``).
+
+The helper is a pure-Python function — no DB, no HTTP client required.
+"""
+
+from __future__ import annotations
+
+from server.api.admin import _like_escape
+
+
+def test_percent_is_escaped():
+    assert _like_escape("100%") == "100\\%"
+
+
+def test_underscore_is_escaped():
+    assert _like_escape("user_123") == "user\\_123"
+
+
+def test_backslash_is_escaped_first():
+    """Backslash must be escaped before the others so that a literal
+    backslash in the input does not turn into an escape prefix for the
+    subsequent ``%`` / ``_`` substitution."""
+    assert _like_escape("path\\file") == "path\\\\file"
+
+
+def test_combined_metacharacters():
+    assert _like_escape("a%b_c\\d") == "a\\%b\\_c\\\\d"
+
+
+def test_normal_text_is_unchanged():
+    assert _like_escape("hello world") == "hello world"
+
+
+def test_empty_string_is_unchanged():
+    assert _like_escape("") == ""


### PR DESCRIPTION
## Summary

SQL LIKE treats `%` (match any sequence) and `_` (match any single character) as wildcards. Three admin search endpoints and two hardcoded internal-subject prefix filters in `server/api/admin.py` did not escape these characters, producing subtly wrong results.

## Before

- `GET /admin/subjects?search=user_123` also returned subjects like `userX123` (the `_` acted as a wildcard).
- `GET /admin/subjects?search=100%25` matched any subject starting with `100` rather than the literal string `100%`.
- The internal-subject exclusion filters `not_like("_snapshot/%")` and `not_like("_bootstrap_tmp/%")` used `_` as a wildcard, so subjects like `Xsnapshot/foo` were incorrectly excluded from the list alongside genuine internal subjects.
- The same unescaped-pattern issue affected the memory search (`GET /admin/memories?search=…`) and episode search (`GET /admin/episodes?search=…`) endpoints.

## After

A module-private `_like_escape` helper escapes `\`, `%`, and `_` (in that order, so a backslash in the input is not turned into an escape prefix for subsequent substitutions). All four ilike/not_like call sites now use `_like_escape` with `escape="\\"` so the database interprets the escape sequences correctly.

## Impact

- No behaviour change for search strings that contain no metacharacters (the common case).
- Searches with `_` or `%` in the query now return only exact-substring matches as intended.
- The `_snapshot/` and `_bootstrap_tmp/` prefix filters now exclude exactly the intended internal subjects without accidentally dropping user subjects whose IDs happen to match the wildcard pattern.

## Test plan

- Added `tests/test_admin_like_escape.py` — six pure-Python unit tests for `_like_escape` covering `%`, `_`, `\`, a combined string, normal text, and empty string. No DB or HTTP client required.
- `ruff check server/ tests/` — clean.
- `pytest tests/test_*.py` — 823 passed (5 pre-existing ambient failures that require a running Postgres instance).