### PR TITLE
feat(llm): return token usage + model from /v1/llm/complete

### DIFF
--- a/server/api/llm.py
+++ b/server/api/llm.py
@@ -25,13 +25,13 @@ from fastapi import APIRouter, HTTPException
 
 from server.core.config import settings
 from server.schemas.requests import LLMCompleteRequest
-from server.schemas.responses import LLMCompleteResponse
+from server.schemas.responses import LLMCompleteResponse, LLMUsage
 from server.services.llm import (
     LLMProviderError,
     LLMResponseError,
     LLMTimeoutError,
     StatewaveLLMError,
-    acomplete,
+    acomplete_with_usage,
 )
 
 router = APIRouter(tags=["llm"])
@@ -52,7 +52,7 @@ async def complete_chat(body: LLMCompleteRequest) -> LLMCompleteResponse:
     messages = [{"role": m.role, "content": m.content} for m in body.messages]
 
     try:
-        reply = await acomplete(
+        reply, usage = await acomplete_with_usage(
             messages,
             max_tokens=body.max_tokens,
             temperature=body.temperature,
@@ -72,4 +72,11 @@ async def complete_chat(body: LLMCompleteRequest) -> LLMCompleteResponse:
             detail={"code": "upstream_llm_error", "message": "Upstream LLM call failed."},
         ) from exc
 
-    return LLMCompleteResponse(reply=reply)
+    return LLMCompleteResponse(
+        reply=reply,
+        usage=LLMUsage(**usage) if usage else None,
+        # The model the server actually used. Safe to return on the success
+        # path (same X-API-Key trust boundary as all of /v1/*); the error
+        # paths above still never echo it.
+        model=settings.litellm_model or None,
+    )

--- a/server/schemas/responses.py
+++ b/server/schemas/responses.py
@@ -215,11 +215,30 @@ class SLASummaryResponse(BaseModel):
     sessions: list[SessionSLAResponse] = Field(default_factory=list)
 
 
+class LLMUsage(BaseModel):
+    """Token usage for one completion, OpenAI-shape. Present when the
+    provider reports it; omitted (the whole object is ``None``) for
+    providers that don't surface usage — e.g. some local/Ollama setups."""
+
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
 class LLMCompleteResponse(BaseModel):
-    """Response body for `POST /v1/llm/complete`. Just the assistant text;
-    callers don't need usage/tokens for the widget-completion use case."""
+    """Response body for `POST /v1/llm/complete`.
+
+    `reply` is the assistant text. `usage` and `model` are optional metadata
+    so first-party consoles (the admin "Chat with Memory", which delegates
+    its LLM call here rather than holding its own provider key) can surface
+    token + model stats. Both are ``None`` when unavailable. Unlike the error
+    path — which deliberately never echoes the model identifier — returning
+    the configured model on the success path is safe: this endpoint sits
+    behind the same ``X-API-Key`` trust boundary as the rest of ``/v1/*``."""
 
     reply: str
+    usage: LLMUsage | None = None
+    model: str | None = None
 
 
 class TenantConfigResponse(BaseModel):

--- a/server/services/llm.py
+++ b/server/services/llm.py
@@ -39,6 +39,8 @@ Public surface:
 
     acomplete(messages, *, model=None, temperature=None, max_tokens=None,
               response_format=None, timeout=None) -> str
+    acomplete_with_usage(messages, *, model=None, temperature=None,
+              max_tokens=None, timeout=None) -> tuple[str, dict | None]
     acomplete_json(messages, *, model=None, ...) -> dict
     aembed_texts(texts, *, model=None, dimensions=None) -> list[list[float]]
     aembed_query(text, *, model=None, dimensions=None) -> list[float]
@@ -230,6 +232,82 @@ async def acomplete(
         return resp.choices[0].message.content or ""
     except (AttributeError, IndexError, KeyError) as exc:
         raise LLMResponseError("LLM response missing expected choices/message") from exc
+
+
+def _extract_usage(resp: Any) -> dict[str, int] | None:
+    """Pull OpenAI-shape token usage off a LiteLLM completion response.
+
+    Returns ``None`` when the provider omits usage (some local models do),
+    so callers can render "tokens: n/a" rather than a misleading zero.
+    """
+    usage = getattr(resp, "usage", None)
+    if usage is None:
+        return None
+
+    def _as_int(value: Any) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    prompt = _as_int(getattr(usage, "prompt_tokens", None))
+    completion = _as_int(getattr(usage, "completion_tokens", None))
+    total = _as_int(getattr(usage, "total_tokens", None)) or (prompt + completion)
+    if prompt == 0 and completion == 0 and total == 0:
+        return None
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total,
+    }
+
+
+async def acomplete_with_usage(
+    messages: list[dict[str, str]],
+    *,
+    model: str | None = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    timeout: float | None = None,
+) -> tuple[str, dict[str, int] | None]:
+    """Like :func:`acomplete`, but also returns token usage when the
+    provider reports it: ``(reply, usage_or_none)``.
+
+    Powers the internal ``/v1/llm/complete`` route so first-party consoles
+    (the admin "Chat with Memory") can show token stats. Kept as a separate
+    function — rather than threading a flag through :func:`acomplete` — so
+    the hot compilation path stays byte-for-byte unchanged; the small amount
+    of duplicated call/error scaffolding is the deliberate cost of that
+    isolation.
+    """
+    litellm = _ensure_litellm()
+    chosen_model = model or settings.litellm_model
+    temp = temperature if temperature is not None else settings.litellm_temperature
+    timeout_s = timeout if timeout is not None else settings.litellm_timeout_seconds
+
+    kwargs: dict[str, Any] = {
+        "model": chosen_model,
+        "messages": messages,
+        "temperature": temp,
+        "num_retries": settings.litellm_max_retries,
+        **_common_kwargs(),
+    }
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
+
+    try:
+        resp = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=timeout_s)
+    except asyncio.TimeoutError as exc:
+        raise LLMTimeoutError(f"LLM completion timed out after {timeout_s}s") from exc
+    except Exception as exc:  # noqa: BLE001
+        raise _classify(exc) from exc
+
+    try:
+        reply = resp.choices[0].message.content or ""
+    except (AttributeError, IndexError, KeyError) as exc:
+        raise LLMResponseError("LLM response missing expected choices/message") from exc
+
+    return reply, _extract_usage(resp)
 
 
 async def acomplete_json(

--- a/tests/test_api_llm.py
+++ b/tests/test_api_llm.py
@@ -1,7 +1,7 @@
 """Tests for the internal /v1/llm/complete endpoint.
 
-The endpoint is a thin pass-through over `services.llm.acomplete`. We mock
-that function to keep these tests provider-free and fast.
+The endpoint is a thin pass-through over `services.llm.acomplete_with_usage`.
+We mock that function to keep these tests provider-free and fast.
 """
 
 from __future__ import annotations
@@ -25,9 +25,12 @@ async def _client_with(monkeypatch=None) -> AsyncClient:
 async def test_complete_chat_happy_path(monkeypatch):
     monkeypatch.setattr(settings, "litellm_model", "gpt-4o-mini")
     with patch(
-        "server.api.llm.acomplete",
+        "server.api.llm.acomplete_with_usage",
         new_callable=AsyncMock,
-        return_value="hello from llm",
+        return_value=(
+            "hello from llm",
+            {"prompt_tokens": 11, "completion_tokens": 4, "total_tokens": 15},
+        ),
     ) as mocked:
         async with await _client_with() as c:
             r = await c.post(
@@ -42,9 +45,15 @@ async def test_complete_chat_happy_path(monkeypatch):
                 },
             )
     assert r.status_code == 200
