### PR TITLE
fix(admin): compile episode payload search as text

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -779,8 +779,7 @@ async def list_subject_episodes(
     offset: int = Query(0, ge=0),
 ):
     """List episodes for a subject with filtering, search, and pagination."""
-    from sqlalchemy import func, or_, select
-    from sqlalchemy.dialects.postgresql import JSONB
+    from sqlalchemy import Text, func, or_, select
 
     from server.db import engine as engine_module
     from server.db.tables import EpisodeRow
@@ -798,7 +797,7 @@ async def list_subject_episodes(
             # Cast payload to text for searching
             base = base.where(
                 or_(
-                    EpisodeRow.payload.cast(JSONB).astext.ilike(search_pattern, escape="\\"),
+                    EpisodeRow.payload.cast(Text).ilike(search_pattern, escape="\\"),
                     EpisodeRow.type.ilike(search_pattern, escape="\\"),
                     EpisodeRow.source.ilike(search_pattern, escape="\\"),
                     EpisodeRow.session_id.ilike(search_pattern, escape="\\"),

--- a/tests/test_admin_like_escape.py
+++ b/tests/test_admin_like_escape.py
@@ -14,6 +14,9 @@ The helper is a pure-Python function — no DB, no HTTP client required.
 
 from __future__ import annotations
 
+import pytest
+from sqlalchemy.dialects import postgresql
+
 from server.api.admin import _like_escape
 
 
@@ -42,3 +45,102 @@ def test_normal_text_is_unchanged():
 
 def test_empty_string_is_unchanged():
     assert _like_escape("") == ""
+
+
+class _FakeScalarRows:
+    def all(self):
+        return []
+
+
+class _FakeResult:
+    def all(self):
+        return []
+
+    def scalars(self):
+        return _FakeScalarRows()
+
+
+class _FakeSession:
+    def __init__(self):
+        self.statements = []
+
+    async def scalar(self, statement):
+        self.statements.append(statement)
+        return 0
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _FakeResult()
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _install_fake_session_factory(monkeypatch):
+    session = _FakeSession()
+    monkeypatch.setattr(
+        "server.db.engine.get_session_factory",
+        lambda: lambda: _FakeSessionContext(session),
+    )
+    return session
+
+
+def _compiled(statement):
+    return statement.compile(dialect=postgresql.dialect())
+
+
+def _param_values(compiled):
+    return set(compiled.params.values())
+
+
+@pytest.mark.anyio
+async def test_admin_subjects_search_and_internal_prefixes_use_like_escape(monkeypatch):
+    from server.api.admin import list_subjects_admin
+
+    session = _install_fake_session_factory(monkeypatch)
+
+    await list_subjects_admin(search="user_123", limit=1, offset=0)
+
+    compiled = _compiled(session.statements[-1])
+    sql = str(compiled)
+
+    assert " ESCAPE '\\\\'" in sql
+    assert r"\_snapshot/%" in _param_values(compiled)
+    assert r"\_bootstrap_tmp/%" in _param_values(compiled)
+    assert r"%user\_123%" in _param_values(compiled)
+
+
+@pytest.mark.anyio
+async def test_admin_memory_search_uses_like_escape(monkeypatch):
+    from server.api.admin import list_subject_memories
+
+    session = _install_fake_session_factory(monkeypatch)
+
+    await list_subject_memories("subject-1", search="100%_match", limit=1, offset=0)
+
+    compiled = _compiled(session.statements[-1])
+
+    assert " ESCAPE '\\\\'" in str(compiled)
+    assert r"%100\%\_match%" in _param_values(compiled)
+
+
+@pytest.mark.anyio
+async def test_admin_episode_search_uses_like_escape(monkeypatch):
+    from server.api.admin import list_subject_episodes
+
+    session = _install_fake_session_factory(monkeypatch)
+
+    await list_subject_episodes("subject-1", search="sess_100%", limit=1, offset=0)
+
+    compiled = _compiled(session.statements[-1])
+
+    assert " ESCAPE '\\\\'" in str(compiled)
+    assert r"%sess\_100\%%" in _param_values(compiled)


### PR DESCRIPTION
## Summary
- Cast admin episode payload search to `Text` before applying the escaped `ILIKE` pattern; `payload.cast(JSONB).astext` raises while constructing the predicate under SQLAlchemy 2.
- Extend the admin LIKE-escape regression tests so they exercise the actual subject, memory, and episode search statements with the PostgreSQL dialect.
- Verify escaped bind values and emitted `ESCAPE` clauses without requiring a live database.

## Tests
- `ruff check server/api/admin.py tests/test_admin_like_escape.py`
- `STATEWAVE_EMBEDDING_PROVIDER=stub STATEWAVE_COMPILER_TYPE=heuristic pytest tests/test_tenant_scoping_invariant.py tests/test_route_limits_invariant.py tests/test_admin_dashboard.py tests/test_admin_like_escape.py -q`
- `PYTHONUTF8=1 pytest tests/test_no_raw_tokenization.py -q`
- `python -m py_compile server/api/admin.py tests/test_admin_like_escape.py`
- `git diff --check`

Note: I also tried `STATEWAVE_EMBEDDING_PROVIDER=stub STATEWAVE_COMPILER_TYPE=heuristic pytest tests/ --ignore=tests/integration -q`; it is not clean in this local Windows environment because smoke tests expect a live server and several non-integration tests attempt the local Postgres default, which currently rejects the `statewave` user password.