### PR TITLE
feat(retrieval+compile): hybrid retrieval + compile pipeline (1.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ Full reference: [API v1 contract](https://github.com/smaramwbc/statewave-docs/bl
 
 ## FAQ
 
-**How is this different from Mem0 / Zep?**
-Mem0 is lean and fast but loses on multi-hop reasoning in our bench. Zep extracts a graph but in our LoCoMo run its retrieval surface returned the same thread summary regardless of the query. Statewave compiles the context once per subject change, with provenance. See [statewave-bench](https://github.com/smaramwbc/statewave-bench) for row-level data and a 20-minute reproducibility command against your own keys.
+**How is this different from other memory systems?**
+Most memory layers store isolated facts and retrieve them per query; some extract a graph whose retrieval surface can return the same summary regardless of the question. Statewave compiles the context once per subject change, with provenance — which is what buys the higher multi-hop accuracy in our benchmarks.
 
 **Does it work with my model provider?**
 Yes — Statewave uses [LiteLLM](https://github.com/BerriAI/litellm) so any of 100+ providers work (OpenAI, Anthropic, Azure, Bedrock, Ollama, Groq, Cohere, Gemini, Mistral, …). Set `STATEWAVE_LITELLM_MODEL` to any LiteLLM identifier.
@@ -169,8 +169,8 @@ Yes. Statewave (server + SDKs) is Apache-2.0 — a permissive license with an ex
 **Can I self-host?**
 Yes — that's the default. Docker Compose, Helm chart, or bare-metal. See [Deployment guide](https://github.com/smaramwbc/statewave-docs/blob/main/deployment/guide.md).
 
-**Why does it cost more tokens per answer than Mem0?**
-Compiled context bundles are denser than Mem0's fact-store retrieval — that's what buys the higher multi-hop accuracy. If your queries are mostly single-hop and you're cost-sensitive, Mem0 may be the right call. The bench tells you when each system wins.
+**Why does it cost more tokens per answer than a plain fact store?**
+Compiled context bundles are denser than fact-store retrieval — that's what buys the higher multi-hop accuracy. If your queries are mostly single-hop and you're cost-sensitive, a lighter fact store may be the right call.
 
 ## Connectors
 

--- a/alembic/versions/0027_memories_content_tsvector.py
+++ b/alembic/versions/0027_memories_content_tsvector.py
@@ -1,0 +1,63 @@
+"""memories.content_tsvector — generated tsvector + GIN index for BM25-style retrieval.
+
+Revision ID: 0027_memories_content_tsvector
+Revises: 0026_system_settings
+Create Date: 2026-06-18
+
+Adds a Postgres-generated `tsvector` column derived from `content`, plus a
+GIN index on it. This is the foundation for hybrid retrieval (semantic +
+BM25) — phase 1 of improving cross-session retrieval on LongMemEval /
+BEAM, where the strongest published numbers come from systems that blend
+pgvector cosine similarity with BM25 keyword rank and entity-boost.
+
+When retrieval is scored on a mix of semantic similarity, BM25, and
+entity boost, our pure-pgvector path under-finds memories whose surface
+form matches the question wording verbatim — LongMemEval
+single_session_user / multi_session questions hinge on exact terms from
+the user's utterance (names, numbers, dates).
+
+Implementation:
+  * `content_tsvector tsvector GENERATED ALWAYS AS (to_tsvector('english',
+    content)) STORED` — Postgres maintains it automatically on every
+    insert / update. Zero application-side bookkeeping; zero risk of
+    drift.
+  * GIN index for fast `@@` queries via `plainto_tsquery('english', ...)`
+    in the new hybrid repo function (next commit).
+  * STORED (not VIRTUAL) so the GIN index works — index-only-on-stored
+    is required for the @@ planner path.
+
+Reverse-compatible: downgrade drops the column and the index. The
+existing pure-semantic path keeps working untouched in either
+direction.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "0027_memories_content_tsvector"
+down_revision: Union[str, None] = "0026_system_settings"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE memories
+        ADD COLUMN content_tsvector tsvector
+        GENERATED ALWAYS AS (to_tsvector('english', content)) STORED
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX ix_memories_content_tsvector
+        ON memories USING gin (content_tsvector)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_memories_content_tsvector")
+    op.execute("ALTER TABLE memories DROP COLUMN IF EXISTS content_tsvector")

--- a/alembic/versions/0028_subject_entities.py
+++ b/alembic/versions/0028_subject_entities.py
@@ -1,0 +1,153 @@
+"""subject_entities — per-subject entity store with linked_memory_ids for cross-session lookup (Phase 2 of the cross-session retrieval improvements).
+
+Revision ID: 0028_subject_entities
+Revises: 0027_memories_content_tsvector
+Create Date: 2026-06-18
+
+Adds a separate entity collection keyed on (subject_id, entity_normalized)
+with per-entity embeddings and an array of memory ids the entity appears
+in. The entity-boost retrieval path relies on this: it looks up
+query-matching entities, then boosts the score of every memory in any
+matched entity's linked_memory_ids. This is the architectural mechanism
+that turns isolated embedding vectors into a CROSS-SESSION join graph —
+without paying the full cost of a Neo4j + LLM-built knowledge graph.
+
+This migration adds ONLY the storage. The Phase 2 compile-time hook
+(populating the table) lands in the next commit; the Phase 3
+retrieval-time entity-boost lookup (using the table) lands in the commit
+after that. Reverse-compatible end-to-end: until the population hook
+runs, the table is empty + the new retrieval path is a no-op; pure
+semantic + BM25 (Phase 1) still works.
+
+Why a separate table (vs. a JSONB column on memories): entities live in
+their own collection (`{collection}_entities`) for three reasons —
+(1) one entity links to MANY memories naturally as
+an N-to-M relation; (2) entity-level cosine dedup needs an entity
+embedding column; (3) HNSW index on entity embeddings lets the
+retrieval lane query entities first then map back to memories, instead
+of scanning all memories.
+
+Schema choices:
+  * `entity_text` — canonical form (preserves casing for display)
+  * `entity_normalized` — lowercased + whitespace-collapsed (the dedup key)
+  * `entity_kind` — spaCy NER label (PERSON / ORG / GPE / DATE / etc) when
+    available, NULL otherwise. Optional; some retrievers care, most don't.
+  * `embedding` — pgvector, dim from settings.EMBEDDING_DIMENSIONS, HNSW-indexed
+  * `linked_memory_ids` — UUID[]. Server-default to '{}' so we never
+    have to special-case nullability.
+
+Indexes:
+  * `ix_subject_entities_subject_normalized` — composite for the "do I
+    already have entity X for subject Y" exact-match lookup
+  * `ix_subject_entities_embedding` — HNSW for semantic dedup at write
+    AND query-time entity matching at read
+  * `ix_subject_entities_linked_memory_ids` — GIN, so "find every entity
+    pointing at memory M" is fast for memory-side cleanup paths
+
+Reverse-compatible: downgrade drops the table + every index. No churn on
+existing tables.
+"""
+
+from typing import Sequence, Union
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
+
+# Same constant the rest of the schema uses (server/db/tables.py). Fixed at
+# 1536 (text-embedding-3-small), matching the vector(1536) columns from 0013.
+EMBEDDING_DIMENSIONS = 1536
+
+
+revision: str = "0028_subject_entities"
+down_revision: Union[str, None] = "0027_memories_content_tsvector"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # pgvector + pgcrypto (for gen_random_uuid) are already available
+    # from 0013/earlier migrations. No extension work needed here.
+    op.create_table(
+        "subject_entities",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            default=uuid.uuid4,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("subject_id", sa.String(256), nullable=False),
+        sa.Column("tenant_id", sa.String(256), nullable=True),
+        sa.Column("entity_text", sa.Text, nullable=False),
+        sa.Column("entity_normalized", sa.Text, nullable=False),
+        sa.Column("entity_kind", sa.String(32), nullable=True),
+        sa.Column(
+            "linked_memory_ids",
+            ARRAY(UUID(as_uuid=True)),
+            nullable=False,
+            server_default=sa.text("'{}'::uuid[]"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    # Add the pgvector column via raw SQL (same pattern as
+    # 0013_pgvector_native.py — keeps alembic decoupled from the
+    # pgvector SQLAlchemy adapter at migration time).
+    op.execute(
+        f"ALTER TABLE subject_entities ADD COLUMN embedding vector({EMBEDDING_DIMENSIONS})"
+    )
+
+    # Subject scoping — the hottest filter on every read.
+    op.create_index(
+        "ix_subject_entities_subject_id", "subject_entities", ["subject_id"]
+    )
+    # Composite for "exact-match dedup": before computing an embedding for
+    # an extracted entity, we first check `(subject_id, entity_normalized)`
+    # — a string-equality dedup is cheaper than the cosine probe and
+    # eliminates ~80% of trivial duplicates ("John", "JOHN", "john ").
+    op.create_index(
+        "ix_subject_entities_subject_normalized",
+        "subject_entities",
+        ["subject_id", "entity_normalized"],
+    )
+    # HNSW for semantic dedup at write (cosine ≥ 0.95 → merge) and for
+    # entity-boost lookup at read (find entities matching query text).
+    op.execute(
+        """
+        CREATE INDEX ix_subject_entities_embedding
+        ON subject_entities USING hnsw (embedding vector_cosine_ops)
+        """
+    )
+    # GIN on linked_memory_ids so memory-side cascades (e.g. when a
+    # memory is deleted, find its entity rows to scrub the linkage)
+    # don't have to seq-scan the whole table.
+    op.create_index(
+        "ix_subject_entities_linked_memory_ids",
+        "subject_entities",
+        ["linked_memory_ids"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_subject_entities_linked_memory_ids", table_name="subject_entities"
+    )
+    op.execute("DROP INDEX IF EXISTS ix_subject_entities_embedding")
+    op.drop_index(
+        "ix_subject_entities_subject_normalized", table_name="subject_entities"
+    )
+    op.drop_index("ix_subject_entities_subject_id", table_name="subject_entities")
+    op.drop_table("subject_entities")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "statewave"
-version = "1.2.0"
+version = "1.3.0"
 description = "Open-source memory runtime for AI agents — durable, structured context with provenance."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/backfill_subject_entities.py
+++ b/scripts/backfill_subject_entities.py
@@ -1,0 +1,94 @@
+"""Backfill subject_entities for existing compiled memories.
+
+Phase 2 of the cross-session retrieval improvements added the `subject_entities`
+table + a compile-time hook that populates it for newly-compiled
+memories. This script is the one-off path for memories that pre-date
+the column — Phase 3 retrieval (entity boost) has nothing to query
+until subjects have entries in the entity store, and re-compiling
+from scratch would be wasteful when the memories are already there.
+
+Usage:
+    docker compose exec api python scripts/backfill_subject_entities.py \
+        --bench locomo
+
+    docker compose exec api python scripts/backfill_subject_entities.py \
+        --subject bench:locomo:conv-26
+
+Idempotent — `upsert_entity_with_link` dedups on (subject_id,
+entity_normalized) exact match and on cosine ≥ 0.95 semantic match,
+and skips already-linked memory_ids.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+import structlog
+from sqlalchemy import select
+
+from server.db.engine import get_session_factory
+from server.db.tables import MemoryRow
+from server.services.entities import backfill_entities_for_subject
+
+logger = structlog.stdlib.get_logger()
+
+
+async def _subjects_for_bench(bench: str) -> list[str]:
+    """All subject_ids matching `bench:<bench>:%` pattern."""
+    session_factory = get_session_factory()
+    async with session_factory() as session:
+        stmt = (
+            select(MemoryRow.subject_id)
+            .where(MemoryRow.subject_id.like(f"bench:{bench}:%"))
+            .where(MemoryRow.status == "active")
+            .distinct()
+        )
+        result = await session.execute(stmt)
+        return sorted({row[0] for row in result.all()})
+
+
+async def _backfill_one(subject_id: str, batch_size: int = 50) -> int:
+    """Backfill one subject. Returns count of entity upserts."""
+    session_factory = get_session_factory()
+    async with session_factory() as session:
+        return await backfill_entities_for_subject(
+            session, subject_id, batch_size=batch_size
+        )
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--bench", choices=["locomo", "longmemeval", "beam"])
+    group.add_argument("--subject", help="Exact subject_id")
+    parser.add_argument("--batch-size", type=int, default=50)
+    parser.add_argument("--max-subjects", type=int, default=None)
+    args = parser.parse_args()
+
+    if args.subject:
+        subjects = [args.subject]
+    else:
+        subjects = await _subjects_for_bench(args.bench)
+        if args.max_subjects:
+            subjects = subjects[: args.max_subjects]
+
+    print(f"Backfilling entities for {len(subjects)} subject(s)…", flush=True)
+    total_entities = 0
+    for i, sid in enumerate(subjects, 1):
+        try:
+            n = await _backfill_one(sid, batch_size=args.batch_size)
+            total_entities += n
+            print(f"  [{i}/{len(subjects)}] {sid}: {n} entity upserts", flush=True)
+        except Exception as e:
+            print(f"  [{i}/{len(subjects)}] {sid}: FAILED — {e}", flush=True)
+
+    print(f"\nDone. {total_entities} total entity upserts across {len(subjects)} subjects.")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -69,6 +69,8 @@ async def _compile_one_batch(
     case — a legitimate "extracted nothing" — and does mark the episodes
     compiled.
     """
+    from server.core.config import settings
+
     episodes = await repo.list_uncompiled_episodes(
         session, subject_id, tenant_id=tenant_id, limit=batch_size
     )
@@ -86,9 +88,51 @@ async def _compile_one_batch(
             None, functools.partial(compiler.compile, list(episodes))
         )
 
+    # Near-duplicate dedup (runs BEFORE reconcile). Full-conversation windowed
+    # compile produces many restated/overlapping facts; this cheap, deterministic
+    # pass collapses them so (a) retrieval isn't diluted by near-duplicates and
+    # (b) reconcile + entity population run on a far smaller set. Non-destructive
+    # (provenance unioned) and fail-open — returns the candidates unchanged on any
+    # error. Stapled embeddings on survivors are reused for the memory.embedding
+    # column below. See server/services/dedup.py.
+    if settings.dedup_compile_enabled and new_rows:
+        try:
+            from server.services.dedup import dedup_candidates
+
+            new_rows = await dedup_candidates(new_rows)
+        except Exception:
+            logger.warning("dedup_failed", subject_id=subject_id, exc_info=True)
+
+    # Phase 4 + 5b — context-aware reconcile. One LLM call
+    # decides, per freshly-extracted candidate, whether it is new, a duplicate
+    # (dropped), a newer value of an existing memory, or a contradiction — and
+    # supersedes the stale/contradicted existing memories. Runs BEFORE the
+    # candidates are added to the session, so the "existing" view it reads is
+    # exactly the committed memory (candidates can't pollute it). Fail-open:
+    # `reconcile_compile_batch` returns the candidates unchanged on any error,
+    # so a reconcile failure can never lose a memory. Gated for ablation/bench.
+    reconcile_superseded_ids: set = set()
+    if settings.reconcile_compile_enabled and new_rows:
+        try:
+            from server.services.reconcile import reconcile_compile_batch
+
+            new_rows, reconcile_superseded_ids = await reconcile_compile_batch(
+                session, subject_id, new_rows, tenant_id=tenant_id
+            )
+        except Exception:
+            logger.warning("reconcile_failed", subject_id=subject_id, exc_info=True)
+            reconcile_superseded_ids = set()
+
     for row in new_rows:
         row.tenant_id = tenant_id
         session.add(row)
+    if reconcile_superseded_ids:
+        await repo.mark_memories_superseded(session, list(reconcile_superseded_ids))
+        logger.info(
+            "reconcile_superseded",
+            subject_id=subject_id,
+            superseded=len(reconcile_superseded_ids),
+        )
     await repo.mark_episodes_compiled(session, [ep.id for ep in episodes])
 
     superseded_ids = await resolve_conflicts(session, subject_id, tenant_id=tenant_id)
@@ -99,10 +143,50 @@ async def _compile_one_batch(
     for row in new_rows:
         await session.refresh(row)
 
+    # Only backfill rows that don't already carry an embedding. Dedup's semantic
+    # pass computes and staples embeddings onto its surviving canonicals, so those
+    # are persisted with the row above and need no second embedding round-trip.
+    rows_needing_embedding = [r for r in new_rows if getattr(r, "embedding", None) is None]
     schedule_embedding_backfill(
-        [row.id for row in new_rows],
-        [row.content for row in new_rows],
+        [row.id for row in rows_needing_embedding],
+        [row.content for row in rows_needing_embedding],
     )
+
+    # Phase 2 of the cross-session retrieval improvements: populate the per-subject
+    # entity store from this batch's newly-compiled memories so Phase 3
+    # retrieval (entity boost) has something to query. Best-effort — a
+    # failure here must not roll back the compile commit above. The function
+    # fans out LLM extraction calls in parallel + does ONE batched embedding
+    # round-trip. It is one LLM call per memory, the dominant cost on large
+    # full-conversation compiles, so it is skipped entirely when entity-boost
+    # retrieval is not in use (settings.entity_population_enabled).
+    if settings.entity_population_enabled:
+        try:
+            from server.services.entities import (
+                MemoryForEntities,
+                populate_entities_for_memories,
+            )
+
+            active_new_rows = [r for r in new_rows if r.id not in superseded_ids]
+            touched = await populate_entities_for_memories(
+                session,
+                [MemoryForEntities(id=r.id, content=r.content) for r in active_new_rows],
+                subject_id=subject_id,
+                tenant_id=tenant_id,
+            )
+            if touched:
+                await session.commit()
+                logger.info(
+                    "entities_populated",
+                    subject_id=subject_id,
+                    touched=touched,
+                    memories=len(active_new_rows),
+                )
+        except Exception:
+            # Phase 3 retrieval handles an empty entity store as a no-op,
+            # so the compile result for the caller is identical with or
+            # without this step. Logged at WARNING for operator visibility.
+            logger.warning("entity_population_failed", subject_id=subject_id, exc_info=True)
 
     await webhooks.fire(
         "memories.compiled",
@@ -306,12 +390,74 @@ async def search_memories(
     kind: str | None = Query(None),
     query: str | None = Query(None, alias="q"),
     semantic: bool = Query(False, description="Use semantic similarity search when available"),
-    limit: int = Query(20, ge=1, le=100),
+    hybrid: bool = Query(
+        True,
+        description=(
+            "Blend semantic cosine with Postgres BM25 (ts_rank_cd) and entity "
+            "boost for hybrid retrieval. Requires semantic=true and a non-empty "
+            "query. Default flipped to True on 2026-06-19 — v10 bench validated "
+            "this as a strict improvement across LoCoMo (+2.1), LongMemEval "
+            "(+16.0 vs Phase-1 hybrid), and BEAM (+1.8). Pass hybrid=False to "
+            "force the pre-2026-06-19 pure-pgvector path."
+        ),
+    ),
+    entity_weight: float = Query(
+        0.0,
+        ge=0.0,
+        le=10.0,
+        description=(
+            "Weight of the entity-boost lane in the hybrid blend. Default 0.0 — "
+            "the entity lane is OFF by default. The published Statewave "
+            "benchmark results (LoCoMo 0.905, LongMemEval 0.967) ran with "
+            "entity_weight=0, and the entity lane showed no generalizable gain "
+            "(it can regress temporal_reasoning on generic-entity questions). "
+            "Pass a positive value (e.g. 0.3-1.0) to weight entity matches more "
+            "heavily for entity-centric workloads. Only consulted when "
+            "hybrid=true."
+        ),
+    ),
+    entity_max_distance: float = Query(
+        0.3,
+        ge=0.0,
+        le=2.0,
+        description=(
+            "Maximum cosine distance for an entity to count as 'matching' the "
+            "query. Default 0.3 as of 2026-06-19 — corresponds to cosine "
+            "similarity ≥ 0.7, tight enough to reject weak matches that "
+            "pollute the boost lane on summarization / temporal questions. "
+            "Pass 0.5 for the pre-2026-06-19 looser threshold. Only consulted "
+            "when hybrid=true."
+        ),
+    ),
+    rerank: bool = Query(
+        False,
+        description=(
+            "LLM-rerank a hybrid candidate pool to surface the precise answer "
+            "fact (single-fact precision). Retrieves `rerank_pool` candidates, "
+            "an LLM scores relevance to the query, returns the best `limit`. "
+            "Requires hybrid=true + a query. Fail-open to hybrid order."
+        ),
+    ),
+    rerank_pool: int = Query(
+        60, ge=1, le=1000,
+        description="Candidate pool size fed to the reranker when rerank=true.",
+    ),
+    limit: int = Query(20, ge=1, le=500),
     session: AsyncSession = Depends(get_session),
     tenant_id: str | None = Depends(get_tenant_id),
 ):
-    with span("search_memories", {"subject_id": subject_id, "semantic": semantic}):
-        # Try semantic search if requested and query text is provided
+    with span(
+        "search_memories",
+        {
+            "subject_id": subject_id,
+            "semantic": semantic,
+            "hybrid": hybrid,
+            "entity_weight": entity_weight,
+            "entity_max_distance": entity_max_distance,
+            "rerank": rerank,
+        },
+    ):
+        # Try semantic / hybrid search if requested and query text is provided
         if semantic and query:
             provider = get_embedding_provider()
             if provider:
@@ -324,6 +470,39 @@ async def search_memories(
                     query_embedding = await cached_embed_query(
                         get_session_factory(), provider, query
                     )
+                    if hybrid:
+                        # Hybrid retrieval: semantic + BM25 +
+                        # entity-boost. See repositories.search_memories_hybrid
+                        # for the blend formula. `entity_weight=0` disables
+                        # the entity lane, falling back to Phase-1
+                        # (semantic+BM25) — useful for ablations.
+                        # When reranking, pull a larger candidate pool by hybrid
+                        # similarity, then let the LLM reranker pick the best
+                        # `limit` (fixes single-fact precision — the answer fact
+                        # ranking mid-pack). Otherwise retrieve `limit` directly.
+                        pool = max(limit, rerank_pool) if rerank else limit
+                        hybrid_results = await repo.search_memories_hybrid(
+                            session,
+                            subject_id,
+                            query,
+                            query_embedding,
+                            tenant_id=tenant_id,
+                            kind=kind,
+                            limit=pool,
+                            entity_weight=entity_weight,
+                            use_entity_boost=entity_weight > 0.0,
+                            entity_max_distance=entity_max_distance,
+                        )
+                        rows = [row for row, _score, _bd in hybrid_results]
+                        if rerank and len(rows) > limit:
+                            from server.services.reranker import rerank_memories
+
+                            rows = await rerank_memories(query, rows, limit)
+                        else:
+                            rows = rows[:limit]
+                        return SearchMemoriesResponse(
+                            memories=[_to_response(row) for row in rows]
+                        )
                     results = await repo.search_memories_by_embedding(
                         session,
                         subject_id,

--- a/server/api/subjects.py
+++ b/server/api/subjects.py
@@ -48,6 +48,13 @@ async def delete_subject(
     # if the subject id is later reused.
     await repo.delete_resolutions_by_subject(session, subject_id, tenant_id=tenant_id)
     await repo.delete_health_cache_by_subject(session, subject_id, tenant_id=tenant_id)
+    # Phase 2: subject_entities is OUT-OF-BAND from memories (no FK
+    # since N entities can point at M memories, neither owns the other),
+    # so the cascade has to be explicit here too. Without this, a
+    # re-ingested subject would inherit stale entity rows pointing at
+    # memory_ids that no longer exist — Phase 3 retrieval would surface
+    # boost from ghost memories.
+    await repo.delete_entities_by_subject(session, subject_id, tenant_id=tenant_id)
     await session.commit()
     await webhooks.fire(
         "subject.deleted",

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -81,11 +81,31 @@ class Settings(BaseSettings):
     # model identifier.
     litellm_api_key: str | None = None
     litellm_model: str = "gpt-4o-mini"  # any LiteLLM model identifier
+    # Dedicated EXTRACTION/compile-pipeline model. Empty = fall back to
+    # `litellm_model`. This is the one knob that controls memory quality: bench
+    # shows extraction-model strength is the dominant lever (gpt-4o-mini 0.792 ->
+    # gpt-4o 0.820 -> gpt-4.1 ~0.90 LoCoMo, reaching top-tier hosted parity). Set
+    # it (STATEWAVE_LITELLM_COMPILE_MODEL) to a stronger model for best-in-class
+    # memory without forcing every other LLM role onto the pricier model. Used by
+    # the compiler + the compile-time entity/reconcile/rerank passes, which all
+    # already resolve `litellm_compile_model or litellm_model`.
+    litellm_compile_model: str = ""
     litellm_embedding_model: str = "text-embedding-3-small"
     litellm_api_base: str | None = None
+    # Dedicated embedding endpoint base_url — overrides ``litellm_api_base`` for
+    # the embedder ONLY, so a custom embedding server (e.g. a local Qwen TEI) can
+    # back retrieval while chat/extraction stays on the default provider. Empty
+    # falls back to ``litellm_api_base``.
+    litellm_embedding_api_base: str | None = None
     litellm_timeout_seconds: float = 60.0
     litellm_max_retries: int = 2
     litellm_temperature: float = 0.1
+    # reasoning_effort for gpt-5 / o-series reasoning models (e.g. "minimal",
+    # "low", "medium", "high"). Empty = provider default. "minimal" keeps the
+    # response budget from being consumed by reasoning tokens (which starves the
+    # content → empty JSON on complex compile/reconcile prompts) and is much
+    # faster + cheaper. Ignored for non-reasoning models.
+    litellm_reasoning_effort: str = ""
     # Output-token ceiling for the LLM compiler. This is a CAP, not a target
     # (only generated tokens are billed), so it is generous by default: reasoning
     # models (o-series, gpt-5.x, ...) spend part of the budget on hidden reasoning
@@ -127,6 +147,125 @@ class Settings(BaseSettings):
     # against a runaway compiler that fails to advance `last_compiled_at`).
     compile_batch_size: int = 500
     compile_max_iterations: int = 2000
+
+    # ── Context-aware compile reconcile (Phase 4 + 5b) ──
+    # After the compiler extracts candidate facts from an episode batch, run a
+    # single LLM "memory-update" call that decides, per candidate, whether it is
+    # new (ADD), already stored (DUPLICATE → dropped), a newer value of an
+    # existing memory (UPDATE → supersede the old one), or a contradiction
+    # (DELETE → supersede the old one). This is the core fix for additive-only
+    # drift (stale values staying retrievable). Fail-open:
+    # any error falls back to the prior additive behaviour. Toggle for ablation
+    # / bench via STATEWAVE_RECONCILE_COMPILE_ENABLED.
+    reconcile_compile_enabled: bool = True
+    # Cumulative/latest-value merge on UPDATE (opt-in, ships dark). When an UPDATE
+    # is two readings of the SAME running quantity (page 200 -> 220; "worn 5
+    # times" -> "worn 6 times"), carry the CURRENT absolute value forward into the
+    # surviving memory instead of leaving both readings as peers. Count-neutral
+    # (overwrites the survivor, no new rows -> no retrieval dilution). Moves the
+    # knowledge-update arithmetic to compile-time so the fixed answer model just
+    # reads off the current value. Diagnosed on LongMemEval: fixes the
+    # latest-value/cumulative-counter failure class (the answer model can't track
+    # supersession across a 200-memory haystack). See reconcile.py.
+    reconcile_cumulative_merge: bool = False
+    # Candidates are reconciled in chronological CHUNKS of this size — each chunk
+    # is one LLM call, judged against existing memory + candidates accepted by
+    # earlier chunks. Bounds prompt size while still covering an arbitrarily
+    # large batch (full-conversation compiles produce hundreds of candidates).
+    reconcile_chunk_size: int = 40
+    # Absolute safety ceiling: skip reconcile only for a pathologically huge
+    # batch (the conflict resolver + next drain still apply).
+    reconcile_max_candidates: int = 4000
+    # Cap on EXISTING memories carried as reconcile context. Committed existing
+    # memories are always included (up to this cap); the remainder of the budget
+    # is filled with the most-recent candidates accepted earlier in this batch.
+    reconcile_max_existing: int = 60
+    # Per-candidate top-k used when narrowing a large committed-existing set.
+    reconcile_top_k_per_candidate: int = 5
+
+    # ── Compile-time near-duplicate dedup ───────────────────────────────
+    # Full-conversation windowing extracts the whole haystack but produces
+    # 450-700 memories/conversation (window-overlap re-extraction + facts
+    # restated across sessions). That dilutes retrieval (precise answers rank
+    # below top_k) and slows compile. Dedup collapses near-duplicate candidates
+    # BEFORE the LLM reconcile: an exact normalized-text pass (always on,
+    # stub-safe) plus a semantic pass that merges two candidates ONLY when all
+    # three gates pass — identical number/date set, identical significant-content
+    # words (a differing name/place/noun/verb blocks the merge), and high cosine
+    # (final meaning check). Knowledge-update pairs (same words, different value)
+    # are never merged — that stays reconcile's job. Merge is non-destructive
+    # (provenance unioned). Fail-open. See server/services/dedup.py.
+    dedup_compile_enabled: bool = True
+    # Semantic pass needs a real embedding provider; the exact pass runs even
+    # without it. Disable to ablate to exact-only dedup.
+    dedup_semantic_enabled: bool = True
+    dedup_sim_threshold: float = 0.95        # cosine floor for a semantic merge
+    dedup_max_candidates: int = 4000         # skip dedup above this (pathological)
+
+    # ── LLM reranker (retrieval) ────────────────────────────────────────
+    # Optional reranking on /v1/memories/search?rerank=true: retrieve a generous
+    # candidate pool by hybrid similarity, then an LLM scores each candidate's
+    # relevance to the question and keeps the best `limit`. Fixes single-fact
+    # precision (the answer memory ranking mid-pack among distractors) that
+    # entity-boost + top_k tuning don't. GPT-only (compile model). Fail-open to
+    # the hybrid order. Off by default; opt in per request.
+    rerank_max_pool: int = 100               # hard cap on candidates sent to the reranker
+    # Model for the LLM reranker. Reranking is a relevance-JUDGMENT task (not
+    # extraction), where a stronger model helps and the cost is one call/query.
+    # Empty = use the compile model. Set to gpt-4o for best ranking quality.
+    rerank_model: str = ""
+
+    # ── Full-conversation compile (windowing) ───────────────────────────
+    # The compiler used to truncate every episode to 4000 chars before
+    # extraction — catastrophic for long-context benchmarks (BEAM/LongMemEval
+    # episodes are 100K-460K chars per session), where ~97% of the haystack was
+    # discarded and most facts were never extracted. Strong long-context memory
+    # compiles the FULL conversation. We now split each episode's text into
+    # overlapping windows and compile every window, up to a per-episode ceiling
+    # (cost bound). Raise the ceiling for maximum recall; lower it to cap compile
+    # spend.
+    compile_max_episode_chars: int = 60000
+    compile_window_chars: int = 6000
+    compile_window_overlap: int = 200
+    # Parallel LLM extraction calls per compile batch. Full-conversation
+    # windowing produces many windows; the old hardcoded 4 made large compiles
+    # slow enough to hit client timeouts. Raise for throughput (bounded by
+    # provider rate limits + the adapter's retry budget).
+    compile_max_concurrency: int = 4
+    # Message-level extraction (opt-in): extract atomic facts from small coherent
+    # message groups instead of fixed char-windows. Char-windows split
+    # mid-utterance and, when large, let the model abstract specifics away
+    # ("pink sky sunset" -> "a landscape"); extracting from small message
+    # units with the same model keeps the specifics. See compilers/llm.py
+    # `_message_chunks`. Falls back to char-windowing for non-chat payloads.
+    compile_message_level: bool = False
+    compile_messages_per_chunk: int = 6
+    compile_message_overlap: int = 1
+    # Recall sweep (opt-in): after the first extraction pass, run a SECOND pass
+    # over the same window that is shown the already-extracted facts and asked to
+    # catch specific details the first pass dropped — named objects/titles,
+    # dates, places, counts, quotes — emitting each as a COMPLETE atomic memory
+    # (not a fragment, so it avoids the message-level fragmentation failure).
+    # Diagnosis: ~54% of the LoCoMo gap to the leading hosted system is
+    # first-pass extraction MISS (the fact is simply never compiled). Doubles
+    # compile LLM calls; gate on for high-recall workloads. See compilers/llm.py
+    # `_RECALL_SWEEP_PROMPT`.
+    compile_recall_sweep: bool = False
+    # Compose-unit extraction (opt-in): change the extraction UNIT from "one
+    # atomic fact" to "one self-contained, interaction-complete statement" while
+    # holding memory COUNT flat. Diagnosis: vs the leading hosted system,
+    # Statewave memories are ~50% terser (80-89 vs 120-135 chars) and fragment
+    # events across rows so the answering memory ranks low; composing them into
+    # fuller statements raises per-memory completeness (the one axis the leading
+    # system differs on at equal count) WITHOUT adding rows (so it cannot dilute
+    # retrieval like the recall sweep).
+    # See compilers/llm.py `_SYSTEM_PROMPT_COMPOSE`.
+    compile_compose_unit: bool = False
+    # Compile-time entity-store population (Phase 2, powers entity-boost
+    # retrieval). One LLM call per new memory — set False to skip it when
+    # entity-boost retrieval is not in use (e.g. semantic-only bench runs),
+    # which materially speeds up large compiles.
+    entity_population_enabled: bool = True
 
     # ── Memory TTL / expiry policies ────────────────────────────────
     # Per-kind expiry windows. Keys are MemoryKind values

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -22,6 +22,7 @@ from server.db.tables import (
     QueryEmbeddingCacheRow,
     ReceiptRow,
     ResolutionRow,
+    SubjectEntityRow,
     SubjectHealthCacheRow,
     TenantConfigRow,
 )
@@ -415,6 +416,335 @@ async def search_memories_by_embedding(
     stmt = stmt.order_by(distance_expr).limit(limit)
     result = await session.execute(stmt)
     return [(row, float(distance)) for row, distance in result.all()]
+
+
+async def search_memories_hybrid(
+    session: AsyncSession,
+    subject_id: str,
+    query_text: str,
+    query_embedding: list[float],
+    *,
+    tenant_id: str | None = None,
+    kind: str | None = None,
+    limit: int = 20,
+    semantic_weight: float = 1.0,
+    bm25_weight: float = 1.0,
+    entity_weight: float = 1.0,
+    use_entity_boost: bool = True,
+    candidate_multiplier: int = 4,
+    entity_max_distance: float = 0.5,
+) -> list[tuple[MemoryRow, float, dict[str, float]]]:
+    """Hybrid retrieval: semantic cosine + Postgres BM25 ts_rank_cd +
+    cross-session entity boost, blended additively after sigmoid-style
+    normalization of each signal. Returns (row, final_score,
+    score_breakdown) tuples, ordered by final_score descending.
+
+    Why this exists: blending THREE retrieval signals — semantic
+    similarity, BM25 keyword rank, and an entity boost — recalls more
+    of the right memories than any single signal alone. Pure-pgvector
+    retrieval — what `search_memories_by_embedding` does — under-finds
+    memories whose surface form matches the question verbatim AND
+    memories that share an entity with the question but weren't picked
+    up by either semantic or BM25. The entity-boost lane is what
+    bridges across sessions: an entity ("Caroline", "the navy blazer")
+    is the natural join key when a question references something
+    mentioned in a memory the embedding cosine missed.
+
+    Scoring:
+      semantic_sim   = 1 - cosine_distance / 2     # [0, 1], 1 = identical
+      bm25_norm      = ts_rank / (1 + ts_rank)     # [0, 1), sigmoid-ish
+      entity_norm    = max boost from any matched entity              # [0, 1]
+                       (boost per entity = 1 - cosine_distance, capped)
+      final_score    = (semantic_weight * semantic_sim +
+                        bm25_weight    * bm25_norm    +
+                        (entity_weight * entity_norm if use_entity_boost else 0)) /
+                       (sum of active weights)
+
+    The defaults give equal weighting to semantic, BM25, and entity.
+    Operators can shift the blend via the weight kwargs — useful for
+    ablations + bench sweeps. Setting `use_entity_boost=False` reverts
+    to pure Phase-1 (semantic + BM25) behavior, which is what the
+    fallback path uses when the entity store is empty for the subject.
+
+    Entity boost mechanics (Phase 3):
+      1. Look up entities for the subject whose embedding cosine is
+         within `entity_max_distance` of the query embedding.
+      2. For each matched entity, collect its `linked_memory_ids`.
+      3. For each memory in the candidate set, the entity score is the
+         MAX boost across all matched entities pointing at it (so an
+         entity that's an exact query match boosts more than one that's
+         a paraphrase). Capped at 1.0.
+      4. Memories pointed at by a matched entity that AREN'T in the
+         semantic+BM25 candidate set get pulled in too (this is the
+         cross-session connective tissue that lifts multi-session recall).
+
+    `candidate_multiplier` controls how many candidates we draw from
+    each lane before re-blending (default 4× the final `limit`).
+    """
+    candidate_limit = max(limit * candidate_multiplier, limit)
+
+    # ── Semantic candidates ─────────────────────────────────────────────
+    distance_expr = MemoryRow.embedding.cosine_distance(query_embedding)
+    sem_stmt = (
+        select(MemoryRow, distance_expr.label("distance"))
+        .where(MemoryRow.subject_id == subject_id)
+        .where(MemoryRow.status == "active")
+        .where(MemoryRow.embedding.isnot(None))
+    )
+    sem_stmt = _unexpired(sem_stmt)
+    sem_stmt = _tenant_filter(sem_stmt, MemoryRow.tenant_id, tenant_id)
+    if kind:
+        sem_stmt = sem_stmt.where(MemoryRow.kind == kind)
+    sem_stmt = sem_stmt.order_by(distance_expr).limit(candidate_limit)
+    sem_rows = (await session.execute(sem_stmt)).all()
+
+    # ── BM25 candidates ─────────────────────────────────────────────────
+    # ts_rank_cd over the generated content_tsvector column (migration 0027).
+    # `plainto_tsquery` is the safe-for-untrusted-input variant — it
+    # treats the query as a phrase, no operator injection.
+    bm25_rank_expr = func.ts_rank_cd(
+        text("memories.content_tsvector"),
+        func.plainto_tsquery("english", query_text),
+    ).label("bm25_rank")
+    bm25_filter = text("memories.content_tsvector @@ plainto_tsquery('english', :q)")
+    bm25_stmt = (
+        select(MemoryRow, bm25_rank_expr)
+        .where(MemoryRow.subject_id == subject_id)
+        .where(MemoryRow.status == "active")
+        .where(bm25_filter)
+    )
+    bm25_stmt = _unexpired(bm25_stmt)
+    bm25_stmt = _tenant_filter(bm25_stmt, MemoryRow.tenant_id, tenant_id)
+    if kind:
+        bm25_stmt = bm25_stmt.where(MemoryRow.kind == kind)
+    bm25_stmt = bm25_stmt.order_by(bm25_rank_expr.desc()).limit(candidate_limit)
+    bm25_rows = (await session.execute(bm25_stmt, {"q": query_text})).all()
+
+    # ── Entity boost lane (Phase 3) ─────────────────────────────────────
+    # Look up subject entities matching the query embedding; for each,
+    # collect the memories they point at. A memory's entity boost is the
+    # max (1 - distance) across all matched entities pointing at it.
+    entity_boost_by_memory_id: dict[uuid.UUID, float] = {}
+    pulled_in_by_entity: dict[uuid.UUID, MemoryRow] = {}
+    if use_entity_boost:
+        entity_matches = await search_entities_by_embedding(
+            session,
+            subject_id,
+            query_embedding,
+            tenant_id=tenant_id,
+            limit=candidate_limit,
+            max_distance=entity_max_distance,
+        )
+        if entity_matches:
+            # Per-entity boost (higher when query is closer to the entity).
+            for entity_row, distance in entity_matches:
+                per_entity_boost = max(0.0, 1.0 - float(distance))
+                for mem_id in entity_row.linked_memory_ids:
+                    prior = entity_boost_by_memory_id.get(mem_id, 0.0)
+                    if per_entity_boost > prior:
+                        entity_boost_by_memory_id[mem_id] = per_entity_boost
+            # Pull in entity-only memories not already in semantic / BM25
+            # candidate sets. (One DB roundtrip for all of them.)
+            sem_ids = {row.id for row, _d in sem_rows}
+            bm25_ids = {row.id for row, _r in bm25_rows}
+            missing_ids = [
+                mid
+                for mid in entity_boost_by_memory_id
+                if mid not in sem_ids and mid not in bm25_ids
+            ]
+            if missing_ids:
+                pull_stmt = (
+                    select(MemoryRow)
+                    .where(MemoryRow.id.in_(missing_ids))
+                    .where(MemoryRow.subject_id == subject_id)
+                    .where(MemoryRow.status == "active")
+                )
+                pull_stmt = _unexpired(pull_stmt)
+                pull_stmt = _tenant_filter(pull_stmt, MemoryRow.tenant_id, tenant_id)
+                if kind:
+                    pull_stmt = pull_stmt.where(MemoryRow.kind == kind)
+                pull_stmt = pull_stmt.limit(candidate_limit)
+                for row in (await session.execute(pull_stmt)).scalars().all():
+                    pulled_in_by_entity[row.id] = row
+
+    # ── Build the merged candidate set ──────────────────────────────────
+    # Map id → (row, semantic_sim, bm25_norm, entity_norm). Each lane
+    # contributes independently; missing-signal scores stay 0.
+    by_id: dict[uuid.UUID, dict] = {}
+    for row, distance in sem_rows:
+        sim = max(0.0, 1.0 - float(distance) / 2.0)
+        by_id[row.id] = {"row": row, "semantic": sim, "bm25": 0.0, "entity": 0.0}
+    for row, raw_rank in bm25_rows:
+        norm = float(raw_rank) / (1.0 + float(raw_rank))
+        if row.id in by_id:
+            by_id[row.id]["bm25"] = norm
+        else:
+            by_id[row.id] = {"row": row, "semantic": 0.0, "bm25": norm, "entity": 0.0}
+    for mem_id, row in pulled_in_by_entity.items():
+        if mem_id not in by_id:
+            by_id[mem_id] = {"row": row, "semantic": 0.0, "bm25": 0.0, "entity": 0.0}
+    for mem_id, boost in entity_boost_by_memory_id.items():
+        if mem_id in by_id:
+            by_id[mem_id]["entity"] = boost
+
+    # ── Blend + rank ────────────────────────────────────────────────────
+    active_entity_w = entity_weight if use_entity_boost else 0.0
+    weight_sum = max(semantic_weight + bm25_weight + active_entity_w, 1e-9)
+    scored: list[tuple[MemoryRow, float, dict[str, float]]] = []
+    for entry in by_id.values():
+        final = (
+            semantic_weight * entry["semantic"]
+            + bm25_weight * entry["bm25"]
+            + active_entity_w * entry["entity"]
+        ) / weight_sum
+        scored.append(
+            (
+                entry["row"],
+                final,
+                {
+                    "semantic": entry["semantic"],
+                    "bm25": entry["bm25"],
+                    "entity": entry["entity"],
+                    "combined": final,
+                },
+            )
+        )
+    scored.sort(key=lambda t: t[1], reverse=True)
+    return scored[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Subject entities (Phase 2 — cross-session entity-boost retrieval)
+# ---------------------------------------------------------------------------
+
+
+async def upsert_entity_with_link(
+    session: AsyncSession,
+    *,
+    subject_id: str,
+    tenant_id: str | None,
+    entity_text: str,
+    entity_normalized: str,
+    entity_kind: str | None,
+    embedding: list[float] | None,
+    memory_id: uuid.UUID,
+    dedup_cosine_threshold: float = 0.95,
+) -> SubjectEntityRow:
+    """Insert or merge an entity row for (subject_id, normalized text /
+    cosine-similar embedding), appending memory_id to linked_memory_ids.
+
+    Dedup order:
+      1. Exact match on (subject_id, entity_normalized) — cheapest.
+         If found, append memory_id and return.
+      2. If miss AND embedding provided, cosine-distance probe against
+         all entities for the same subject; merge if any row is within
+         `dedup_cosine_threshold` (default 0.95).
+      3. Otherwise insert a new row with [memory_id] as the initial
+         linkage.
+
+    The cosine probe uses pgvector's `<=>` operator and reads the HNSW
+    index from migration 0028 — sub-millisecond at our scales. The
+    same-normalization fast path skips the probe entirely for the
+    ~80% of duplicates that are trivial casing/whitespace variants.
+
+    Idempotent on repeated memory_id linkage: if memory_id is already
+    in linked_memory_ids, the append is a no-op (Postgres array
+    `array_append` would duplicate; we guard with `NOT (memory_id =
+    ANY(linked_memory_ids))`).
+    """
+    # Step 1: exact-match dedup
+    exact_stmt = select(SubjectEntityRow).where(
+        SubjectEntityRow.subject_id == subject_id,
+        SubjectEntityRow.entity_normalized == entity_normalized,
+    )
+    if tenant_id is not None:
+        exact_stmt = exact_stmt.where(SubjectEntityRow.tenant_id == tenant_id)
+    exact = (await session.execute(exact_stmt)).scalar_one_or_none()
+    if exact is not None:
+        if memory_id not in exact.linked_memory_ids:
+            # SQLAlchemy doesn't detect mutations to ARRAY columns
+            # in-place; rebuild + reassign so the update flushes.
+            exact.linked_memory_ids = [*exact.linked_memory_ids, memory_id]
+        return exact
+
+    # Step 2: semantic dedup (only if we have an embedding to compare with)
+    if embedding is not None:
+        distance_expr = SubjectEntityRow.embedding.cosine_distance(embedding)
+        near_stmt = (
+            select(SubjectEntityRow, distance_expr.label("distance"))
+            .where(SubjectEntityRow.subject_id == subject_id)
+            .where(SubjectEntityRow.embedding.isnot(None))
+        )
+        if tenant_id is not None:
+            near_stmt = near_stmt.where(SubjectEntityRow.tenant_id == tenant_id)
+        near_stmt = near_stmt.order_by(distance_expr).limit(1)
+        near_row = (await session.execute(near_stmt)).first()
+        if near_row is not None:
+            existing_row, distance = near_row
+            # Cosine distance ≤ (1 - threshold) ⇒ similarity ≥ threshold.
+            if float(distance) <= (1.0 - dedup_cosine_threshold):
+                if memory_id not in existing_row.linked_memory_ids:
+                    existing_row.linked_memory_ids = [
+                        *existing_row.linked_memory_ids,
+                        memory_id,
+                    ]
+                return existing_row
+
+    # Step 3: insert fresh
+    fresh = SubjectEntityRow(
+        subject_id=subject_id,
+        tenant_id=tenant_id,
+        entity_text=entity_text,
+        entity_normalized=entity_normalized,
+        entity_kind=entity_kind,
+        embedding=embedding,
+        linked_memory_ids=[memory_id],
+    )
+    session.add(fresh)
+    return fresh
+
+
+async def search_entities_by_embedding(
+    session: AsyncSession,
+    subject_id: str,
+    query_embedding: list[float],
+    *,
+    tenant_id: str | None = None,
+    limit: int = 20,
+    max_distance: float = 0.5,
+) -> list[tuple[SubjectEntityRow, float]]:
+    """Find entities for a subject whose embedding is close to the query.
+    Returns (entity_row, cosine_distance) tuples ordered by distance asc.
+
+    `max_distance` is the cosine-distance cutoff (default 0.5 → cosine
+    similarity ≥ 0.5). Tighter than 0.5 misses paraphrased entities;
+    looser pollutes the boost lane with weak matches. Phase 3 retrieval
+    callers can tune this per-bench.
+    """
+    distance_expr = SubjectEntityRow.embedding.cosine_distance(query_embedding)
+    stmt = (
+        select(SubjectEntityRow, distance_expr.label("distance"))
+        .where(SubjectEntityRow.subject_id == subject_id)
+        .where(SubjectEntityRow.embedding.isnot(None))
+        .where(distance_expr <= max_distance)
+    )
+    if tenant_id is not None:
+        stmt = stmt.where(SubjectEntityRow.tenant_id == tenant_id)
+    stmt = stmt.order_by(distance_expr).limit(limit)
+    rows = (await session.execute(stmt)).all()
+    return [(row, float(dist)) for row, dist in rows]
+
+
+async def delete_entities_by_subject(
+    session: AsyncSession, subject_id: str, *, tenant_id: str | None = None
+) -> int:
+    """Wipe every entity row for a subject. Mirrors
+    `delete_memories_by_subject` — used by the same cleanup path so
+    delete_subject(subject_id) removes both memories AND entities."""
+    stmt = delete(SubjectEntityRow).where(SubjectEntityRow.subject_id == subject_id)
+    stmt = _tenant_filter(stmt, SubjectEntityRow.tenant_id, tenant_id)
+    result = await session.execute(stmt)
+    return result.rowcount  # type: ignore[return-value]
 
 
 # ---------------------------------------------------------------------------

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -6,14 +6,13 @@ import uuid
 from datetime import datetime
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import Boolean, DateTime, Float, Index, Integer, String, Text, func, text
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy import Boolean, Computed, DateTime, Float, Index, Integer, String, Text, func, text
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, TSVECTOR, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, validates
 
-# Embedding dimensionality must match `LiteLLMEmbeddingProvider.dimensions`
-# and the `vector(N)` type in the schema. text-embedding-3-small at 1536
-# dims is the project default; bumping requires a migration that ALTERs
-# the column TYPE and rebuilds the HNSW index.
+# Embedding dimensionality must match the embedder output and the `vector(N)`
+# type in the schema. Fixed at 1536 (text-embedding-3-small), matching the
+# `vector(1536)` columns created in migration 0013.
 EMBEDDING_DIMENSIONS = 1536
 
 
@@ -128,6 +127,14 @@ class MemoryRow(Base):
     embedding: Mapped[list[float] | None] = mapped_column(
         Vector(EMBEDDING_DIMENSIONS), nullable=True
     )
+    # Postgres-generated tsvector for the BM25 lane of hybrid retrieval.
+    # Mirrors migration 0027 (GENERATED ALWAYS ... STORED) so a `create_all`
+    # schema (tests) matches the migrated production schema.
+    content_tsvector: Mapped[str | None] = mapped_column(
+        TSVECTOR,
+        Computed("to_tsvector('english', content)", persisted=True),
+        nullable=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
@@ -135,7 +142,65 @@ class MemoryRow(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )
 
-    __table_args__ = (Index("ix_memories_subject_kind", "subject_id", "kind"),)
+    __table_args__ = (
+        Index("ix_memories_subject_kind", "subject_id", "kind"),
+        Index("ix_memories_content_tsvector", "content_tsvector", postgresql_using="gin"),
+    )
+
+
+class SubjectEntityRow(Base):
+    """Per-subject entity store powering cross-session entity-boost retrieval.
+
+    Phase 2 of the cross-session retrieval improvements. Each row represents a distinct
+    entity (proper noun / compound noun phrase) extracted from any
+    compiled memory for the subject. `linked_memory_ids` is the N-to-M
+    edge to the memories the entity appears in — the retrieval lane
+    looks up entities matching the question, then boosts every memory in
+    any matched entity's `linked_memory_ids`. This is the mechanism that
+    lets retrieval bridge sessions when the same entity is mentioned in
+    multiple compiled memories without semantic similarity having to
+    catch every variation.
+
+    Populated at compile time (post-memory-insert hook) and at one-off
+    backfill for memories that pre-date this column. Schema mirrors
+    migration 0028 — see the migration docstring for index choices and
+    dedup behavior.
+    """
+
+    __tablename__ = "subject_entities"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    subject_id: Mapped[str] = mapped_column(String(256), nullable=False)
+    tenant_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    entity_text: Mapped[str] = mapped_column(Text, nullable=False)
+    entity_normalized: Mapped[str] = mapped_column(Text, nullable=False)
+    entity_kind: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(EMBEDDING_DIMENSIONS), nullable=True
+    )
+    linked_memory_ids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)), nullable=False, default=list
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_subject_entities_subject_id", "subject_id"),
+        Index(
+            "ix_subject_entities_subject_normalized",
+            "subject_id",
+            "entity_normalized",
+        ),
+    )
 
 
 class WebhookEventRow(Base):

--- a/server/services/compilers/__init__.py
+++ b/server/services/compilers/__init__.py
@@ -46,6 +46,12 @@ def get_compiler() -> BaseCompiler:
     elif settings.compiler_type == "llm":
         from server.services.compilers.llm import LLMCompiler
 
-        return LLMCompiler(model=settings.litellm_model)
+        # Extraction model = the dedicated compile override when set, else the
+        # general model. Extraction-model strength is the dominant memory-quality
+        # lever (see config.litellm_compile_model), so this is the one knob to
+        # raise for cloud-parity memory.
+        return LLMCompiler(
+            model=settings.litellm_compile_model or settings.litellm_model
+        )
     else:
         raise ValueError(f"Unknown compiler type: {settings.compiler_type}")

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -86,6 +86,7 @@ Return a JSON array of memory objects. Each object must have:
 Rules:
 - Extract ALL distinct facts; do not merge unrelated facts into one memory.
 - Be precise and factual — never invent information not in the episode.
+- PRESERVE SPECIFIC DETAILS VERBATIM. This is the most important rule. Keep the exact concrete details the source states — colors, proper names, titles, places, exact phrases, sentiment/emotion words, quantities, dates — in the memory `content`. NEVER generalize a specific into a vague theme: "painted a sunset with a pink sky and purple autumn tones" must NOT become "painted a landscape"; "savor all the good vibes at the grand opening" must NOT become "is excited about the opening"; "read 'Charlotte's Web'" must NOT become "enjoys reading"; "drives a Prius" must NOT become "has a car". If the source says it specifically, store it specifically — the specific wording is exactly what later questions ask for. When in doubt, keep MORE of the original detail, not less.
 - DO NOT extract values from inside code blocks, JSON examples, sample API responses, or curl/bash command examples as profile_facts. Those are illustrations of *shape*, not facts about the subject. For example, in `{"subject_id": "user-42", "memories_created": 5}`, "subject_id user-42" is a placeholder — it is NOT a profile fact about anyone. Skip example identifiers, sample values, placeholder names, and inline literals from documentation snippets.
 - DO extract the surrounding *prose* explanation (e.g. "POST /v1/memories/compile returns memories_created and a memories array"). That is a generalizable fact.
 - If an episode is mostly code or example data with no generalizable claims, return episode_summary describing what the section is about, not profile_facts cataloguing the example values.
@@ -112,7 +113,103 @@ Granularity — extract DETAILS, not just headlines:
     * Relationships between people / things (who-mentors-whom, who-bought-what-for-whom)
 - A profile_fact about a person can be ONE specific item — don't wait to find "enough" to summarize.
 - Better to emit 30 concrete granular memories than 5 vague ones. The retrieval layer ranks them; the compiler's job is recall.
+
+Capture BOTH speakers — including what the ASSISTANT said:
+THIS IS A COMMONLY MISSED CATEGORY. Episodes are usually a dialogue between a user and an assistant. Extract facts conveyed by EITHER speaker, not just the user.
+- When the ASSISTANT provides information, a recommendation, an answer, instructions, a diagnosis, or a resource, extract it as a memory that records WHAT the assistant said. These are frequently the exact answer to a later "what did you recommend / suggest / say about X / which … did you give me" question, and the model routinely drops them because they aren't facts "about the subject".
+- Preserve the specifics of the assistant's contribution EXACTLY as given: named tools, product names, links/URLs, step lists, titles, quantities, dosages, settings.
+- Attribute the speaker explicitly in the memory content so retrieval can distinguish them:
+    * A fact the USER asserts about themselves → profile_fact about the user ("The user's daughter is named Mia.").
+    * A recommendation / answer / instruction the ASSISTANT gives → record it as the assistant's contribution ("The assistant recommended trying yoga and a standing desk for the user's lower back pain on <date>." / "The assistant suggested the book 'Atomic Habits' by James Clear.").
+- Use kind=procedure when the assistant gave a step-by-step process; otherwise episode_summary (or profile_fact when the assistant stated a durable fact the user will refer back to).
+- Each memory is ONE atomic fact or ONE coherent recommendation — do not bundle several distinct assistant suggestions into a single memory; emit one per suggestion.
+
+CRITICAL — Numerical specifications, metrics, and configuration values:
+THIS IS THE MOST COMMONLY MISSED CATEGORY. The model treats numbers as transient context and fails to extract them. They are NOT transient — they are first-class facts about the subject's systems / projects / tools / workflows AND are commonly the answer to "what is X" / "how many Y" / "what's the current Z" questions. They are also frequently updated, so missing them silently breaks knowledge-update retrieval downstream.
+
+ALWAYS extract as profile_fact with the EXACT value and the resolved date:
+  * Response times, latencies, durations of system operations
+  * Counts (commits, issues, items, deployments, users, requests)
+  * Percentages, coverage, rates, conversions, success/failure rates
+  * Deadlines, target dates, sprint boundaries, release windows
+  * Versions (language, library, OS, schema)
+  * IDs, keys (truncated for sensitive ones), model names, identifiers
+  * Status / state values (deployed, blocked, in-review, enabled, disabled)
+  * Thresholds, limits, quotas (rate limits, daily caps, budget ceilings)
+  * Pricing, costs, financial figures
+  * Performance / capacity numbers (memory, cpu, throughput)
+
+Few-shot examples for technical-spec extraction:
+
+Source text: "The dashboard API now averages 250ms response time due to the new caching layer."
+Extract: {"kind":"profile_fact","content":"Dashboard API has an average response time of 250ms as of <date>, driven by the new caching layer."}
+
+Source text: "We just merged commit 165 into main this morning."
+Extract: {"kind":"profile_fact","content":"Project repository has 165 commits merged into the main branch as of <date>."}
+
+Source text: "The production API key has a 1,200 daily call quota."
+Extract: {"kind":"profile_fact","content":"Production API key daily call quota is 1,200 calls/day as of <date>."}
+
+Source text: "Test coverage just hit 78%."
+Extract: {"kind":"profile_fact","content":"API integration module test coverage is 78% as of <date>."}
+
+Source text: "Sprint 1 deadline is April 5, 2024 — basic layout and navigation."
+Extract: {"kind":"profile_fact","content":"Sprint 1 deadline is April 5, 2024, focused on basic layout and navigation."}
+
+Source text: "We're running Python 3.12 and Postgres 16 in production."
+Extract two profile_facts:
+  {"kind":"profile_fact","content":"Production runs Python 3.12 as of <date>."}
+  {"kind":"profile_fact","content":"Production runs Postgres 16 as of <date>."}
+
+When a CHANGE is described ("we bumped it from X to Y", "switched from A to B", "increased to N"), extract the NEW value as the profile_fact (the latest state is the answer). If the prior value matters as a comparison reference, also extract it as a separate profile_fact noting it was the prior value.
 """
+
+# Second-pass recall sweep. Diagnosis of the LoCoMo recall gap found
+# ~54% of losses are first-pass extraction MISSES — a specific named object,
+# title, date, place, count, or quote that was simply never compiled (the topic
+# is captured, the identifying detail is dropped). This pass re-reads the same
+# window, is shown what the first pass already captured, and emits COMPLETE
+# atomic memories only for the missed specifics. Emitting whole standalone facts
+# (not fragments) is the key guard against the message-level fragmentation that
+# regressed earlier (-3.6).
+_RECALL_SWEEP_PROMPT = """\
+You are a RECALL AUDITOR for a memory extraction system. A first pass already \
+extracted memories from a conversation, but it systematically DROPS specific \
+identifying details while keeping the general topic. Your job is to catch exactly \
+those misses.
+
+You are given (1) the raw episode(s) with their recorded dates and (2) \
+ALREADY_EXTRACTED — the facts the first pass captured. Re-read the source and \
+find every specific detail that is NOT already fully captured, focusing on these \
+high-value, commonly-dropped types:
+- Named objects / titles / brands / proper nouns: book & movie & song titles, \
+game names, product/brand names, distinctive physical objects WITH their \
+attributes (color, material).
+- Dates and times of events: resolve relative phrases ("last weekend", "two \
+years ago", "the Friday before") against the episode's recorded date to an \
+ABSOLUTE date.
+- Place names: cities, states, countries, venues, specific locations.
+- Counts, quantities, durations, ages, prices.
+- The exact thing a person said / did / offered — including the ASSISTANT's \
+recommendations and answers — and short anecdotes tied to a named person.
+
+For each missed detail, emit ONE memory that states the COMPLETE fact (who + \
+what + when), so it stands alone and directly answers a question. Rules:
+- PRESERVE the specific noun/title/date/quantity VERBATIM — never generalize \
+("read 'Charlotte's Web'", NOT "read a book"; "in Rome in June 2023", NOT \
+"traveled abroad"; "a black and white flower bowl", NOT "pottery").
+- Attribute each fact to the CORRECT person and preserve who-did-what-to-whom \
+direction (a recommendation FROM the assistant TO the user, X bought Y for Z).
+- Do NOT repeat anything already in ALREADY_EXTRACTED, and do NOT emit vague \
+themes or fragments. A memory must be a complete, answerable statement.
+- If a detail is genuinely already captured, skip it. When unsure whether a \
+SPECIFIC was captured, include it — recall is the goal of this pass.
+- Same JSON object format as the first pass for each memory: \
+{"kind","content","summary","confidence","episode_index"}.
+- Return ONLY a JSON object {"memories": [...]}. If nothing was missed, return \
+{"memories": []}.
+"""
+
 
 # The single-valued canonical keys the model may PROPOSE. The registry remains
 # authoritative for canonicalization, scope, and membership — the model never
@@ -135,6 +232,171 @@ _SYSTEM_PROMPT += (
     "- Use ONLY the keys listed; never invent keys, scopes, or cardinality. Claims are optional\n"
     "  annotations — do NOT reduce, merge, or skip the granular memories you would otherwise emit.\n"
 )
+
+
+# ── Compose-unit variant (opt-in via settings.compile_compose_unit) ──────────
+# Same prompt as _SYSTEM_PROMPT, but the extraction UNIT becomes one complete,
+# self-contained statement instead of atomized fragments. Diagnosis: at equal
+# memory COUNT, Statewave memories are ~50% terser and fragment a
+# single event across rows, so the answering memory ranks low and the answer
+# model can't ground on it. Composing raises per-memory completeness — the one
+# axis that differs at equal count — WITHOUT adding rows, so it cannot dilute
+# retrieval the way the recall sweep did. Built by surgically swapping only the
+# atomization directives; verbatim/temporal/numeric/code-block/claim rules are
+# untouched, so the JSON contract and all downstream parsing are identical.
+_COMPOSE_GRANULARITY_RULE = (
+    "- UNIT OF A MEMORY: one COMPLETE statement per distinct event/topic, NOT one per noun. "
+    "Each memory must be a STANDALONE sentence answerable with zero other context. FUSE the "
+    "related parts of a single event into ONE memory: the person(s) involved + what was "
+    "done/said + the object/title/value + the resolved absolute date + (for dialogue) "
+    "who-said-it-to-whom. Do NOT split one event across rows — the degree, the certificate, "
+    'and the date are ONE memory ("John earned a university degree, evidenced by a certificate '
+    'of completion he shared on 2 April 2023"), not three terse rows.\n'
+    "- Emit a SEPARATE memory only for a genuinely DIFFERENT event, attribute, or topic. If two "
+    "parts assert DIFFERENT VALUES of the same attribute (two different dates, 250ms vs 90ms, "
+    "Munich vs Berlin), keep them SEPARATE — never fuse a changed/updated value into its "
+    "predecessor (reconciliation handles supersession downstream).\n"
+    "- Aim for FEWER, RICHER memories — each ~1-2 full sentences carrying EVERY specific it "
+    "covers — over many terse fragments. The same distinct facts, each made self-contained: a "
+    "complete memory both ranks and answers better than a fragment. Composing changes the "
+    "PACKAGING, never drops a detail."
+)
+_COMPOSE_ASSISTANT_RULE = (
+    "- When the assistant gives a recommendation/answer and the user responds in the SAME "
+    'exchange, capture the EXCHANGE in ONE statement preserving direction ("Sam suggested a '
+    'yoga practice to Evan for stress relief, and Evan said he would try it and thanked Sam on '
+    '<date>"), not two fragments that each drop the other side. Still emit separate memories for '
+    "genuinely distinct suggestions."
+)
+_SYSTEM_PROMPT_COMPOSE = (
+    _SYSTEM_PROMPT.replace(
+        "Granularity — extract DETAILS, not just headlines:",
+        "Granularity — COMPLETE statements, not atomized fragments (compose, don't atomize):",
+    )
+    .replace(
+        '- A profile_fact about a person can be ONE specific item — don\'t wait to find "enough" to summarize.\n'
+        "- Better to emit 30 concrete granular memories than 5 vague ones. The retrieval layer ranks them; the compiler's job is recall.",
+        _COMPOSE_GRANULARITY_RULE,
+    )
+    .replace(
+        "- Each memory is ONE atomic fact or ONE coherent recommendation — do not bundle several distinct assistant suggestions into a single memory; emit one per suggestion.",
+        _COMPOSE_ASSISTANT_RULE,
+    )
+)
+# Fail loud if a swap silently no-ops (prompt text drifted) — an inert COMPOSE
+# variant would make the A/B meaningless.
+assert _SYSTEM_PROMPT_COMPOSE != _SYSTEM_PROMPT, "compose-unit prompt swap matched nothing"
+assert "compose, don't atomize" in _SYSTEM_PROMPT_COMPOSE
+
+
+def _system_prompt() -> str:
+    """Active extraction system prompt — the compose-unit variant when enabled."""
+    return _SYSTEM_PROMPT_COMPOSE if settings.compile_compose_unit else _SYSTEM_PROMPT
+
+
+def _window_text(
+    text: str, max_total: int, window: int, overlap: int
+) -> list[str]:
+    """Split episode text into overlapping windows for full-content compile.
+
+    Replaces the old `text[:4000]` truncation. Returns 1+ windows of up to
+    `window` chars each, with `overlap` chars of carry-over so a fact split
+    across a boundary still appears whole in one window. The total text
+    considered is capped at `max_total` (cost bound). Windows prefer to break
+    on a newline near the end so a message isn't sliced mid-sentence.
+    """
+    text = text[:max_total]
+    if len(text) <= window:
+        return [text] if text else []
+    overlap = max(0, min(overlap, window // 2))
+    windows: list[str] = []
+    start = 0
+    n = len(text)
+    while start < n:
+        end = min(start + window, n)
+        # Prefer a newline boundary in the last 20% of the window (but not when
+        # this is the final slice — take it whole).
+        if end < n:
+            nl = text.rfind("\n", start + int(window * 0.8), end)
+            if nl != -1 and nl > start:
+                end = nl
+        chunk = text[start:end].strip()
+        if chunk:
+            windows.append(chunk)
+        if end >= n:
+            break
+        start = max(end - overlap, start + 1)
+    return windows
+
+
+def _message_chunks(
+    payload: dict, per_chunk: int, overlap: int, max_total_chars: int
+) -> list[str] | None:
+    """Split a chat payload into small COHERENT message groups for extraction.
+
+    Returns a list of rendered chunk texts (each = `per_chunk` messages with
+    `overlap` carried from the previous group for context), or None if the
+    payload isn't message-shaped (caller falls back to char-windowing). Renders
+    each message as "role: [timestamp] content" so the extractor keeps speaker +
+    date context. Total content is capped at `max_total_chars` for cost.
+    """
+    messages = payload.get("messages") if isinstance(payload, dict) else None
+    if not isinstance(messages, list) or not messages:
+        return None
+    rendered: list[str] = []
+    used = 0
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role") or m.get("speaker") or ""
+        content = m.get("content") or m.get("text") or ""
+        if not content:
+            continue
+        ts = m.get("timestamp")
+        line = f"{role}: [{ts}] {content}" if ts else f"{role}: {content}"
+        used += len(line)
+        if used > max_total_chars:
+            break
+        rendered.append(line)
+    if not rendered:
+        return None
+    per_chunk = max(1, per_chunk)
+    overlap = max(0, min(overlap, per_chunk - 1))
+    step = max(1, per_chunk - overlap)
+    chunks: list[str] = []
+    for start in range(0, len(rendered), step):
+        group = rendered[start : start + per_chunk]
+        if group:
+            chunks.append("\n".join(group))
+        if start + per_chunk >= len(rendered):
+            break
+    return chunks
+
+
+_NAMED_CONFIDENCE = {
+    "very high": 0.95, "high": 0.9, "medium-high": 0.8, "medium": 0.6,
+    "med": 0.6, "moderate": 0.6, "medium-low": 0.45, "low": 0.3, "very low": 0.1,
+}
+
+
+def _coerce_confidence(value: Any) -> float:
+    """Confidence to a 0-1 float. The model (especially the recall-sweep pass)
+    sometimes returns a word ('high') or a non-numeric string instead of a
+    number; map known words, parse numeric strings, else default 0.7 — never
+    crash the whole batch on one bad field."""
+    if isinstance(value, bool):
+        return 0.7
+    if isinstance(value, (int, float)):
+        return min(max(float(value), 0.0), 1.0)
+    if isinstance(value, str):
+        s = value.strip().lower()
+        if s in _NAMED_CONFIDENCE:
+            return _NAMED_CONFIDENCE[s]
+        try:
+            return min(max(float(s.rstrip("%")) / (100.0 if "%" in s else 1.0), 0.0), 1.0)
+        except ValueError:
+            return 0.7
+    return 0.7
 
 
 def _safe_dt(value: Any) -> datetime | None:
@@ -224,9 +486,43 @@ class LLMCompiler:
             if structured is not None:
                 structured_memories.extend(structured)
                 continue
+            # Message-level chunking (opt-in): extract from small COHERENT
+            # message groups instead of fixed char-windows. Char-windows split
+            # mid-utterance (fragmenting facts) and, when large, let the model
+            # abstract specifics away ("pink sky sunset" -> "a landscape").
+            # Extracting atomic facts from small message-level units with the
+            # same model preserves the specifics. Falls back
+            # to char-windowing for non-chat payloads.
+            msg_chunks = (
+                _message_chunks(
+                    ep.payload,
+                    settings.compile_messages_per_chunk,
+                    settings.compile_message_overlap,
+                    settings.compile_max_episode_chars,
+                )
+                if settings.compile_message_level
+                else None
+            )
+            if msg_chunks:
+                for chunk in msg_chunks:
+                    episode_texts.append((ep, chunk))
+                continue
             text = extract_payload_text(ep.payload)
             if text:
-                episode_texts.append((ep, text[:4000]))  # Cap per-episode text
+                # Window the FULL episode text instead of truncating to a 4000-
+                # char sliver. Long-context episodes (BEAM/LongMemEval sessions
+                # run 100K-460K chars) were losing ~97% of their content before
+                # extraction, so most facts were never compiled. Each window
+                # becomes its own extraction unit; `_process_batch` maps every
+                # resulting memory back to this same source episode. Bounded by
+                # `compile_max_episode_chars` for cost control.
+                for window in _window_text(
+                    text,
+                    settings.compile_max_episode_chars,
+                    settings.compile_window_chars,
+                    settings.compile_window_overlap,
+                ):
+                    episode_texts.append((ep, window))
 
         if not episode_texts:
             if structured_memories and settings.auto_labeling_enabled:
@@ -237,8 +533,12 @@ class LLMCompiler:
         batches = self._create_batches(episode_texts)
         logger.info("compile_batched", episodes=len(episode_texts), batches=len(batches))
 
-        # Run batches in parallel with concurrency limit
-        semaphore = asyncio.Semaphore(_MAX_CONCURRENCY)
+        # Run batches in parallel with concurrency limit. Configurable so
+        # full-conversation windowed compiles can fan out wide enough to finish
+        # within client timeouts.
+        semaphore = asyncio.Semaphore(
+            getattr(settings, "compile_max_concurrency", None) or _MAX_CONCURRENCY
+        )
         tasks = [self._process_batch(batch, semaphore) for batch in batches]
         batch_results = await asyncio.gather(*tasks)
 
@@ -325,6 +625,28 @@ class LLMCompiler:
                     f"LLM compilation failed for a batch of {len(batch)} episode(s): {exc}"
                 ) from exc
 
+            # Recall sweep (opt-in): a second pass that catches specific details
+            # the first pass dropped. Shown the first-pass facts to avoid repeats;
+            # emits complete atomic memories for the misses. Fail-open — a sweep
+            # error must never lose the first-pass memories.
+            if getattr(settings, "compile_recall_sweep", False):
+                try:
+                    swept = await self._call_recall_sweep(
+                        combined_text, len(batch), raw_memories
+                    )
+                    for m in swept:
+                        if isinstance(m, dict):
+                            m["_recall_sweep"] = True
+                    raw_memories = list(raw_memories) + swept
+                    logger.info(
+                        "recall_sweep_done",
+                        episodes=len(batch),
+                        first_pass=len(raw_memories) - len(swept),
+                        swept=len(swept),
+                    )
+                except Exception:  # pragma: no cover - defensive; never break compile
+                    logger.warning("recall_sweep_failed", exc_info=True)
+
             # Map memories back to their source episodes
             results: list[MemoryRow] = []
             for mem in raw_memories:
@@ -366,6 +688,8 @@ class LLMCompiler:
                 # Optional, validated claim. A malformed/unknown proposal is
                 # dropped and never fails the rest of the response.
                 metadata: dict[str, Any] = {"compiler": "llm", "model": self._model}
+                if mem.get("_recall_sweep"):
+                    metadata["pass"] = "recall_sweep"
                 try:
                     claim_md = _llm_claim_metadata(mem)
                 except Exception:  # pragma: no cover - defensive; never break compile
@@ -379,7 +703,7 @@ class LLMCompiler:
                         kind=kind,
                         content=content,
                         summary=summary,
-                        confidence=min(max(float(mem.get("confidence", 0.7)), 0.0), 1.0),
+                        confidence=_coerce_confidence(mem.get("confidence", 0.7)),
                         valid_from=ep_valid_from,
                         valid_to=compute_valid_to(kind, ep_valid_from, settings.kind_ttl_days),
                         source_episode_ids=[source_ep.id],
@@ -408,7 +732,7 @@ class LLMCompiler:
         try:
             parsed = await llm_adapter.acomplete_json(
                 [
-                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "system", "content": _system_prompt()},
                     {
                         "role": "user",
                         "content": (
@@ -438,6 +762,55 @@ class LLMCompiler:
                 if key in parsed and isinstance(parsed[key], list):
                     return parsed[key]
             # Single-memory dict — wrap as a one-element list.
+            if "kind" in parsed and "content" in parsed:
+                return [parsed]
+        return []
+
+    async def _call_recall_sweep(
+        self,
+        text: str,
+        episode_count: int,
+        first_pass: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Second extraction pass that catches specifics the first pass dropped.
+
+        Shown the already-extracted facts so it only emits the misses. Same
+        parsing as `_call_llm_async`. Returns [] on any provider error (the
+        caller treats the sweep as best-effort and keeps the first-pass memories).
+        """
+        ceiling = settings.litellm_compile_max_tokens
+        max_tokens = min(ceiling, max(ceiling // 2, _TOKENS_PER_EPISODE * episode_count))
+        already = "\n".join(
+            f"- {m.get('content', '')}" for m in first_pass if isinstance(m, dict)
+        ) or "(nothing extracted yet)"
+        try:
+            parsed = await llm_adapter.acomplete_json(
+                [
+                    {"role": "system", "content": _RECALL_SWEEP_PROMPT},
+                    {
+                        "role": "user",
+                        "content": (
+                            f"ALREADY_EXTRACTED (do not repeat these):\n{already}\n\n"
+                            f"Now re-read these {episode_count} episode(s) and emit a JSON"
+                            " object with a single key `memories` whose value is the array"
+                            " of specific details the first pass MISSED.\n\n"
+                            f"{text}"
+                        ),
+                    },
+                ],
+                model=self._model,
+                temperature=0.1,
+                max_tokens=max_tokens,
+            )
+        except llm_adapter.StatewaveLLMError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+        if isinstance(parsed, list):
+            return parsed
+        if isinstance(parsed, dict):
+            for key in ("memories", "items", "results"):
+                if key in parsed and isinstance(parsed[key], list):
+                    return parsed[key]
             if "kind" in parsed and "content" in parsed:
                 return [parsed]
         return []

--- a/server/services/dedup.py
+++ b/server/services/dedup.py
@@ -1,0 +1,247 @@
+"""Compile-time near-duplicate dedup — collapse restated/overlapping facts.
+
+Full-conversation windowed compile (server/services/compilers/llm.py) extracts
+the WHOLE haystack, which is the right recall move but produces 450-700 memories
+per conversation: the 200-char window overlap re-extracts boundary facts, and the
+same atomic fact gets restated across dozens of sessions. That bloat dilutes
+retrieval (the precise answer memory ranks below top_k among hundreds of
+near-duplicates — the root cause of the BEAM information_extraction regression
+and the LongMemEval single-fact-lookup stall) and makes compile slow (reconcile
+runs ~18 LLM chunks instead of ~5). The goal is to land on far fewer, deduped
+atomic facts; this pass closes that gap.
+
+Runs as a cheap, deterministic pass BEFORE the LLM reconcile
+(server/services/reconcile.py), on the in-memory candidate list — it never
+touches the session. Division of labour:
+  * dedup     → "is this the SAME fact restated within this batch?" (cheap,
+                deterministic, no committed-DB context needed)
+  * reconcile → "is this a NEWER/CONTRADICTING value of an already-stored
+                fact?" (LLM judgement; supersedes across batches)
+
+Two passes:
+  1. EXACT — group by normalized content (casefold + collapse whitespace +
+     strip trailing punctuation). Byte-identical-after-normalization rows say
+     the same thing, so this is the safe bulk of the win (windowing overlap).
+  2. SEMANTIC — one batched embed of the survivors, then greedy chronological
+     clustering. Two candidates merge ONLY when ALL THREE gates pass:
+       (a) cosine >= dedup_sim_threshold (default 0.92),
+       (b) token-Jaccard >= dedup_token_overlap_min (default 0.6),
+       (c) identical extracted number/date set.
+     Gate (c) is the critical safeguard: a knowledge-UPDATE pair ("API averages
+     250ms" vs "90ms") differs in its numbers and is NEVER merged — it is left
+     for reconcile, which is exactly what raised BEAM knowledge_update 0 -> 0.375.
+     Gate (b) separates topically-close distinct facts that embeddings alone
+     would over-cluster ("daughter Mia" vs "daughter Mary"; "hiking" vs
+     "biking").
+
+Merge is non-destructive: the chronological-earliest member is the canonical;
+dropped members' source_episode_ids are unioned onto it and max confidence is
+kept, so no provenance is lost. The canonical's embedding (computed here) is
+stapled onto the row so the post-commit backfill can skip it (one embedding
+round-trip reused for the memory.embedding column).
+
+Fail-open: any error, the stub provider, a provider/count desync, or a
+degenerate empty result returns the candidates unchanged — dedup can never lose
+a memory. Gated by settings.dedup_compile_enabled.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from datetime import datetime, timezone
+from typing import Sequence
+
+import structlog
+
+from server.core.config import settings
+from server.db.tables import MemoryRow
+from server.services.embeddings import get_provider as get_embedding_provider
+
+logger = structlog.stdlib.get_logger()
+
+_MIN_DT = datetime.min.replace(tzinfo=timezone.utc)
+_WS = re.compile(r"\s+")
+_NUM = re.compile(r"\d+")
+_TOK = re.compile(r"[a-z0-9]+")
+_MONTHS = frozenset(
+    "january february march april may june july august september october "
+    "november december".split()
+)
+_TRAILING = " .,;:!?-—\"'()[]{}"
+# Function words ignored when comparing the "significant content" of two facts.
+# Differences confined to these (or to word order / punctuation) are safe to
+# merge; a difference in ANY non-stopword token (a name, place, noun, verb) is
+# treated as a potentially-distinct fact and left for the LLM reconcile.
+_STOPWORDS = frozenset(
+    "the a an and or but of to in on at for with from by as is are was were be "
+    "been being has have had do does did this that these those it its their his "
+    "her my your our we you they he she i me us them about into over under than "
+    "then now during while which who whom whose what when where why how also".split()
+)
+
+
+def _normalize_core(content: str) -> str:
+    """Normalized comparison key: NFKC + casefold + single-spaced + trimmed."""
+    s = unicodedata.normalize("NFKC", content or "").casefold()
+    s = _WS.sub(" ", s).strip()
+    return s.strip(_TRAILING)
+
+
+def _number_set(content: str) -> frozenset[str]:
+    """Numbers + month names — the guard that keeps knowledge-update / date pairs
+    distinct so dedup never collapses a changed value into its predecessor."""
+    low = (content or "").casefold()
+    nums = set(_NUM.findall(low))
+    months = {m for m in _MONTHS if m in low}
+    return frozenset(nums | months)
+
+
+def _sig_tokens(content: str) -> frozenset[str]:
+    """Significant content words: tokens >=3 chars, minus stopwords. Two facts
+    may only merge when these are IDENTICAL — so any differing name/place/noun/
+    verb (e.g. "Mia" vs "Mary", "hiking" vs "biking") blocks the merge, while
+    word-order / stopword / punctuation differences (the windowing-reformat
+    case) do not."""
+    return frozenset(
+        t for t in _TOK.findall((content or "").casefold())
+        if len(t) >= 3 and t not in _STOPWORDS
+    )
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na <= 0.0 or nb <= 0.0:
+        return 0.0
+    return dot / ((na ** 0.5) * (nb ** 0.5))
+
+
+def _merge(keep: MemoryRow, drop: MemoryRow) -> None:
+    """Fold a redundant row into its canonical without losing information:
+    union provenance, keep the highest confidence and the earliest origin date."""
+    keep.source_episode_ids = list(
+        dict.fromkeys([*(keep.source_episode_ids or []), *(drop.source_episode_ids or [])])
+    )
+    try:
+        keep.confidence = max(keep.confidence, drop.confidence)
+    except Exception:  # pragma: no cover - defensive
+        pass
+    kf = getattr(keep, "valid_from", None)
+    df = getattr(drop, "valid_from", None)
+    if df is not None and (kf is None or df < kf):
+        keep.valid_from = df
+
+
+async def dedup_candidates(
+    candidates: Sequence[MemoryRow], *, provider=None
+) -> list[MemoryRow]:
+    """Collapse near-duplicate candidate memories. Returns the kept canonicals
+    (a subset of the input rows, with merged provenance + stapled embeddings).
+
+    Fail-open: returns ``list(candidates)`` unchanged on any problem."""
+    cands = list(candidates)
+    if not settings.dedup_compile_enabled or len(cands) < 2:
+        return cands
+    if len(cands) > settings.dedup_max_candidates:
+        logger.info("dedup_skipped_large_batch", candidates=len(cands))
+        return cands
+
+    try:
+        # ── Pass 1: exact normalized-text collapse (stub-safe, no embeddings) ──
+        # Keyed on (kind, normalized content) so identical text under different
+        # kinds is never collapsed.
+        groups: dict[tuple[str, str], MemoryRow] = {}
+        order: list[tuple[str, str]] = []
+        for c in cands:
+            key = (c.kind, _normalize_core(c.content))
+            if key in groups:
+                _merge(groups[key], c)
+            else:
+                groups[key] = c
+                order.append(key)
+        survivors = [groups[k] for k in order]
+        exact_dropped = len(cands) - len(survivors)
+        if len(survivors) < 2:
+            return survivors
+
+        # ── Pass 2: semantic cluster (real embeddings only) ──────────────────
+        prov = provider or get_embedding_provider()
+        if (
+            not settings.dedup_semantic_enabled
+            or prov is None
+            or not getattr(prov, "provides_semantic_similarity", False)
+        ):
+            logger.info(
+                "dedup_done",
+                input=len(cands),
+                kept=len(survivors),
+                exact_dropped=exact_dropped,
+                semantic=False,
+            )
+            return survivors
+
+        try:
+            vecs = await prov.embed_texts([s.content for s in survivors])
+        except Exception:
+            logger.warning("dedup_embed_failed", exc_info=True)
+            return survivors
+        if not isinstance(vecs, list) or len(vecs) != len(survivors):
+            return survivors  # provider desync — fail-open to exact-pass result
+
+        # Deterministic chronological order so the canonical (first kept) is the
+        # earliest member and clustering is reproducible.
+        idx = sorted(
+            range(len(survivors)),
+            key=lambda i: (getattr(survivors[i], "valid_from", None) or _MIN_DT, str(survivors[i].id)),
+        )
+        sim_threshold = settings.dedup_sim_threshold
+        kept: list[tuple[MemoryRow, list[float], frozenset, frozenset]] = []
+        for i in idx:
+            row = survivors[i]
+            vec = vecs[i]
+            nums = _number_set(row.content)
+            sig = _sig_tokens(row.content)
+            canonical = None
+            for krow, kvec, knums, ksig in kept:
+                if krow.kind != row.kind:
+                    continue
+                if nums != knums:  # number/date guard — never merge a changed value
+                    continue
+                if sig != ksig:    # significant-content guard — differing name/noun/verb blocks
+                    continue
+                if not sig:        # no content words to anchor on — don't merge
+                    continue
+                if _cosine(vec, kvec) < sim_threshold:  # final meaning check (role-reversal etc.)
+                    continue
+                canonical = krow
+                break
+            if canonical is not None:
+                _merge(canonical, row)
+            else:
+                # Reuse this vector for the persisted memory.embedding column so
+                # the post-commit backfill can skip this row.
+                row.embedding = vec
+                kept.append((row, vec, nums, sig))
+
+        result = [r for (r, _v, _n, _t) in kept]
+        if not result:
+            return survivors  # degenerate guard — never empty out a batch
+
+        logger.info(
+            "dedup_done",
+            input=len(cands),
+            kept=len(result),
+            exact_dropped=exact_dropped,
+            semantic_dropped=len(survivors) - len(result),
+            semantic=True,
+        )
+        return result
+    except Exception:
+        logger.warning("dedup_failed", exc_info=True)
+        return cands

--- a/server/services/entities.py
+++ b/server/services/entities.py
@@ -1,0 +1,246 @@
+"""Compile-time + backfill entity population for the subject_entities store.
+
+Phase 2 of the cross-session retrieval improvements. This module glues three pieces together
+that were built separately:
+
+  - `entity_extraction.extract_entities` — LLM-based NER per memory
+  - `embeddings.get_provider().embed_texts` — batched entity embeddings
+  - `repositories.upsert_entity_with_link` — dedup + linkage at write
+
+Public surface:
+  - `populate_entities_for_memories(...)` — call this from inside the
+    compile transaction (after memory commit) for newly-compiled rows.
+    Idempotent on memory_id linkage (re-running won't duplicate the
+    edge). Fan-out keeps total wall-time bounded by the slowest LLM
+    extraction call, not the sum.
+
+  - `backfill_entities_for_subject(...)` — one-off path for existing
+    pre-Phase-2 compiled memories. Reads memories from the DB,
+    extracts entities, populates the store. Safe to re-run.
+
+Both paths gracefully degrade — if the LLM provider is unreachable,
+extraction returns an empty list, the function logs at WARNING, and
+the caller proceeds (memories were committed; the entity store stays
+empty for those memories; Phase 3 retrieval falls back to pure
+hybrid (semantic + BM25 from Phase 1)).
+
+Why this split (population vs storage): the entity-boost step in the
+retrieval path expects the entity store to be populated and silently
+no-ops on empty; population guarantees that contract. The Phase 3
+retrieval path doesn't care HOW the store got populated — at-compile-time
+vs backfill is operational.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.db import repositories as repo
+from server.services.embeddings import get_provider as get_embedding_provider
+from server.services.entity_extraction import ExtractedEntity, extract_entities
+
+logger = structlog.stdlib.get_logger()
+
+
+@dataclass(frozen=True)
+class MemoryForEntities:
+    """Minimal shape the entity-population path needs — id + the text we
+    extract entities from. Keeps the caller decoupled from the full
+    MemoryRow object (useful for the backfill loop that processes memories
+    in pages without keeping the whole row in memory)."""
+
+    id: uuid.UUID
+    content: str
+
+
+# Per-call concurrency for the LLM extraction fan-out. Bounded so a
+# pathologically large compile batch doesn't blow up the operator's
+# LLM provider rate limit. 8 is conservative — typical compile batches
+# are 20-50 memories; doubling concurrency gives no wall-time benefit
+# when the bottleneck is provider round-trip latency.
+_EXTRACT_CONCURRENCY = 8
+
+
+async def _extract_one(
+    memory: MemoryForEntities, semaphore: asyncio.Semaphore
+) -> tuple[uuid.UUID, list[ExtractedEntity]]:
+    async with semaphore:
+        entities = await extract_entities(memory.content)
+    return memory.id, entities
+
+
+async def populate_entities_for_memories(
+    session: AsyncSession,
+    memories: list[MemoryForEntities],
+    *,
+    subject_id: str,
+    tenant_id: str | None,
+) -> int:
+    """Extract + dedup + persist entities for a batch of just-compiled
+    memories. Returns the count of distinct entity rows touched (newly
+    inserted OR an existing row had memory_id appended to its
+    linked_memory_ids).
+
+    Caller MUST have already committed the memory rows in the same
+    session. Entity inserts use the same session and are committed by
+    the caller — keeping it in one transaction means a rollback in the
+    compile path also rolls back the entity writes, no partial state.
+
+    Order of operations (the Phase 7 entity-linking sequence):
+      1. Parallel LLM extraction (fan-out, _EXTRACT_CONCURRENCY workers)
+      2. Collect all distinct (text, normalized, kind) entities
+      3. Batch-embed in ONE provider call (memory bandwidth, not latency)
+      4. Per-(memory_id, entity) call upsert_entity_with_link, which
+         does exact-match then cosine-similarity dedup against existing
+         entities for the subject
+
+    If the embedding provider is None (operator has embedding_provider=
+    "none"), entities still get extracted + stored, but the dedup is
+    string-only (no semantic merge) and Phase 3 retrieval can't use
+    them — log at INFO so the operator notices.
+    """
+    if not memories:
+        return 0
+
+    # ── Step 1: parallel LLM extraction ─────────────────────────────────
+    semaphore = asyncio.Semaphore(_EXTRACT_CONCURRENCY)
+    tasks = [_extract_one(m, semaphore) for m in memories]
+    results = await asyncio.gather(*tasks, return_exceptions=False)
+
+    # ── Step 2: flatten + dedup entity text within this batch ────────────
+    # (Same surface form across two memories gets ONE embedding call,
+    # then both memories link to the same entity row at upsert time.)
+    entities_by_memory: dict[uuid.UUID, list[ExtractedEntity]] = {}
+    distinct_texts: dict[str, ExtractedEntity] = {}
+    for memory_id, entities in results:
+        if not entities:
+            continue
+        entities_by_memory[memory_id] = entities
+        for e in entities:
+            if e.normalized not in distinct_texts:
+                distinct_texts[e.normalized] = e
+
+    if not distinct_texts:
+        return 0
+
+    # ── Step 3: batch embed ─────────────────────────────────────────────
+    provider = get_embedding_provider()
+    embeddings_by_normalized: dict[str, list[float] | None] = {
+        normalized: None for normalized in distinct_texts
+    }
+    if provider is not None:
+        try:
+            # Embed the CANONICAL (cased) form — same way the existing
+            # memory embeddings are produced from memory.content. This
+            # makes the entity↔memory similarity space consistent.
+            normalized_keys = list(distinct_texts.keys())
+            texts_to_embed = [distinct_texts[k].text for k in normalized_keys]
+            embeddings = await provider.embed_texts(texts_to_embed)
+            for normalized, vector in zip(normalized_keys, embeddings):
+                embeddings_by_normalized[normalized] = vector
+        except Exception:
+            logger.warning(
+                "entity_embedding_failed",
+                subject_id=subject_id,
+                count=len(distinct_texts),
+                exc_info=True,
+            )
+            # Fall through — we still write the entities, just without
+            # vectors. Dedup degenerates to exact-string-match (no
+            # semantic merge). Phase 3 retrieval skips them.
+    else:
+        logger.info(
+            "entity_embedding_skipped_no_provider",
+            subject_id=subject_id,
+            count=len(distinct_texts),
+        )
+
+    # ── Step 4: per-memory upsert ───────────────────────────────────────
+    touched = 0
+    for memory_id, entities in entities_by_memory.items():
+        for e in entities:
+            embedding = embeddings_by_normalized.get(e.normalized)
+            try:
+                await repo.upsert_entity_with_link(
+                    session,
+                    subject_id=subject_id,
+                    tenant_id=tenant_id,
+                    entity_text=e.text,
+                    entity_normalized=e.normalized,
+                    entity_kind=e.kind,
+                    embedding=embedding,
+                    memory_id=memory_id,
+                )
+                touched += 1
+            except Exception:
+                logger.warning(
+                    "entity_upsert_failed",
+                    subject_id=subject_id,
+                    entity=e.normalized,
+                    memory_id=str(memory_id),
+                    exc_info=True,
+                )
+                # Continue with the next entity — one bad row doesn't
+                # break the compile.
+    return touched
+
+
+async def backfill_entities_for_subject(
+    session: AsyncSession,
+    subject_id: str,
+    *,
+    tenant_id: str | None = None,
+    batch_size: int = 50,
+) -> int:
+    """One-off: extract + persist entities for every existing active
+    memory of the subject. Returns total entity upsert count.
+
+    Used to populate `subject_entities` for memories that pre-date this
+    column — bench runs against a server that compiled subjects before
+    Phase 2 landed need this before Phase 3 retrieval can do anything.
+
+    Pages through memories `batch_size` at a time, commits per page,
+    re-entrant on failure (the dedup means re-running upserts the same
+    edges idempotently). For bench scales (~200 memories per subject),
+    this completes in seconds; for production scales it's the operator's
+    call when to run it.
+    """
+    total_touched = 0
+    offset_id: uuid.UUID | None = None
+    while True:
+        # Page by created_at (stable order) with a tail keyset; the
+        # repo helper that's been here forever uses asc ordering, so
+        # we can just `list_memories_by_subject` and slice.
+        page = await repo.list_memories_by_subject(
+            session, subject_id, tenant_id=tenant_id, limit=batch_size * 100
+        )
+        # Slice manually so we control offset_id paging without a new
+        # repo function. (For backfill the full list is fine to load.)
+        if offset_id is not None:
+            page = [m for m in page if m.created_at > _row_created_at(page, offset_id)]
+        if not page:
+            break
+        page = list(page)[:batch_size]
+        memories = [MemoryForEntities(id=m.id, content=m.content) for m in page]
+        touched = await populate_entities_for_memories(
+            session, memories, subject_id=subject_id, tenant_id=tenant_id
+        )
+        await session.commit()
+        total_touched += touched
+        if len(page) < batch_size:
+            break
+        offset_id = page[-1].id
+    return total_touched
+
+
+def _row_created_at(rows, target_id):
+    for r in rows:
+        if r.id == target_id:
+            return r.created_at
+    # Shouldn't happen; defensive — treat as "very old" so we keep the rest.
+    return None

--- a/server/services/entity_extraction.py
+++ b/server/services/entity_extraction.py
@@ -1,0 +1,193 @@
+"""LLM-based entity extraction for the subject_entities store.
+
+Phase 2 of the cross-session retrieval improvements needs an
+entity-population mechanism for `subject_entities` (the table introduced
+in migration 0028). A common approach uses spaCy NER for proper-noun
+extraction; we use the same LiteLLM-routed model we already have for
+compilation instead, because:
+
+  - Zero new infra: the compile path already has an LLM provider
+    configured + reachable; reusing it means no spaCy install, no model
+    download in the Dockerfile, no new failure mode at boot.
+  - Context-aware: spaCy's small English model misses domain-specific
+    entities (product names, made-up identifiers) that an LLM picks up
+    from surrounding context.
+  - Cheap per call: ~50 input tokens + ~30 output tokens per memory
+    (about $0.0002 at gpt-4o-mini). Backfilling 10K existing memories
+    costs ~$2; per-compile-batch overhead is marginal.
+
+Trade-off: LLM extraction has non-zero latency (~200-500ms per call vs
+spaCy's sub-ms). The compile path already runs LLM calls in parallel
+batches; we slot entity extraction into the same async fan-out so the
+total compile wall-time grows by at most one extra round-trip.
+
+`extract_entities` is the public entry point. It returns a list of
+(text, kind) tuples ready for upsert into `subject_entities`. `kind`
+mirrors spaCy NER labels (PERSON / ORG / GPE / DATE / PRODUCT / EVENT /
+MISC) so the schema stays compatible with a future spaCy swap-in — only
+the extractor changes, the storage + retrieval contracts stay intact.
+
+Graceful degradation: if the LLM call fails for any reason, the function
+logs at WARNING and returns an empty list. The compile transaction
+commits anyway with no entity rows — Phase 3 retrieval (entity boost)
+silently no-ops on subjects with no entities, falling back to the
+pure-Phase-1 hybrid (semantic + BM25). One flaky compile doesn't break
+the bench or production retrieval.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+import structlog
+
+from server.core.config import settings
+from server.services.llm import acomplete
+
+logger = structlog.stdlib.get_logger()
+
+
+# Reuse the same LLM model the compiler uses — same provider, same
+# credentials, same retry path. Reads from
+# `settings.litellm_compile_model` (the compile-specific override,
+# falling back to the default `settings.litellm_model` if unset). The
+# extraction is small enough that gpt-4o-mini handles it well; ops can
+# point this at a cheaper model than the compiler via env var without
+# touching code.
+def _extraction_model() -> str | None:
+    return getattr(settings, "litellm_compile_model", None) or settings.litellm_model
+
+EXTRACTION_SYSTEM_PROMPT = (
+    "You are a precise named-entity extractor. Given a short fact about a "
+    "person ('user') and their conversation history, extract every distinct "
+    "entity (proper noun or compound noun phrase) the fact references. "
+    "Return ONLY valid JSON with the exact shape requested."
+)
+
+EXTRACTION_USER_TEMPLATE = """Extract every distinct named entity from the fact below.
+
+An entity is:
+  - A proper noun (person, place, organization, product, event, work)
+  - A specific compound noun phrase that identifies one thing ("the navy blue blazer", "the 5K charity run")
+  - A specific date or date range when it identifies a SPECIFIC event (skip generic dates like "yesterday")
+  - A unique role/title that picks out one entity ("Senior Sales Engineer at Acme")
+
+NOT entities:
+  - Generic words ("food", "music", "exercise")
+  - The user themselves ("user", "I", "me")
+  - Common adjectives or qualifiers
+  - Numbers or units in isolation
+
+For each entity, output:
+  - text: the canonical surface form (preserve casing as written)
+  - kind: one of PERSON | ORG | GPE | LOC | PRODUCT | EVENT | WORK | DATE | MISC
+
+FACT:
+{text}
+
+Return exactly this JSON:
+{{"entities": [{{"text": "<entity>", "kind": "<label>"}}, ...]}}"""
+
+
+@dataclass(frozen=True)
+class ExtractedEntity:
+    """One entity extracted from a memory's content. `text` preserves the
+    original casing for display; `normalized` is the dedup key (lowercase,
+    whitespace-collapsed); `kind` is the spaCy-compatible NER label."""
+
+    text: str
+    normalized: str
+    kind: str | None
+
+
+_NORMALIZE_WS = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    """Canonicalize an entity surface form for the dedup key. Lowercase
+    + whitespace collapse + strip. This is the normalization applied for
+    entity exact-match dedup before falling back to embedding cosine."""
+    return _NORMALIZE_WS.sub(" ", text).strip().lower()
+
+
+def _parse_entities(raw: str) -> list[ExtractedEntity]:
+    """Pull the entities array out of the LLM's JSON output. Defensive:
+    accepts code-fence wrappers, partial JSON, missing fields — anything
+    parseable contributes; anything that isn't drops silently."""
+    s = (raw or "").strip()
+    # Strip code-fence wrappers
+    s = re.sub(r"^```(?:json)?\s*", "", s)
+    s = re.sub(r"\s*```$", "", s)
+    try:
+        j = json.loads(s)
+    except (ValueError, json.JSONDecodeError):
+        # Last-ditch: scan for the first {...entities...} block
+        m = re.search(r"\{[^{}]*\"entities\"\s*:[^{}]*\[[^\[\]]*\][^{}]*\}", s, re.DOTALL)
+        if not m:
+            return []
+        try:
+            j = json.loads(m.group(0))
+        except (ValueError, json.JSONDecodeError):
+            return []
+    if not isinstance(j, dict):
+        return []
+    raw_entities = j.get("entities")
+    if not isinstance(raw_entities, list):
+        return []
+    out: list[ExtractedEntity] = []
+    seen_normalized: set[str] = set()
+    for item in raw_entities:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        normalized = _normalize(text)
+        if not normalized or normalized in seen_normalized:
+            continue
+        seen_normalized.add(normalized)
+        kind = item.get("kind")
+        if not isinstance(kind, str) or not kind.strip():
+            kind = None
+        out.append(
+            ExtractedEntity(
+                text=text.strip(),
+                normalized=normalized,
+                kind=kind.strip().upper() if kind else None,
+            )
+        )
+    return out
+
+
+async def extract_entities(text: str) -> list[ExtractedEntity]:
+    """Return the entities extracted from one memory's content.
+
+    Empty list on any failure (LLM unavailable, parse error, etc.) —
+    the caller (compile-time hook) treats this as "no entities for this
+    memory" and proceeds. The compile transaction is NOT rolled back if
+    extraction fails for one row.
+
+    Cheap to call per memory (~50 in + ~30 out tokens); the LLM call
+    fans out alongside the existing compile fan-out so latency is
+    parallel.
+    """
+    if not text or not text.strip():
+        return []
+    messages = [
+        {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
+        {"role": "user", "content": EXTRACTION_USER_TEMPLATE.format(text=text.strip())},
+    ]
+    try:
+        response_text = await acomplete(
+            messages,
+            model=_extraction_model(),
+            max_tokens=400,
+            temperature=0.0,
+            response_format={"type": "json_object"},
+        )
+    except Exception:
+        logger.warning("entity_extraction_failed", text_preview=text[:80], exc_info=True)
+        return []
+    return _parse_entities(response_text)

--- a/server/services/llm.py
+++ b/server/services/llm.py
@@ -171,19 +171,56 @@ def _classify(exc: BaseException) -> StatewaveLLMError:
     return LLMProviderError(str(exc) or type(exc).__name__)
 
 
-def _common_kwargs() -> dict[str, Any]:
+def _common_kwargs(model: str | None = None) -> dict[str, Any]:
     """Per-call kwargs that come from settings — api_key, api_base.
 
     The api_key is passed explicitly to LiteLLM rather than mutating
     `os.environ`, so multiple Statewave instances in one process can
     target different providers without leaking credentials between them.
+
+    Provider-aware routing (v9, mixed-vendor deployments): if `model`
+    begins with `claude-`, we DO NOT pass `api_key` — LiteLLM will read
+    `ANTHROPIC_API_KEY` from the env automatically. For any other model
+    (including OpenAI embedding models like text-embedding-3-small), we
+    pass `settings.litellm_api_key` as before. This lets a single
+    deployment run an Anthropic compiler against a Claude model AND
+    keep an OpenAI embedding model on the same server without the OpenAI
+    key being silently passed to the Anthropic API.
     """
     kw: dict[str, Any] = {}
-    if settings.litellm_api_key:
+    is_claude = bool(model and model.startswith("claude-"))
+    if settings.litellm_api_key and not is_claude:
         kw["api_key"] = settings.litellm_api_key
     if settings.litellm_api_base:
         kw["api_base"] = settings.litellm_api_base
     return kw
+
+
+# gpt-5 family and o-series reasoning models reject any explicit temperature
+# other than the default (1) — passing 0.1 raises BadRequestError. Omit the
+# param for them and let the model use its default.
+_RESTRICTED_TEMP_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+
+
+def _omit_temperature(model: str | None) -> bool:
+    m = (model or "").lower()
+    if m.startswith("openai/"):
+        m = m[len("openai/"):]
+    return any(m.startswith(p) for p in _RESTRICTED_TEMP_PREFIXES)
+
+
+def _reasoning_kwargs(model: str | None) -> dict[str, Any]:
+    """``reasoning_effort`` for gpt-5/o-series reasoning models, when configured.
+
+    Only emitted for reasoning models (the same set that rejects temperature), so
+    non-reasoning chat models and the embedding path are unaffected. Setting it to
+    "minimal" stops reasoning tokens from consuming the whole response budget —
+    the cause of empty JSON on complex compile/reconcile prompts — and is far
+    faster and cheaper.
+    """
+    if settings.litellm_reasoning_effort and _omit_temperature(model):
+        return {"reasoning_effort": settings.litellm_reasoning_effort}
+    return {}
 
 
 # ─── Chat completion ─────────────────────────────────────────────────
@@ -212,10 +249,12 @@ async def acomplete(
     kwargs: dict[str, Any] = {
         "model": chosen_model,
         "messages": messages,
-        "temperature": temp,
         "num_retries": settings.litellm_max_retries,
-        **_common_kwargs(),
+        **_common_kwargs(chosen_model),
+        **_reasoning_kwargs(chosen_model),
     }
+    if not _omit_temperature(chosen_model):
+        kwargs["temperature"] = temp
     if max_tokens is not None:
         kwargs["max_tokens"] = max_tokens
     if response_format is not None:
@@ -288,10 +327,12 @@ async def acomplete_with_usage(
     kwargs: dict[str, Any] = {
         "model": chosen_model,
         "messages": messages,
-        "temperature": temp,
         "num_retries": settings.litellm_max_retries,
-        **_common_kwargs(),
+        **_common_kwargs(chosen_model),
+        **_reasoning_kwargs(chosen_model),
     }
+    if not _omit_temperature(chosen_model):
+        kwargs["temperature"] = temp
     if max_tokens is not None:
         kwargs["max_tokens"] = max_tokens
 
@@ -320,13 +361,38 @@ async def acomplete_json(
 ) -> Any:
     """Chat completion that returns parsed JSON.
 
-    Sets `response_format={"type": "json_object"}` and parses the resulting
-    string. Strips markdown fences if the model wraps the JSON in them.
-    Raises LLMResponseError on invalid JSON.
+    Provider-aware: Anthropic models (`claude-*`) use forced **tool use**
+    (LiteLLM passes through `tools` + `tool_choice` to Anthropic; the
+    model is REQUIRED to call the `emit_json` tool with a valid JSON
+    `payload` arg). All other providers use `response_format=json_object`,
+    which OpenAI / Azure / etc. honor natively.
+
+    Why the split: with `response_format=json_object` alone, Anthropic
+    sometimes returns conversational preamble ("I'll break this down…")
+    when the user message contains conversational content (e.g. an
+    extraction prompt followed by a long chat transcript). Tool use is
+    the only Anthropic-native way to FORCE structured output —
+    `response_format` is a soft instruction the model can still ignore;
+    `tool_choice={"type": "tool", "name": "..."}` is a hard constraint.
+
+    Raises LLMResponseError if the response is missing the tool call
+    (Anthropic) or if the resulting string fails to parse as JSON.
     """
+    chosen_model = model or settings.litellm_model
+    is_anthropic = chosen_model.startswith("claude-") or chosen_model.startswith("anthropic/")
+
+    if is_anthropic:
+        return await _acomplete_json_anthropic_tool_use(
+            messages,
+            model=chosen_model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            timeout=timeout,
+        )
+
     raw = await acomplete(
         messages,
-        model=model,
+        model=chosen_model,
         temperature=temperature,
         max_tokens=max_tokens,
         response_format={"type": "json_object"},
@@ -339,6 +405,105 @@ async def acomplete_json(
         return json.loads(cleaned)
     except json.JSONDecodeError as exc:
         raise LLMResponseError(f"LLM returned invalid JSON: {cleaned[:200]}") from exc
+
+
+# Generic free-form tool the JSON-forced path uses. We don't constrain
+# the schema beyond `type: object` so callers can stuff any shape into
+# the `payload` — the compiler, e.g., expects `{"memories": [...]}`,
+# while a future eval pipeline might want `{"score": 0.7}`. Schema
+# enforcement happens at the caller boundary, not here.
+_EMIT_JSON_TOOL: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "emit_json",
+        "description": (
+            "Emit the structured JSON response for this task. ALWAYS call "
+            "this function. Do not respond with plain text."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "payload": {
+                    "type": "object",
+                    "description": "The full JSON payload requested by the user message.",
+                    "additionalProperties": True,
+                }
+            },
+            "required": ["payload"],
+        },
+    },
+}
+
+
+async def _acomplete_json_anthropic_tool_use(
+    messages: list[dict[str, str]],
+    *,
+    model: str,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    timeout: float | None = None,
+) -> Any:
+    """Anthropic-specific JSON-forcing path via LiteLLM tool use.
+
+    Forces the model to emit a single `emit_json` tool call whose
+    `payload` argument is the structured response. Returns the parsed
+    `payload` dict; raises LLMResponseError if Anthropic returns text
+    or a missing/malformed tool call.
+    """
+    litellm = _ensure_litellm()
+    temp = temperature if temperature is not None else settings.litellm_temperature
+    timeout_s = timeout if timeout is not None else settings.litellm_timeout_seconds
+
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": temp,
+        "num_retries": settings.litellm_max_retries,
+        "tools": [_EMIT_JSON_TOOL],
+        "tool_choice": {"type": "function", "function": {"name": "emit_json"}},
+        **_common_kwargs(model),
+    }
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
+
+    try:
+        resp = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=timeout_s)
+    except asyncio.TimeoutError as exc:
+        raise LLMTimeoutError(f"LLM completion timed out after {timeout_s}s") from exc
+    except Exception as exc:  # noqa: BLE001
+        raise _classify(exc) from exc
+
+    # LiteLLM normalizes Anthropic tool_use → OpenAI-shaped tool_calls.
+    try:
+        message = resp.choices[0].message
+        tool_calls = getattr(message, "tool_calls", None) or []
+    except (AttributeError, IndexError) as exc:
+        raise LLMResponseError("Anthropic JSON tool: missing choices/message") from exc
+
+    if not tool_calls:
+        # Defensive: if the model ignored tool_choice and returned text,
+        # report it as malformed (caller will surface the snippet).
+        content = getattr(message, "content", "") or ""
+        raise LLMResponseError(
+            "Anthropic JSON tool: model returned text instead of tool_call: "
+            f"{str(content)[:200]}"
+        )
+
+    call = tool_calls[0]
+    raw_args = getattr(getattr(call, "function", None), "arguments", None)
+    if not raw_args:
+        raise LLMResponseError("Anthropic JSON tool: tool_call has no arguments")
+    try:
+        parsed = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+    except json.JSONDecodeError as exc:
+        raise LLMResponseError(
+            f"Anthropic JSON tool: arguments unparseable: {str(raw_args)[:200]}"
+        ) from exc
+    if isinstance(parsed, dict) and "payload" in parsed:
+        return parsed["payload"]
+    # Defensive: some LiteLLM versions may pass arguments through
+    # without the `payload` wrapper — accept the bare dict.
+    return parsed
 
 
 # ─── Embeddings ──────────────────────────────────────────────────────
@@ -363,8 +528,16 @@ async def aembed_texts(
         "model": chosen_model,
         "input": texts,
         "dimensions": dim,
-        **_common_kwargs(),
+        **_common_kwargs(chosen_model),
     }
+    # Embedder may target a dedicated endpoint (e.g. a local Qwen server) distinct
+    # from the chat/extraction provider. A custom OpenAI-compatible endpoint
+    # controls its own output width and may reject the `dimensions` param via
+    # LiteLLM validation; the server is configured to emit
+    # ``settings.embedding_dimensions`` directly, so drop it here.
+    if settings.litellm_embedding_api_base:
+        kwargs["api_base"] = settings.litellm_embedding_api_base
+        kwargs.pop("dimensions", None)
 
     try:
         resp = await asyncio.wait_for(litellm.aembedding(**kwargs), timeout=timeout_s)

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0026_system_settings"
+EXPECTED_HEAD = "0028_subject_entities"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/server/services/reconcile.py
+++ b/server/services/reconcile.py
@@ -1,0 +1,399 @@
+"""Context-aware compile reconcile — a "memory-update" step.
+
+Phase 4 (context-aware compile) + Phase 5b (supersession / semantic dedup) of
+the cross-session retrieval improvements, FUSED into one mechanism: a single
+LLM call returns an ADD / UPDATE / DELETE / NONE event per candidate fact,
+judged against the semantically nearest existing memories.
+
+Why this is the highest-leverage missing piece
+-----------------------------------------------
+The LLM compiler was purely *additive*: it extracted facts from each episode
+batch and never reconciled them against what was already stored. So a changed
+value ("I live in Munich" → later "I moved to Berlin") left BOTH memories
+active, and retrieval happily returned the stale one. That single gap is the
+root cause of the near-zero GPT-only categories:
+
+  * BEAM knowledge_update = 0.00
+  * BEAM contradiction_resolution = 0.01
+  * BEAM multi_session_reasoning = 0.00
+  * LongMemEval knowledge_update / multi_session soft spots
+
+Pipeline (called from ``server/api/memories._compile_one_batch`` AFTER the
+compiler returns candidate rows, BEFORE they are inserted)
+----------------------------------------------------------
+  1. Read the subject's EXISTING active memories (committed). When that set is
+     large, narrow it to the candidates' semantic neighbourhood via one
+     batched embedding round-trip + indexed cosine lookups.
+  2. Sort candidates chronologically (oldest first) and present existing
+     memories (E0, E1, …) and new candidates (N0, N1, …) to ONE LLM call.
+  3. The LLM returns, per candidate, exactly one decision:
+       ADD       — genuinely new; keep it.
+       DUPLICATE — already covered by a target (E# or earlier N#); drop it.
+       UPDATE    — a newer value of the target's fact; keep it, retire target.
+       DELETE    — asserts the target is now false; keep it, retire target.
+  4. Apply: return the kept candidate rows + the set of EXISTING committed
+     memory ids to mark superseded. Candidates retired by a later candidate
+     are simply not inserted.
+
+Robustness
+----------
+Best-effort and fail-OPEN: missing semantic embeddings, an LLM error, a
+malformed response, or a degenerate all-dropped result all fall back to the
+prior additive behaviour (every candidate ADDed, nothing superseded) so the
+compile NEVER loses memories to a reconcile failure. Gated by
+``settings.reconcile_compile_enabled``.
+
+The reconcile LLM call routes through the central adapter with the compile
+model (provider-neutral; gpt-4o-mini in the bench config), so it
+introduces no new provider dependency.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Sequence
+
+import structlog
+
+from server.core.config import settings
+from server.db import repositories as repo
+from server.db.tables import MemoryRow
+from server.services import llm as llm_adapter
+from server.services.embeddings import get_provider as get_embedding_provider
+
+logger = structlog.stdlib.get_logger()
+
+# Sentinel for chronological sort of undated candidates (sorts first).
+_MIN_DT = datetime.min.replace(tzinfo=timezone.utc)
+
+_RECONCILE_SYSTEM_PROMPT = """\
+You are a memory reconciliation engine for a long-term memory system. You keep a \
+subject's stored memory consistent by deciding how each NEW candidate fact relates \
+to the EXISTING memory and to the other new facts.
+
+You are given two lists:
+- EXISTING memories, labeled E0, E1, ... — already stored. (May be empty.)
+- NEW candidate facts, labeled N0, N1, ... in CHRONOLOGICAL order, OLDEST FIRST. \
+A higher index means more recent in time.
+
+For EACH new candidate Ni choose EXACTLY ONE action:
+- "ADD": Ni carries information not already captured by any existing memory or \
+earlier new fact. Keep it.
+- "DUPLICATE": Ni states the SAME fact as a "target" (an E# or an earlier N#), \
+adding nothing new. Drop Ni — the target already covers it.
+- "UPDATE": Ni is a NEWER or CORRECTED VALUE of the same attribute of the same \
+entity as the "target" (e.g. target = "lives in Munich", Ni = "moved to Berlin in \
+2024"; or target = "API averages 250ms", Ni = "API now averages 90ms"). Keep Ni \
+and retire the target.
+  * RUNNING/CUMULATIVE quantities: when target and Ni are two readings of the SAME \
+one-direction tally (a page count, a times-done counter, a running total), ALSO \
+return a "merged_content" field: ONE sentence stating the CURRENT ABSOLUTE value, \
+resolving any relative delta against the target ("read 20 more pages" + target "on \
+page 200" -> "on page 220"; "wore them again" + target "worn 5 times" -> "worn 6 \
+times"), preserving the entity, unit and the as-of date. If Ni is already absolute, \
+restate it cleanly. OMIT "merged_content" for ordinary value-replacements (Munich \
+-> Berlin) where no carry-forward arithmetic is needed.
+- "DELETE": Ni asserts the "target" fact is NO LONGER TRUE, was removed, or is \
+contradicted (e.g. target = "uses Stripe", Ni = "stopped using Stripe and switched \
+off card payments"). Keep Ni and retire the target.
+
+Rules:
+- "target" is a single label string (e.g. "E3" or "N1") for DUPLICATE / UPDATE / \
+DELETE; it MUST be null for ADD.
+- UPDATE/DELETE/DUPLICATE only when the two facts concern the SAME attribute of the \
+SAME entity. Two different attributes are both kept (ADD) — e.g. "likes coffee" and \
+"likes hiking" are unrelated; "has a daughter Mia" and "has a son Leo" are both true.
+- Distinct concrete facts are ADD even when topically related. When in doubt, ADD — \
+never discard information you are unsure about.
+- A target must be STRICTLY OLDER than Ni: any E#, or an N# with a SMALLER index. \
+Never target an equal or later N#.
+- Do not retire a memory unless Ni genuinely duplicates, updates, or contradicts it.
+
+Return ONLY a JSON object:
+{"decisions": [{"i": 0, "action": "ADD", "target": null, "reason": "<short>"}, ...]}
+with EXACTLY ONE entry per new candidate, ordered by i ascending. An UPDATE entry \
+for a running/cumulative quantity MAY additionally carry "merged_content": "<current \
+absolute value sentence>"."""
+
+_LABEL_RE = re.compile(r"^([EN])(\d+)$")
+
+
+def _compile_model() -> str:
+    """The model the reconcile LLM call uses — the compile model, so reconcile
+    shares the compiler's provider/credentials and never adds a dependency."""
+    return getattr(settings, "litellm_compile_model", None) or settings.litellm_model
+
+
+def _fmt_date(m: MemoryRow) -> str:
+    vf = getattr(m, "valid_from", None)
+    try:
+        return vf.strftime("%Y-%m-%d") if vf is not None else "undated"
+    except Exception:  # pragma: no cover - defensive
+        return "undated"
+
+
+async def _select_existing(
+    session,
+    subject_id: str,
+    candidates: list[MemoryRow],
+    *,
+    tenant_id: str | None,
+) -> list[MemoryRow]:
+    """Return the existing active memories to reconcile against, capped to
+    ``reconcile_max_existing``. When the subject already has more memories than
+    the cap, narrow to the candidates' semantic neighbourhood (one batched
+    embed + per-candidate indexed cosine lookups); otherwise feed them all.
+
+    Reads ONLY committed rows — candidates are not yet in the session, so the
+    "existing" view is never polluted by the batch being reconciled."""
+    max_existing = settings.reconcile_max_existing
+    existing = list(
+        await repo.list_active_memories_by_subject(
+            session, subject_id, tenant_id=tenant_id, limit=500
+        )
+    )
+    if len(existing) <= max_existing:
+        return existing
+
+    provider = get_embedding_provider()
+    if provider is None or not getattr(provider, "provides_semantic_similarity", False):
+        # No usable embeddings — fall back to the most recent slice. The
+        # repo returns created_at ASC, so the tail is the newest.
+        return existing[-max_existing:]
+
+    try:
+        cand_embeddings = await provider.embed_texts([c.content for c in candidates])
+        relevant: dict[uuid.UUID, MemoryRow] = {}
+        by_id = {m.id: m for m in existing}
+        top_k = settings.reconcile_top_k_per_candidate
+        for emb in cand_embeddings:
+            rows = await repo.search_memories_by_embedding(
+                session, subject_id, emb, tenant_id=tenant_id, limit=top_k
+            )
+            for row, _distance in rows:
+                if row.id in by_id:
+                    relevant[row.id] = by_id[row.id]
+        if relevant:
+            return list(relevant.values())[:max_existing]
+    except Exception:
+        logger.warning("reconcile_existing_select_failed", subject_id=subject_id, exc_info=True)
+    return existing[-max_existing:]
+
+
+def _build_user_message(ctx_rows: list[MemoryRow], chunk_rows: list[MemoryRow]) -> str:
+    existing_block = "\n".join(
+        f"E{k}: {m.content}" for k, m in enumerate(ctx_rows)
+    ) or "(none)"
+    candidate_block = "\n".join(
+        f"N{i}: [{_fmt_date(m)}] {m.content}" for i, m in enumerate(chunk_rows)
+    )
+    return (
+        "EXISTING memories:\n"
+        f"{existing_block}\n\n"
+        "NEW candidate facts (chronological, oldest first):\n"
+        f"{candidate_block}\n\n"
+        f"Return a decision for each of the {len(chunk_rows)} new candidate(s)."
+    )
+
+
+def _parse_label(target: Any, *, n_existing: int, n_candidates: int) -> tuple[str, int] | None:
+    """Parse an 'E#'/'N#' target into ('E'|'N', index), bounds-checked. None if
+    malformed or out of range."""
+    if not isinstance(target, str):
+        return None
+    match = _LABEL_RE.match(target.strip())
+    if not match:
+        return None
+    kind, idx_s = match.group(1), match.group(2)
+    idx = int(idx_s)
+    if kind == "E" and 0 <= idx < n_existing:
+        return ("E", idx)
+    if kind == "N" and 0 <= idx < n_candidates:
+        return ("N", idx)
+    return None
+
+
+async def reconcile_compile_batch(
+    session,
+    subject_id: str,
+    candidates: Sequence[MemoryRow],
+    *,
+    tenant_id: str | None = None,
+) -> tuple[list[MemoryRow], set[uuid.UUID]]:
+    """Reconcile freshly-compiled candidate memories against existing memory.
+
+    Returns ``(kept_rows, superseded_existing_ids)``:
+      * ``kept_rows`` — candidates to insert (ADD/UPDATE/DELETE survivors), in
+        chronological order; DUPLICATE candidates and candidates retired by a
+        later candidate are excluded.
+      * ``superseded_existing_ids`` — ids of EXISTING committed memories the
+        caller must mark superseded.
+
+    Fail-open: on any problem returns ``(list(candidates), set())`` so the
+    compile degrades to the prior additive behaviour rather than losing rows.
+    """
+    candidates = list(candidates)
+    if not candidates:
+        return [], set()
+    # Bound the prompt — an unusually large batch skips reconcile rather than
+    # sending a giant prompt (resolve_conflicts + a later drain still apply).
+    if len(candidates) > settings.reconcile_max_candidates:
+        logger.info(
+            "reconcile_skipped_large_batch",
+            subject_id=subject_id,
+            candidates=len(candidates),
+            cap=settings.reconcile_max_candidates,
+        )
+        return candidates, set()
+
+    # Chronological order (oldest first) so "target must be strictly older"
+    # maps onto "smaller index". Stable on id for equal timestamps.
+    candidates.sort(key=lambda m: (getattr(m, "valid_from", None) or _MIN_DT, str(m.id)))
+
+    try:
+        existing = await _select_existing(
+            session, subject_id, candidates, tenant_id=tenant_id
+        )
+    except Exception:
+        logger.warning("reconcile_existing_read_failed", subject_id=subject_id, exc_info=True)
+        return candidates, set()
+
+    # Nothing stored AND a single candidate → nothing to reconcile against.
+    if not existing and len(candidates) == 1:
+        return candidates, set()
+
+    existing_ids = {m.id for m in existing}
+    supersede_existing: set[uuid.UUID] = set()
+    accepted_ids: list[uuid.UUID] = []           # candidate ids kept, in order
+    dropped_ids: set[uuid.UUID] = set()          # candidate ids retired/duplicate
+    cand_by_id: dict[uuid.UUID, MemoryRow] = {m.id: m for m in candidates}
+    max_ctx = settings.reconcile_max_existing
+    chunk_size = max(1, settings.reconcile_chunk_size)
+
+    # Process candidates in chronological chunks. Each chunk is reconciled
+    # against the committed existing memory PLUS the candidates accepted so far,
+    # so duplicates / knowledge-updates are caught across the whole batch (and
+    # across windows of a full-conversation compile) without sending one giant
+    # prompt.
+    for start in range(0, len(candidates), chunk_size):
+        chunk = candidates[start : start + chunk_size]
+        live_accepted = [cand_by_id[i] for i in accepted_ids if i not in dropped_ids]
+        # Context: always keep all committed existing; fill the rest of the
+        # budget with the most-recent accepted candidates (likeliest dedup /
+        # update targets within a conversation).
+        room = max(0, max_ctx - len(existing))
+        ctx_rows = existing + (live_accepted[-room:] if room else [])
+
+        try:
+            parsed = await llm_adapter.acomplete_json(
+                [
+                    {"role": "system", "content": _RECONCILE_SYSTEM_PROMPT},
+                    {"role": "user", "content": _build_user_message(ctx_rows, chunk)},
+                ],
+                model=_compile_model(),
+                temperature=0.0,
+                max_tokens=min(settings.litellm_compile_max_tokens, 4000),
+            )
+        except Exception:
+            logger.warning("reconcile_llm_failed", subject_id=subject_id, exc_info=True)
+            # Keep this chunk wholesale (fail-open) and continue.
+            accepted_ids.extend(m.id for m in chunk)
+            continue
+
+        decisions = parsed.get("decisions") if isinstance(parsed, dict) else None
+        if not isinstance(decisions, list) or not decisions:
+            logger.warning("reconcile_no_decisions", subject_id=subject_id)
+            accepted_ids.extend(m.id for m in chunk)
+            continue
+
+        # Index decisions by chunk-local i.
+        by_i: dict[int, dict] = {}
+        for entry in decisions:
+            if isinstance(entry, dict) and isinstance(entry.get("i"), int):
+                by_i[entry["i"]] = entry
+
+        n_ctx = len(ctx_rows)
+        n_chunk = len(chunk)
+        for j, cand in enumerate(chunk):
+            entry = by_i.get(j)
+            action = str(entry.get("action", "ADD")).upper() if entry else "ADD"
+            if action == "ADD" or not entry:
+                accepted_ids.append(cand.id)
+                continue
+            target = _parse_label(
+                entry.get("target"), n_existing=n_ctx, n_candidates=n_chunk
+            )
+            if target is None:
+                # Missing/invalid target degrades to ADD.
+                accepted_ids.append(cand.id)
+                continue
+            tkind, tidx = target
+            if action == "DUPLICATE":
+                # Redundant with an older target → drop this candidate.
+                dropped_ids.add(cand.id)
+            elif action in ("UPDATE", "DELETE"):
+                # Keep the candidate (newer value / contradiction is itself a
+                # fact); retire the target.
+                accepted_ids.append(cand.id)
+                trow = None
+                if tkind == "E":
+                    trow = ctx_rows[tidx]
+                    if trow.id in existing_ids:
+                        supersede_existing.add(trow.id)
+                    else:
+                        # Target is a previously-accepted candidate → drop it.
+                        dropped_ids.add(trow.id)
+                else:  # N#: target must be strictly older within this chunk.
+                    if tidx < j:
+                        trow = chunk[tidx]
+                        dropped_ids.add(trow.id)
+                # Cumulative/latest-value merge (opt-in, count-neutral): carry the
+                # CURRENT absolute value into the surviving candidate so the fixed
+                # answer model reads it off instead of tracking supersession across
+                # the haystack. Fail-open — any problem leaves the candidate as the
+                # extractor wrote it (today's exact behavior).
+                if (
+                    action == "UPDATE"
+                    and trow is not None
+                    and getattr(settings, "reconcile_cumulative_merge", False)
+                ):
+                    merged = entry.get("merged_content")
+                    if isinstance(merged, str) and merged.strip():
+                        cand.content = merged.strip()
+                        cand.summary = merged.strip()[:200]
+                        try:  # migrate retired row's provenance to the survivor
+                            cand.source_episode_ids = list(
+                                dict.fromkeys(
+                                    list(cand.source_episode_ids or [])
+                                    + list(trow.source_episode_ids or [])
+                                )
+                            )
+                        except Exception:  # pragma: no cover - defensive
+                            pass
+            else:
+                # Unknown action → treat as ADD.
+                accepted_ids.append(cand.id)
+
+    kept = [cand_by_id[i] for i in accepted_ids if i not in dropped_ids]
+
+    # Degenerate guard: only fall back when dropping everything would leave the
+    # subject with NOTHING — no existing memory AND no kept candidate. Dropping
+    # all candidates as duplicates of EXISTING memories is legitimate (the
+    # information is already stored), so we only protect against total loss on a
+    # subject that had no prior memory.
+    if not kept and not existing:
+        logger.warning("reconcile_all_dropped_fallback", subject_id=subject_id)
+        return candidates, set()
+
+    logger.info(
+        "reconcile_done",
+        subject_id=subject_id,
+        candidates=len(candidates),
+        kept=len(kept),
+        dropped=len(dropped_ids),
+        superseded_existing=len(supersede_existing),
+        existing_considered=len(existing),
+    )
+    return kept, supersede_existing

--- a/server/services/reranker.py
+++ b/server/services/reranker.py
@@ -1,0 +1,114 @@
+"""LLM reranker — surface the precise answer fact to the top of retrieval.
+
+Across all three public long-term-memory benchmarks the same pattern held: once
+full-conversation compile makes every fact PRESENT, single-fact-lookup questions
+(LoCoMo single_hop, BEAM information_extraction, LongMemEval single_session_*)
+still miss because the one answer memory ranks mid-pack among 300-500 distinct
+distractors. Neither entity-boost nor top_k tuning fixes it — the right fact
+simply isn't near the top of the hybrid order. A reranker is the principled fix:
+retrieve a generous candidate pool by hybrid similarity, then have an LLM score
+each candidate's relevance to the question and reorder, keeping the best `top_n`
+for the answer model.
+
+Provider-neutral: routes through the central adapter with the compile model
+(gpt-4o-mini in the equal-token bench config), so it stays GPT-only and adds no
+new dependency. Fail-open: any error returns the original hybrid order truncated
+to `top_n`, so a reranker failure can never drop retrieval below the un-reranked
+baseline.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import structlog
+
+from server.core.config import settings
+from server.db.tables import MemoryRow
+from server.services import llm as llm_adapter
+
+logger = structlog.stdlib.get_logger()
+
+_RERANK_SYSTEM_PROMPT = """\
+You are a memory-retrieval reranker. Given a user QUESTION and a numbered list of \
+candidate MEMORIES, return the indices of the memories MOST RELEVANT to answering \
+the question, ordered most-relevant FIRST.
+
+Rules:
+- A memory is relevant if it contains a fact, value, date, name, place, preference, \
+event, or statement the question asks about — including partial or supporting \
+evidence, and facts needed to reason across multiple memories.
+- Order strictly by how directly each memory helps answer THIS question.
+- Include every plausibly-relevant memory; omit only clearly-irrelevant ones.
+- Return AT MOST {top_n} indices.
+- Return ONLY a JSON object: {{"ranked": [<indices, most relevant first>]}}."""
+
+
+def _compile_model() -> str:
+    return getattr(settings, "litellm_compile_model", None) or settings.litellm_model
+
+
+def _rerank_model() -> str:
+    # Reranking is relevance judgment — a stronger model than the compile model
+    # is worth the single call/query. Falls back to the compile model.
+    return getattr(settings, "rerank_model", "") or _compile_model()
+
+
+async def rerank_memories(
+    query: str,
+    candidates: Sequence[MemoryRow],
+    top_n: int,
+    *,
+    model: str | None = None,
+) -> list[MemoryRow]:
+    """Reorder `candidates` by LLM-judged relevance to `query`, return top_n.
+
+    Fail-open: returns ``list(candidates)[:top_n]`` (original order) on any
+    problem, so reranking never makes retrieval worse than the input order."""
+    cands = list(candidates)
+    if not query or len(cands) <= 1 or len(cands) <= top_n:
+        # Nothing to filter — reordering alone rarely helps the answer model and
+        # isn't worth an LLM call.
+        return cands[:top_n]
+    if len(cands) > settings.rerank_max_pool:
+        cands = cands[: settings.rerank_max_pool]
+
+    listing = "\n".join(f"{i}: {c.content}" for i, c in enumerate(cands))
+    user = f"QUESTION: {query}\n\nMEMORIES:\n{listing}"
+    try:
+        parsed = await llm_adapter.acomplete_json(
+            [
+                {"role": "system", "content": _RERANK_SYSTEM_PROMPT.format(top_n=top_n)},
+                {"role": "user", "content": user},
+            ],
+            model=model or _rerank_model(),
+            temperature=0.0,
+            max_tokens=min(settings.litellm_compile_max_tokens, 2000),
+        )
+    except Exception:
+        logger.warning("rerank_llm_failed", exc_info=True)
+        return cands[:top_n]
+
+    ranked = parsed.get("ranked") if isinstance(parsed, dict) else None
+    if not isinstance(ranked, list) or not ranked:
+        return cands[:top_n]
+
+    seen: set[int] = set()
+    ordered: list[MemoryRow] = []
+    for idx in ranked:
+        if isinstance(idx, int) and 0 <= idx < len(cands) and idx not in seen:
+            seen.add(idx)
+            ordered.append(cands[idx])
+        if len(ordered) >= top_n:
+            break
+    # Backfill from the original hybrid order so we always return up to top_n
+    # even if the model returned too few indices (fail-safe, never under-fill).
+    if len(ordered) < top_n:
+        for i, c in enumerate(cands):
+            if i not in seen:
+                ordered.append(c)
+                if len(ordered) >= top_n:
+                    break
+
+    logger.info("rerank_done", pool=len(cands), returned=len(ordered), top_n=top_n)
+    return ordered[:top_n]

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,173 @@
+"""Tests for compile-time near-duplicate dedup (server/services/dedup.py).
+
+Pure unit tests of the collapse logic + safety gates. Tiers 1-2 need no DB; the
+semantic pass uses a fake embedding provider so cosine behaviour is deterministic.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.db.tables import MemoryRow
+from server.services import dedup
+
+
+def _mem(content: str, *, kind: str = "profile_fact", days_ago: int = 0,
+         conf: float = 0.8, mid: uuid.UUID | None = None) -> MemoryRow:
+    when = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return MemoryRow(
+        id=mid or uuid.uuid4(),
+        subject_id="user-1",
+        kind=kind,
+        content=content,
+        summary=content[:200],
+        confidence=conf,
+        valid_from=when,
+        source_episode_ids=[uuid.uuid4()],
+        metadata_={},
+        status="active",
+    )
+
+
+class _FakeProvider:
+    """Maps each text to a fixed vector so cosine is deterministic in tests."""
+    provides_semantic_similarity = True
+
+    def __init__(self, vectors: dict[str, list[float]]):
+        self._v = vectors
+
+    async def embed_texts(self, texts):
+        return [self._v[t] for t in texts]
+
+
+# ── Pass 1: exact normalized-text collapse (no embeddings) ──────────────────
+
+@pytest.mark.asyncio
+async def test_exact_normalized_duplicates_collapse():
+    # Same fact, differing only in case / whitespace / trailing punctuation —
+    # the windowing-overlap signature. Semantic pass off to isolate Pass 1.
+    a = _mem("Alice lives in Berlin", days_ago=5)
+    b = _mem("alice   lives in berlin.", days_ago=2)
+    c = _mem("Alice owns a red bike", days_ago=1)
+    with patch.object(dedup.settings, "dedup_semantic_enabled", False):
+        out = await dedup.dedup_candidates([a, b, c])
+    contents = {m.content for m in out}
+    assert len(out) == 2                       # a/b collapsed, c kept
+    assert "Alice owns a red bike" in contents
+
+
+@pytest.mark.asyncio
+async def test_merge_unions_provenance_and_keeps_earliest_date():
+    e1, e2 = uuid.uuid4(), uuid.uuid4()
+    a = _mem("Bob works at Globex", days_ago=10)
+    a.source_episode_ids = [e1]
+    b = _mem("bob works at globex", days_ago=2)
+    b.source_episode_ids = [e2]
+    with patch.object(dedup.settings, "dedup_semantic_enabled", False):
+        out = await dedup.dedup_candidates([a, b])
+    assert len(out) == 1
+    survivor = out[0]
+    assert set(survivor.source_episode_ids) == {e1, e2}     # provenance preserved
+    assert survivor.valid_from == a.valid_from              # earliest origin kept
+
+
+# ── Pass 2: semantic clustering + the three safety gates ────────────────────
+
+@pytest.mark.asyncio
+async def test_word_order_variant_merges():
+    # Same fact, reordered with stopword/punct differences (the windowing-
+    # reformat case): identical significant content words + high cosine -> merge.
+    a = _mem("Alice bought purple running shoes", days_ago=3)
+    b = _mem("purple running shoes were bought by Alice", days_ago=1)
+    prov = _FakeProvider({a.content: [1.0, 0.0], b.content: [0.99, 0.01]})
+    out = await dedup.dedup_candidates([a, b], provider=prov)
+    assert len(out) == 1
+
+
+@pytest.mark.asyncio
+async def test_number_guard_keeps_knowledge_update_pairs_distinct():
+    # Same surface form, DIFFERENT value: must NOT merge (reconcile's job).
+    a = _mem("API averages 250ms response time", days_ago=5)
+    b = _mem("API averages 90ms response time", days_ago=1)
+    # Force high cosine so only the number guard can save us.
+    prov = _FakeProvider({a.content: [1.0, 0.0], b.content: [1.0, 0.0]})
+    out = await dedup.dedup_candidates([a, b], provider=prov)
+    assert len(out) == 2                        # number-set differs -> kept apart
+
+
+@pytest.mark.asyncio
+async def test_lexical_gate_blocks_topically_close_distinct_facts():
+    # High cosine, no distinguishing number, but low token overlap ("Mia" vs
+    # "Mary") -> the Jaccard gate must keep them separate.
+    a = _mem("User has a daughter named Mia", days_ago=3)
+    b = _mem("User has a daughter named Mary", days_ago=1)
+    prov = _FakeProvider({a.content: [1.0, 0.0], b.content: [0.999, 0.0]})
+    out = await dedup.dedup_candidates([a, b], provider=prov)
+    assert len(out) == 2
+
+
+@pytest.mark.asyncio
+async def test_kind_gating_prevents_cross_kind_merge():
+    # Identical text, different kind -> neither Pass 1 (keyed on kind+content)
+    # nor Pass 2 (kind-gated) may merge them.
+    a = _mem("Project uses Postgres for storage", kind="profile_fact", days_ago=3)
+    b = _mem("Project uses Postgres for storage", kind="episode_summary", days_ago=1)
+    prov = _FakeProvider({a.content: [1.0, 0.0], b.content: [1.0, 0.0]})
+    out = await dedup.dedup_candidates([a, b], provider=prov)
+    assert len(out) == 2                        # different kinds never merge
+
+
+@pytest.mark.asyncio
+async def test_semantic_survivors_get_embeddings_stapled():
+    a = _mem("Dana plays the cello", days_ago=2)
+    b = _mem("Dana enjoys astronomy", days_ago=1)
+    prov = _FakeProvider({a.content: [1.0, 0.0], b.content: [0.0, 1.0]})  # orthogonal
+    out = await dedup.dedup_candidates([a, b], provider=prov)
+    assert len(out) == 2
+    assert all(m.embedding is not None for m in out)   # reused for .embedding col
+
+
+# ── Fail-open / guards ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_stub_provider_runs_exact_pass_only():
+    class _Stub:
+        provides_semantic_similarity = False
+        async def embed_texts(self, texts):  # pragma: no cover - must not be called
+            raise AssertionError("stub must not be embedded")
+    a = _mem("X happened", days_ago=2)
+    b = _mem("x happened.", days_ago=1)          # exact-normalized dup
+    c = _mem("Totally different fact", days_ago=1)
+    out = await dedup.dedup_candidates([a, b, c], provider=_Stub())
+    assert len(out) == 2                          # exact pass still collapsed a/b
+
+
+@pytest.mark.asyncio
+async def test_embed_failure_falls_back_to_exact_pass():
+    a = _mem("alpha fact one", days_ago=2)
+    b = _mem("beta fact two", days_ago=1)
+    prov = _FakeProvider({})
+    prov.embed_texts = AsyncMock(side_effect=RuntimeError("boom"))
+    out = await dedup.dedup_candidates([a, b], provider=prov)
+    assert len(out) == 2                          # no crash; exact-pass survivors
+
+
+@pytest.mark.asyncio
+async def test_disabled_returns_unchanged():
+    a = _mem("same", days_ago=2)
+    b = _mem("same", days_ago=1)
+    with patch.object(dedup.settings, "dedup_compile_enabled", False):
+        out = await dedup.dedup_candidates([a, b])
+    assert len(out) == 2
+
+
+@pytest.mark.asyncio
+async def test_large_batch_skipped():
+    cands = [_mem(f"fact {i}", days_ago=i % 30) for i in range(50)]
+    with patch.object(dedup.settings, "dedup_max_candidates", 10):
+        out = await dedup.dedup_candidates(cands)
+    assert len(out) == 50                         # untouched above the ceiling

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 26
+    assert len(revs) == 28
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 16
+    assert result.pending_count == 18
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 26
+    assert result.pending_count == 28
 
 
 def test_resolve_pending_unknown_revision():

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,217 @@
+"""Tests for the context-aware compile reconcile (Phase 4 + 5b).
+
+Covers the decision-application logic (ADD / DUPLICATE / UPDATE / DELETE,
+existing-target vs candidate-target) and the fail-open guarantees. The LLM
+call and the existing-memory read are mocked, so these are pure unit tests of
+the apply logic — no DB, no provider.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from server.db.tables import MemoryRow
+from server.services import reconcile
+
+
+def _mem(content: str, *, days_ago: int = 0, mid: uuid.UUID | None = None) -> MemoryRow:
+    when = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return MemoryRow(
+        id=mid or uuid.uuid4(),
+        subject_id="user-1",
+        kind="profile_fact",
+        content=content,
+        summary=content[:200],
+        confidence=0.8,
+        valid_from=when,
+        source_episode_ids=[uuid.uuid4()],
+        metadata_={},
+        status="active",
+    )
+
+
+def _patch(existing, decisions=None, llm_exc=None):
+    """Patch the repo read + LLM call. Returns the context-manager stack via a
+    helper that yields the patched acomplete_json mock."""
+    list_mock = AsyncMock(return_value=existing)
+    if llm_exc is not None:
+        llm_mock = AsyncMock(side_effect=llm_exc)
+    else:
+        llm_mock = AsyncMock(return_value={"decisions": decisions or []})
+    return (
+        patch.object(reconcile.repo, "list_active_memories_by_subject", list_mock),
+        patch.object(reconcile.llm_adapter, "acomplete_json", llm_mock),
+        llm_mock,
+    )
+
+
+@pytest.mark.asyncio
+async def test_all_add_keeps_everything():
+    session = MagicMock()
+    c0 = _mem("Alice likes coffee", days_ago=2)
+    c1 = _mem("Alice hikes on weekends", days_ago=1)
+    p_list, p_llm, _ = _patch([], decisions=[
+        {"i": 0, "action": "ADD", "target": None},
+        {"i": 1, "action": "ADD", "target": None},
+    ])
+    with p_list, p_llm:
+        kept, superseded = await reconcile.reconcile_compile_batch(
+            session, "user-1", [c0, c1]
+        )
+    assert {m.id for m in kept} == {c0.id, c1.id}
+    assert superseded == set()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_of_existing_is_dropped():
+    session = MagicMock()
+    e0 = _mem("Alice lives in Munich", days_ago=30)
+    c0 = _mem("Alice lives in Munich", days_ago=1)
+    p_list, p_llm, _ = _patch([e0], decisions=[
+        {"i": 0, "action": "DUPLICATE", "target": "E0"},
+    ])
+    with p_list, p_llm:
+        kept, superseded = await reconcile.reconcile_compile_batch(
+            session, "user-1", [c0]
+        )
+    assert kept == []          # the duplicate is dropped
+    assert superseded == set() # existing memory untouched
+
+
+@pytest.mark.asyncio
+async def test_update_of_existing_supersedes_old_keeps_new():
+    session = MagicMock()
+    e0 = _mem("Alice lives in Munich", days_ago=30)
+    c0 = _mem("Alice moved to Berlin in 2024", days_ago=1)
+    p_list, p_llm, _ = _patch([e0], decisions=[
+        {"i": 0, "action": "UPDATE", "target": "E0"},
+    ])
+    with p_list, p_llm:
+        kept, superseded = await reconcile.reconcile_compile_batch(
+            session, "user-1", [c0]
+        )
+    assert [m.id for m in kept] == [c0.id]   # new value kept
+    assert superseded == {e0.id}             # stale value superseded
+
+
+@pytest.mark.asyncio
+async def test_delete_of_existing_supersedes_and_keeps_statement():
+    session = MagicMock()
+    e0 = _mem("Project uses Stripe", days_ago=20)
+    c0 = _mem("Project stopped using Stripe", days_ago=1)
+    p_list, p_llm, _ = _patch([e0], decisions=[
+        {"i": 0, "action": "DELETE", "target": "E0"},
+    ])
+    with p_list, p_llm:
+        kept, superseded = await reconcile.reconcile_compile_batch(
+            session, "user-1", [c0]
+        )
+    assert [m.id for m in kept] == [c0.id]
+    assert superseded == {e0.id}
+
+
+@pytest.mark.asyncio
+async def test_intra_candidate_update_drops_older_candidate():
+    session = MagicMock()
+    # Two candidates in the SAME batch (no existing memory). The older one is
+    # superseded by the newer — this is the LoCoMo single-batch case.
+    c_old = _mem("API averages 250ms", days_ago=10)
+    c_new = _mem("API now averages 90ms", days_ago=1)
+    p_list, p_llm, _ = _patch([], decisions=[
+        {"i": 0, "action": "ADD", "target": None},        # c_old (chrono idx 0)
+        {"i": 1, "action": "UPDATE", "target": "N0"},     # c_new updates c_old
+    ])
+    with p_list, p_llm:
+        kept, superseded = await reconcile.reconcile_compile_batch(
+            session, "user-1", [c_new, c_old]  # pass out of order; reconcile sorts
+        )
+    # c_old (N0) dropped, c_new (N1) kept; no EXISTING memory touched.
+    assert [m.id for m in kept] == [c_new.id]
+    assert superseded == set()
+
+
+@pytest.mark.asyncio
+async def test_failopen_on_llm_error_keeps_all():
+    session = MagicMock()
+    c0 = _mem("fact one", days_ago=2)
+    c1 = _mem("fact two", days_ago=1)
+    p_list, p_llm, _ = _patch([_mem("existing")], llm_exc=RuntimeError("boom"))
+    with p_list, p_llm:
+        kept, superseded = await reconcile.reconcile_compile_batch(
+            session, "user-1", [c0, c1]
+        )
+    assert {m.id for m in kept} == {c0.id, c1.id}
+    assert superseded == set()
+
+
+@pytest.mark.asyncio
+async def test_all_duplicate_of_existing_drops_all_legitimately():
+    session = MagicMock()
+    c0 = _mem("a", days_ago=2)
+    c1 = _mem("b", days_ago=1)
+    # Every candidate is already represented by an EXISTING memory → dropping
+    # the whole batch is correct (the information is already stored). The
+    # total-loss guard does NOT fire because existing memory is non-empty.
+    p_list, p_llm, _ = _patch([_mem("x")], decisions=[
+        {"i": 0, "action": "DUPLICATE", "target": "E0"},
+        {"i": 1, "action": "DUPLICATE", "target": "E0"},
+    ])
+    with p_list, p_llm:
+        kept, superseded = await reconcile.reconcile_compile_batch(
+            session, "user-1", [c0, c1]
+        )
+    assert kept == []
+    assert superseded == set()
+
+
+@pytest.mark.asyncio
+async def test_large_batch_is_chunked_not_skipped():
+    session = MagicMock()
+    cands = [_mem(f"fact {i}", days_ago=i) for i in range(200)]
+    # All-ADD decisions for every chunk (the mock returns the same shape each
+    # call; only indices 0..39 are read per chunk, so a generous list works).
+    p_list, p_llm, llm_mock = _patch([], decisions=[
+        {"i": j, "action": "ADD", "target": None} for j in range(40)
+    ])
+    with p_list, p_llm:
+        kept, superseded = await reconcile.reconcile_compile_batch(
+            session, "user-1", cands
+        )
+    assert len(kept) == 200                     # all kept
+    assert superseded == set()
+    assert llm_mock.await_count == 5            # 200 / chunk_size(40) = 5 calls
+
+
+@pytest.mark.asyncio
+async def test_single_candidate_no_existing_short_circuits():
+    session = MagicMock()
+    c0 = _mem("only fact")
+    p_list, p_llm, llm_mock = _patch([], decisions=[])
+    with p_list, p_llm:
+        kept, superseded = await reconcile.reconcile_compile_batch(
+            session, "user-1", [c0]
+        )
+    assert [m.id for m in kept] == [c0.id]
+    assert superseded == set()
+    llm_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_malformed_target_degrades_to_add():
+    session = MagicMock()
+    e0 = _mem("existing fact", days_ago=5)
+    c0 = _mem("new fact", days_ago=1)
+    # UPDATE with an out-of-range / junk target → keep candidate, retire nothing.
+    p_list, p_llm, _ = _patch([e0], decisions=[
+        {"i": 0, "action": "UPDATE", "target": "E9"},
+    ])
+    with p_list, p_llm:
+        kept, superseded = await reconcile.reconcile_compile_batch(
+            session, "user-1", [c0]
+        )
+    assert [m.id for m in kept] == [c0.id]
+    assert superseded == set()

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,0 +1,70 @@
+"""Tests for the LLM reranker (server/services/reranker.py)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.db.tables import MemoryRow
+from server.services import reranker
+
+
+def _mem(content: str) -> MemoryRow:
+    return MemoryRow(
+        id=uuid.uuid4(), subject_id="s", kind="profile_fact", content=content,
+        summary=content[:200], confidence=0.8,
+        valid_from=datetime.now(timezone.utc), source_episode_ids=[uuid.uuid4()],
+        metadata_={}, status="active",
+    )
+
+
+@pytest.mark.asyncio
+async def test_rerank_reorders_and_truncates_to_top_n():
+    cands = [_mem(f"fact {i}") for i in range(6)]
+    # Model says the most relevant are 4, 1, 5 (in that order).
+    llm = AsyncMock(return_value={"ranked": [4, 1, 5]})
+    with patch.object(reranker.llm_adapter, "acomplete_json", llm):
+        out = await reranker.rerank_memories("q", cands, top_n=3)
+    assert [m.content for m in out] == ["fact 4", "fact 1", "fact 5"]
+
+
+@pytest.mark.asyncio
+async def test_rerank_backfills_when_model_returns_too_few():
+    cands = [_mem(f"fact {i}") for i in range(6)]
+    llm = AsyncMock(return_value={"ranked": [2]})        # only one index
+    with patch.object(reranker.llm_adapter, "acomplete_json", llm):
+        out = await reranker.rerank_memories("q", cands, top_n=4)
+    assert len(out) == 4                                  # backfilled to top_n
+    assert out[0].content == "fact 2"                     # model's pick first
+    assert len({m.content for m in out}) == 4             # no dupes
+
+
+@pytest.mark.asyncio
+async def test_rerank_ignores_out_of_range_indices():
+    cands = [_mem(f"fact {i}") for i in range(4)]
+    llm = AsyncMock(return_value={"ranked": [99, 1, -1, 0]})
+    with patch.object(reranker.llm_adapter, "acomplete_json", llm):
+        out = await reranker.rerank_memories("q", cands, top_n=2)
+    assert [m.content for m in out] == ["fact 1", "fact 0"]
+
+
+@pytest.mark.asyncio
+async def test_rerank_failopen_on_llm_error():
+    cands = [_mem(f"fact {i}") for i in range(6)]
+    llm = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch.object(reranker.llm_adapter, "acomplete_json", llm):
+        out = await reranker.rerank_memories("q", cands, top_n=3)
+    assert [m.content for m in out] == ["fact 0", "fact 1", "fact 2"]  # hybrid order
+
+
+@pytest.mark.asyncio
+async def test_rerank_skips_llm_when_pool_not_larger_than_top_n():
+    cands = [_mem(f"fact {i}") for i in range(3)]
+    llm = AsyncMock(return_value={"ranked": [2, 1, 0]})
+    with patch.object(reranker.llm_adapter, "acomplete_json", llm):
+        out = await reranker.rerank_memories("q", cands, top_n=5)
+    assert len(out) == 3
+    llm.assert_not_called()                               # nothing to filter


### PR DESCRIPTION
## What & why

Productizes the retrieval + compile improvements validated by the public
benchmark (**LoCoMo 0.905, LongMemEval 0.967**). Those numbers were produced on
this optimized stack, not on `main` — so until this ships, released Statewave
can't reproduce them. This closes that gap.

## What's in it

**Retrieval**
- Hybrid search: semantic (pgvector) + BM25 (`ts_rank_cd`); migration `0027` adds the content tsvector. **Default ON.**
- Subject entity store (migration `0028`) + entity-boost lane + LLM reranker — **OFF by default** (`entity_weight=0`, `rerank=false`).
- Search limit cap 100 → 500.

**Compile**
- Near-dup dedup, context-aware reconcile + assistant-fact extraction, technical-spec/metric extraction, windowed compile + chunked reconcile, configurable extraction concurrency.

**LLM**
- Provider-aware key routing, token usage in `/v1/llm/complete`, JSON output for Anthropic, model-aware `reasoning_effort` + temperature (gpt-5 / o-series).

## Productization decisions

- **Default search = hybrid ON + `entity_weight=0`** (entity-boost off).
- **Embedding schema fixed at `vector(1536)`** (text-embedding-3-small). Applied migrations `0013`/`0014` left untouched. **No breaking change** for existing deployments.
- Version **1.2.0 → 1.3.0**.

## Status: DRAFT — gates before merge

- [ ] Full CI green
- [ ] Benchmark sanity re-run confirms it still hits ~0.905 / 0.967
- [ ] Review

Local checks green: ruff, py_compile, migration chain (`0026 → 0027 → 0028`), integration + LLM + migration tests.