-    assert r.json() == {"reply": "hello from llm"}
-    # acomplete called with (messages_list, max_tokens=..., temperature=...) — no
-    # model kwarg, since callers must not pick the model.
+    # reply + usage + the server-resolved model (so first-party consoles can
+    # render token/model stats without holding their own provider key).
+    assert r.json() == {
+        "reply": "hello from llm",
+        "usage": {"prompt_tokens": 11, "completion_tokens": 4, "total_tokens": 15},
+        "model": "gpt-4o-mini",
+    }
+    # acomplete_with_usage called with (messages_list, max_tokens=...,
+    # temperature=...) — no model kwarg, since callers must not pick the model.
     args, kwargs = mocked.call_args
     assert args[0] == [
         {"role": "system", "content": "you are helpful"},
@@ -54,12 +63,37 @@ async def test_complete_chat_happy_path(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_complete_chat_usage_absent_when_provider_omits_it(monkeypatch):
+    """Some providers (e.g. local models) don't report token usage. The
+    route must surface `usage: null` rather than a misleading zero."""
+    monkeypatch.setattr(settings, "litellm_model", "ollama/llama3")
+    with patch(
+        "server.api.llm.acomplete_with_usage",
+        new_callable=AsyncMock,
+        return_value=("local reply", None),
+    ):
+        async with await _client_with() as c:
+            r = await c.post(
+                "/v1/llm/complete",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+    assert r.status_code == 200
+    assert r.json() == {
+        "reply": "local reply",
+        "usage": None,
+        "model": "ollama/llama3",
+    }
+
+
+@pytest.mark.asyncio
 async def test_complete_chat_caller_cannot_pick_model(monkeypatch):
     """The schema does not accept a `model` field — caller-supplied values
     are silently dropped (Pydantic's default for unknown fields)."""
     monkeypatch.setattr(settings, "litellm_model", "gpt-4o-mini")
     with patch(
-        "server.api.llm.acomplete", new_callable=AsyncMock, return_value="ok"
+        "server.api.llm.acomplete_with_usage",
+        new_callable=AsyncMock,
+        return_value=("ok", None),
     ) as mocked:
         async with await _client_with() as c:
             r = await c.post(
@@ -91,7 +125,7 @@ async def test_complete_chat_returns_503_when_no_model(monkeypatch):
 async def test_complete_chat_provider_error_returns_502(monkeypatch):
     monkeypatch.setattr(settings, "litellm_model", "gpt-4o-mini")
     with patch(
-        "server.api.llm.acomplete",
+        "server.api.llm.acomplete_with_usage",
         new_callable=AsyncMock,
         side_effect=LLMProviderError("rate limit hit at https://internal-config"),
     ):
@@ -111,7 +145,7 @@ async def test_complete_chat_provider_error_returns_502(monkeypatch):
 async def test_complete_chat_timeout_returns_504(monkeypatch):
     monkeypatch.setattr(settings, "litellm_model", "gpt-4o-mini")
     with patch(
-        "server.api.llm.acomplete",
+        "server.api.llm.acomplete_with_usage",
         new_callable=AsyncMock,
         side_effect=LLMTimeoutError("timed out talking to https://internal-config after 60s"),
     ):

--- a/tests/test_llm_complete_usage.py
+++ b/tests/test_llm_complete_usage.py
@@ -1,0 +1,81 @@
+"""Unit tests for ``acomplete_with_usage`` + ``_extract_usage``.
+
+These power the token stats that ``/v1/llm/complete`` returns so first-party
+consoles (the admin "Chat with Memory") can show usage without holding their
+own provider key. The provider call is mocked so the tests stay fast and
+credential-free; we only assert how usage is extracted and shaped.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from server.services import llm as llm_mod
+
+
+def _fake_completion(content: str, usage):
+    """Build a LiteLLM-shaped chat-completion response object."""
+    message = SimpleNamespace(content=content)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+@pytest.mark.anyio
+async def test_returns_reply_and_usage(monkeypatch):
+    monkeypatch.setattr(llm_mod.settings, "litellm_model", "gpt-4o-mini")
+    usage = SimpleNamespace(prompt_tokens=11, completion_tokens=4, total_tokens=15)
+    fake_litellm = MagicMock()
+    fake_litellm.acompletion = AsyncMock(return_value=_fake_completion("hi there", usage))
+
+    with patch.object(llm_mod, "_ensure_litellm", return_value=fake_litellm):
+        reply, got = await llm_mod.acomplete_with_usage(
+            [{"role": "user", "content": "hi"}], max_tokens=50
+        )
+
+    assert reply == "hi there"
+    assert got == {"prompt_tokens": 11, "completion_tokens": 4, "total_tokens": 15}
+
+
+@pytest.mark.anyio
+async def test_usage_none_when_provider_omits_it(monkeypatch):
+    monkeypatch.setattr(llm_mod.settings, "litellm_model", "ollama/llama3")
+    fake_litellm = MagicMock()
+    fake_litellm.acompletion = AsyncMock(return_value=_fake_completion("local", None))
+
+    with patch.object(llm_mod, "_ensure_litellm", return_value=fake_litellm):
+        reply, got = await llm_mod.acomplete_with_usage([{"role": "user", "content": "hi"}])
+
+    assert reply == "local"
+    assert got is None
+
+
+@pytest.mark.anyio
+async def test_derives_total_when_provider_omits_it(monkeypatch):
+    """Some providers report prompt/completion but not total — derive it."""
+    monkeypatch.setattr(llm_mod.settings, "litellm_model", "gpt-4o-mini")
+    usage = SimpleNamespace(prompt_tokens=7, completion_tokens=3, total_tokens=None)
+    fake_litellm = MagicMock()
+    fake_litellm.acompletion = AsyncMock(return_value=_fake_completion("x", usage))
+
+    with patch.object(llm_mod, "_ensure_litellm", return_value=fake_litellm):
+        _, got = await llm_mod.acomplete_with_usage([{"role": "user", "content": "hi"}])
+
+    assert got == {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10}
+
+
+@pytest.mark.anyio
+async def test_all_zero_usage_collapses_to_none(monkeypatch):
+    """An all-zero usage block is indistinguishable from "not reported" — we
+    surface None so the UI shows "n/a" rather than a misleading 0."""
+    monkeypatch.setattr(llm_mod.settings, "litellm_model", "gpt-4o-mini")
+    usage = SimpleNamespace(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+    fake_litellm = MagicMock()
+    fake_litellm.acompletion = AsyncMock(return_value=_fake_completion("x", usage))
+
+    with patch.object(llm_mod, "_ensure_litellm", return_value=fake_litellm):
+        _, got = await llm_mod.acomplete_with_usage([{"role": "user", "content": "hi"}])
+
+    assert got is None


### PR DESCRIPTION
## Summary

Extends the internal `POST /v1/llm/complete` endpoint with **optional `usage` + `model`** metadata, so a first-party console can show token/model stats when it delegates generation here instead of holding its own provider key.

This is the backend half of making the admin "Chat with Memory" reuse the backend's already-configured LLM (companion PR: statewave-admin `feat/chat-backend-delegation`).

- `LLMUsage` schema added; `LLMCompleteResponse` gains optional `usage` + `model` (both `None` when unavailable, e.g. a provider that omits usage)
- `acomplete_with_usage()` added alongside `acomplete()` — the hot compilation path stays byte-for-byte unchanged; `_extract_usage()` helper handles OpenAI-shape usage and derives `total` when a provider omits it
- The route returns the server-resolved model **on success only**; the error paths still never echo the model identifier (unchanged security posture)

The endpoint remains narrow — callers still cannot pick the model, and it stays behind the same `X-API-Key` trust boundary as the rest of `/v1/*`.

## Test plan

- [x] `tests/test_api_llm.py` updated (9 tests) + new `tests/test_llm_complete_usage.py` (4 tests) — usage present, usage-omitted → `null`, total derived, all-zero → `null`
- [x] `acomplete` (compile path) untouched — 44 llm-adapter tests pass
- [x] `ruff check` clean; full backend suite green against a local pgvector DB

## Merge ordering

Independently mergeable. Merge **before** the admin delegation PR so the delegated chat path shows token stats immediately (admin works without it — it just won't have tokens until this ships).
