### PR TITLE
fix(admin): harden bulk delete matching

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -7,7 +7,7 @@ from typing import Literal, Optional
 
 import structlog
 from fastapi import APIRouter, Header, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from server.core.config import settings
 from server.schemas.requests import TenantConfigPatch
@@ -2927,7 +2927,7 @@ class BulkDeleteFilter(BaseModel):
     subject_id_prefix: str | None = None
     """Match subjects whose id starts with this prefix (e.g. 'demo_web_')."""
 
-    older_than_days: int | None = None
+    older_than_days: int | None = Field(default=None, ge=1)
     """Match subjects whose most recent episode is older than N days."""
 
     tenant_id: str | None = None
@@ -2999,8 +2999,9 @@ async def _matching_subjects(
     from server.db.tables import EpisodeRow, MemoryRow
 
     async with engine_module.get_session_factory()() as session:
-        # Aggregate per (subject_id, tenant_id) from episodes — this is the
-        # authoritative grouping used elsewhere in admin.
+        # Aggregate per (subject_id, tenant_id) from both episodes and
+        # memories. Some subjects can be memory-only after import/clone flows,
+        # and a destructive admin preview must account for them too.
         ep_stmt = select(
             EpisodeRow.subject_id,
             EpisodeRow.tenant_id,
@@ -3008,7 +3009,8 @@ async def _matching_subjects(
             func.max(EpisodeRow.created_at).label("last_episode_at"),
         ).group_by(EpisodeRow.subject_id, EpisodeRow.tenant_id)
         if f.subject_id_prefix:
-            ep_stmt = ep_stmt.where(EpisodeRow.subject_id.like(f"{f.subject_id_prefix}%"))
+            prefix_pattern = f"{_like_escape(f.subject_id_prefix)}%"
+            ep_stmt = ep_stmt.where(EpisodeRow.subject_id.like(prefix_pattern, escape="\\"))
         if f.tenant_id:
             ep_stmt = ep_stmt.where(EpisodeRow.tenant_id == f.tenant_id)
         if f.older_than_days is not None:
@@ -3022,35 +3024,63 @@ async def _matching_subjects(
                 sub.c.last_episode_at,
             ).where(sub.c.last_episode_at < cutoff)
 
-        rows = (await session.execute(ep_stmt)).all()
+        ep_rows = (await session.execute(ep_stmt)).all()
 
-        # Memory counts per subject — separate query for clarity.
+        mem_stmt = select(
+            MemoryRow.subject_id,
+            MemoryRow.tenant_id,
+            func.count().label("mem_count"),
+        ).group_by(MemoryRow.subject_id, MemoryRow.tenant_id)
+        if f.subject_id_prefix:
+            prefix_pattern = f"{_like_escape(f.subject_id_prefix)}%"
+            mem_stmt = mem_stmt.where(MemoryRow.subject_id.like(prefix_pattern, escape="\\"))
+        if f.tenant_id:
+            mem_stmt = mem_stmt.where(MemoryRow.tenant_id == f.tenant_id)
+        mem_rows = (await session.execute(mem_stmt)).all()
+
+        def _row_matches_filter(subject_id: str, tenant_id: str | None) -> bool:
+            if f.subject_id_prefix and not subject_id.startswith(f.subject_id_prefix):
+                return False
+            if f.tenant_id and tenant_id != f.tenant_id:
+                return False
+            return True
+
+        ep_counts: dict[tuple[str, str | None], int] = {}
+        last_episode_at: dict[tuple[str, str | None], datetime | None] = {}
+        for r in ep_rows:
+            if not _row_matches_filter(r.subject_id, r.tenant_id):
+                continue
+            key = (r.subject_id, r.tenant_id)
+            ep_counts[key] = r.ep_count
+            last_episode_at[key] = r.last_episode_at
+
         mem_counts: dict[tuple[str, str | None], int] = {}
-        if rows:
-            mem_stmt = (
-                select(
-                    MemoryRow.subject_id,
-                    MemoryRow.tenant_id,
-                    func.count().label("mem_count"),
-                )
-                .where(MemoryRow.subject_id.in_([r.subject_id for r in rows]))
-                .group_by(MemoryRow.subject_id, MemoryRow.tenant_id)
-            )
-            for m in (await session.execute(mem_stmt)).all():
-                mem_counts[(m.subject_id, m.tenant_id)] = m.mem_count
+        for m in mem_rows:
+            if not _row_matches_filter(m.subject_id, m.tenant_id):
+                continue
+            mem_counts[(m.subject_id, m.tenant_id)] = m.mem_count
 
-    total_eps = sum(r.ep_count for r in rows)
-    total_mems = sum(mem_counts.values())
+    if f.older_than_days is not None:
+        # Age is defined by the most recent episode. Memory-only subjects do
+        # not have a last episode timestamp, so only the age-filtered episode
+        # aggregate can admit keys for this selector.
+        matched_keys = set(ep_counts)
+    else:
+        matched_keys = set(ep_counts) | set(mem_counts)
+
+    total_eps = sum(ep_counts.get(key, 0) for key in matched_keys)
+    total_mems = sum(mem_counts.get(key, 0) for key in matched_keys)
 
     matches: list[BulkDeleteSample] = []
-    for r in rows:
+    for subject_id, tenant_id in sorted(matched_keys, key=lambda k: (k[0], k[1] or "")):
+        last_seen = last_episode_at.get((subject_id, tenant_id))
         matches.append(
             BulkDeleteSample(
-                subject_id=r.subject_id,
-                tenant_id=r.tenant_id,
-                episode_count=r.ep_count,
-                memory_count=mem_counts.get((r.subject_id, r.tenant_id), 0),
-                last_episode_at=r.last_episode_at.isoformat() if r.last_episode_at else None,
+                subject_id=subject_id,
+                tenant_id=tenant_id,
+                episode_count=ep_counts.get((subject_id, tenant_id), 0),
+                memory_count=mem_counts.get((subject_id, tenant_id), 0),
+                last_episode_at=last_seen.isoformat() if last_seen else None,
             )
         )
     return matches, total_eps, total_mems
@@ -3120,6 +3150,33 @@ async def preview_bulk_delete(filter: BulkDeleteFilter):
     )
 
 
+async def _delete_subject_key(session, subject_id: str, tenant_id: str | None) -> tuple[int, int]:
+    """Delete exactly one concrete (subject_id, tenant_id) key.
+
+    Repository delete helpers keep their public single-tenant behavior where
+    tenant_id=None means "no tenant filter". Bulk delete works from concrete
+    preview samples, so None must instead mean the global tenant key.
+    """
+    from sqlalchemy import delete
+
+    from server.db.tables import EpisodeRow, MemoryRow, ResolutionRow, SubjectHealthCacheRow
+
+    async def _delete_from(row_model) -> int:
+        stmt = delete(row_model).where(row_model.subject_id == subject_id)
+        if tenant_id is None:
+            stmt = stmt.where(row_model.tenant_id.is_(None))
+        else:
+            stmt = stmt.where(row_model.tenant_id == tenant_id)
+        result = await session.execute(stmt)
+        return int(result.rowcount or 0)
+
+    ep_n = await _delete_from(EpisodeRow)
+    mem_n = await _delete_from(MemoryRow)
+    await _delete_from(ResolutionRow)
+    await _delete_from(SubjectHealthCacheRow)
+    return ep_n, mem_n
+
+
 @router.post("/subjects/bulk-delete", response_model=BulkDeleteResult)
 async def commit_bulk_delete(req: BulkDeleteCommitRequest):
     """Commit a previously previewed filtered bulk delete.
@@ -3129,8 +3186,6 @@ async def commit_bulk_delete(req: BulkDeleteCommitRequest):
     request is rejected with 409 — the operator must re-preview.
     """
     from server.db import engine as engine_module
-    from server.db import repositories as repo
-
     if not req.confirm:
         raise HTTPException(status_code=400, detail="confirm must be true to commit a bulk delete")
     if _filter_is_empty(req):
@@ -3162,18 +3217,7 @@ async def commit_bulk_delete(req: BulkDeleteCommitRequest):
     async with engine_module.get_session_factory()() as session:
         for s in matches:
             try:
-                ep_n = await repo.delete_episodes_by_subject(
-                    session, s.subject_id, tenant_id=s.tenant_id
-                )
-                mem_n = await repo.delete_memories_by_subject(
-                    session, s.subject_id, tenant_id=s.tenant_id
-                )
-                await repo.delete_resolutions_by_subject(
-                    session, s.subject_id, tenant_id=s.tenant_id
-                )
-                await repo.delete_health_cache_by_subject(
-                    session, s.subject_id, tenant_id=s.tenant_id
-                )
+                ep_n, mem_n = await _delete_subject_key(session, s.subject_id, s.tenant_id)
                 await session.commit()
                 deleted_subjects += 1
                 deleted_eps += ep_n

--- a/tests/test_admin_bulk_delete_matching.py
+++ b/tests/test_admin_bulk_delete_matching.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.dialects import postgresql
+
+from server.api.admin import (
+    BulkDeleteCommitRequest,
+    BulkDeleteFilter,
+    BulkDeleteSample,
+    _delete_subject_key,
+    _matching_subjects,
+    commit_bulk_delete,
+)
+
+
+class _Rows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _Rowcount:
+    def __init__(self, rowcount):
+        self.rowcount = rowcount
+
+
+class _FakeSession:
+    def __init__(self, *, episode_rows=None, memory_rows=None):
+        self._results = [
+            list(episode_rows or []),
+            list(memory_rows or []),
+        ]
+        self.statements = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _Rows(self._results.pop(0))
+
+    async def commit(self):
+        self.commits += 1
+
+    async def rollback(self):
+        self.rollbacks += 1
+
+
+class _DeleteSession:
+    def __init__(self, rowcounts):
+        self._rowcounts = list(rowcounts)
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _Rowcount(self._rowcounts.pop(0))
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _install_session(monkeypatch, session):
+    monkeypatch.setattr(
+        "server.db.engine.get_session_factory",
+        lambda: lambda: _FakeSessionContext(session),
+    )
+
+
+def _row(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def _compiled(statement):
+    return statement.compile(dialect=postgresql.dialect())
+
+
+@pytest.mark.anyio
+async def test_matching_subjects_includes_memory_only_subjects(monkeypatch):
+    session = _FakeSession(
+        episode_rows=[],
+        memory_rows=[
+            _row(subject_id="memory-only", tenant_id="tenant-a", mem_count=2),
+        ],
+    )
+    _install_session(monkeypatch, session)
+
+    matches, total_eps, total_mems = await _matching_subjects(
+        BulkDeleteFilter(tenant_id="tenant-a")
+    )
+
+    assert total_eps == 0
+    assert total_mems == 2
+    assert [m.model_dump() for m in matches] == [
+        {
+            "subject_id": "memory-only",
+            "tenant_id": "tenant-a",
+            "episode_count": 0,
+            "memory_count": 2,
+            "last_episode_at": None,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_matching_subjects_sums_memory_counts_only_for_matched_tenant(monkeypatch):
+    session = _FakeSession(
+        episode_rows=[
+            _row(
+                subject_id="shared",
+                tenant_id="tenant-a",
+                ep_count=1,
+                last_episode_at=None,
+            ),
+        ],
+        memory_rows=[
+            _row(subject_id="shared", tenant_id="tenant-a", mem_count=2),
+            # Defensive: even if a future query regression fetched this row,
+            # totals must only include the concrete matched key.
+            _row(subject_id="shared", tenant_id="tenant-b", mem_count=7),
+        ],
+    )
+    _install_session(monkeypatch, session)
+
+    matches, total_eps, total_mems = await _matching_subjects(
+        BulkDeleteFilter(tenant_id="tenant-a")
+    )
+
+    assert total_eps == 1
+    assert total_mems == 2
+    assert matches[0].memory_count == 2
+
+
+@pytest.mark.anyio
+async def test_matching_subjects_escapes_prefix_like_metacharacters(monkeypatch):
+    session = _FakeSession()
+    _install_session(monkeypatch, session)
+
+    await _matching_subjects(BulkDeleteFilter(subject_id_prefix="demo_web_"))
+
+    for statement in session.statements:
+        compiled = _compiled(statement)
+        assert " ESCAPE '\\\\'" in str(compiled)
+        assert "demo\\_web\\_%" in set(compiled.params.values())
+
+
+@pytest.mark.anyio
+async def test_delete_subject_key_treats_none_tenant_as_global_only():
+    session = _DeleteSession(rowcounts=[1, 2, 3, 4])
+
+    ep_count, mem_count = await _delete_subject_key(session, "shared", tenant_id=None)
+
+    assert (ep_count, mem_count) == (1, 2)
+    assert len(session.statements) == 4
+    for statement in session.statements:
+        sql = str(_compiled(statement))
+        assert "tenant_id IS NULL" in sql
+        assert "tenant_id =" not in sql
+
+
+@pytest.mark.anyio
+async def test_commit_bulk_delete_uses_concrete_none_tenant_key(monkeypatch):
+    session = _FakeSession()
+    _install_session(monkeypatch, session)
+    calls = []
+
+    async def fake_matching(_req):
+        return (
+            [
+                BulkDeleteSample(
+                    subject_id="global-subject",
+                    tenant_id=None,
+                    episode_count=0,
+                    memory_count=1,
+                    last_episode_at=None,
+                )
+            ],
+            0,
+            1,
+        )
+
+    async def fake_delete_subject_key(session_arg, subject_id, tenant_id):
+        calls.append((session_arg, subject_id, tenant_id))
+        return 0, 1
+
+    async def fake_fire(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("server.api.admin._matching_subjects", fake_matching)
+    monkeypatch.setattr("server.api.admin._delete_subject_key", fake_delete_subject_key)
+    monkeypatch.setattr("server.api.admin.webhooks.fire", fake_fire)
+
+    result = await commit_bulk_delete(
+        BulkDeleteCommitRequest(match_all=True, expected_count=1, confirm=True)
+    )
+
+    assert calls == [(session, "global-subject", None)]
+    assert result.deleted_subjects == 1
+    assert result.deleted_episodes == 0
+    assert result.deleted_memories == 1
+    assert session.commits == 1
+    assert session.rollbacks == 0
+
+
+@pytest.mark.parametrize("older_than_days", [-1, 0])
+def test_bulk_delete_filter_rejects_non_positive_age(older_than_days):
+    with pytest.raises(ValidationError):
+        BulkDeleteFilter(older_than_days=older_than_days)


### PR DESCRIPTION
## Summary
- include memory-only subjects in admin bulk-delete previews and totals
- keep episode/memory counts keyed by concrete `(subject_id, tenant_id)` pairs, with literal prefix escaping
- delete bulk matches by exact tenant key so global rows use `tenant_id IS NULL`, and reject non-positive `older_than_days`

## Tests
- `STATEWAVE_EMBEDDING_PROVIDER=stub STATEWAVE_COMPILER_TYPE=heuristic PYTHONUTF8=1 .\.venv\Scripts\python.exe -m pytest tests/test_admin_bulk_delete_matching.py -q`
- `.\.venv\Scripts\ruff.exe check server/api/admin.py tests/test_admin_bulk_delete_matching.py`
- `.\.venv\Scripts\python.exe -m py_compile server/api/admin.py tests/test_admin_bulk_delete_matching.py`
- `STATEWAVE_EMBEDDING_PROVIDER=stub STATEWAVE_COMPILER_TYPE=heuristic PYTHONUTF8=1 .\.venv\Scripts\python.exe -m pytest tests/test_tenant_scoping_invariant.py tests/test_route_limits_invariant.py tests/test_admin_dashboard.py tests/test_admin_bulk_delete_matching.py -q`
- `git diff --check && git diff --cached --check`