### PR TITLE
fix(tests): isolate test runs from the repo .env

### DIFF
--- a/server/core/config.py
+++ b/server/core/config.py
@@ -3,11 +3,19 @@
 from __future__ import annotations
 
 import json
+import os
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 from server.core.webhook_events import parse_webhook_event_filter
+
+# Which dotenv file to load, if any. Defaults to `.env` so normal local runs
+# and deployments are unchanged. The test suite sets `STATEWAVE_ENV_FILE=""`
+# (see tests/conftest.py) so a developer's real `.env` — which may carry a
+# live LiteLLM key — never bleeds into tests and diverges them from CI, which
+# has no `.env`. An empty value disables dotenv loading entirely.
+_ENV_FILE = os.getenv("STATEWAVE_ENV_FILE", ".env") or None
 
 
 class Settings(BaseSettings):
@@ -378,7 +386,7 @@ class Settings(BaseSettings):
     memory_import_max_memories: int = 50_000
     memory_import_max_subjects: int = 100
 
-    model_config = {"env_prefix": "STATEWAVE_", "env_file": ".env", "extra": "ignore"}
+    model_config = {"env_prefix": "STATEWAVE_", "env_file": _ENV_FILE, "extra": "ignore"}
 
 
 settings = Settings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
-from typing import Generator
+# Pin the test environment to match CI BEFORE any `server.*` import constructs
+# the Settings singleton. CI runs with no `.env`; a developer's local `.env`
+# (which may carry a live LiteLLM key) would otherwise leak into tests and
+# diverge them from CI — e.g. the settings-redaction tests would see the real
+# key instead of the value they monkeypatch. `setdefault` lets a developer
+# still point at a dedicated test env file via `STATEWAVE_ENV_FILE=.env.test`.
+import os
 
-import pytest
-from httpx import ASGITransport, AsyncClient
-from starlette.routing import BaseRoute
+os.environ.setdefault("STATEWAVE_ENV_FILE", "")
 
-from server.app import create_app
+from typing import Generator  # noqa: E402
+
+import pytest  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+from starlette.routing import BaseRoute  # noqa: E402
+
+from server.app import create_app  # noqa: E402
 
 
 def iter_routes(app_or_router) -> Generator[BaseRoute, None, None]:


### PR DESCRIPTION
## Summary

Local test runs loaded the developer's repo `.env` (via pydantic-settings `env_file=".env"`), which diverged them from CI — CI has no `.env`. The real `STATEWAVE_LITELLM_API_KEY` leaked into the settings-redaction tests (they monkeypatch a known key but observed the `.env` value), and the embedding/compiler defaults differed, producing spurious local-only failures.

This pins the test environment to match CI at the source, so no manual `.env` juggling or per-run env overrides are needed.

- **`config.py`** — `env_file` now honors a `STATEWAVE_ENV_FILE` override (defaults to `.env`; empty disables dotenv loading). **Production behavior unchanged.**
- **`conftest.py`** — `setdefault STATEWAVE_ENV_FILE=""` before any `server.*` import, so the singleton `Settings()` never reads the repo `.env`. A developer can still point at a dedicated file via `STATEWAVE_ENV_FILE=.env.test`.

## Test plan

- [x] Full suite green locally **with `.env` present, no overrides**: unit 877 passed / 1 skipped, integration 255 passed
- [x] Previously-failing `test_list_settings_redacts_secrets` now passes with `.env` present
- [x] `ruff check` clean
