### PR TITLE
feat(admin): POST /admin/jobs/reset-stuck

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2759,6 +2759,26 @@ async def purge_compile_jobs(
     return {"deleted": deleted}
 
 
+@router.post("/jobs/reset-stuck")
+async def reset_stuck_compile_jobs(
+    threshold_minutes: int = Query(
+        30, ge=1, le=1440, description="Jobs running longer than this many minutes are reset"
+    ),
+):
+    """Reset stuck compile jobs back to pending so a worker can retry them.
+
+    A job is stuck when its worker crashed or was restarted mid-run and
+    never marked the job completed or failed. This endpoint finds all jobs
+    that have been in `running` state longer than `threshold_minutes` and
+    resets them to `pending`, clearing `started_at` so they can be
+    reclaimed by the next available worker.
+    """
+    from server.services.compile_jobs_durable import reset_stuck_jobs
+
+    reset = await reset_stuck_jobs(threshold_minutes=threshold_minutes)
+    return {"reset": reset}
+
+
 # ─── Tenant Audit ───
 
 

--- a/server/services/compile_jobs_durable.py
+++ b/server/services/compile_jobs_durable.py
@@ -305,3 +305,31 @@ async def purge_jobs(
             tenant_id=tenant_id,
         )
         return count
+
+
+async def reset_stuck_jobs(threshold_minutes: int = 30) -> int:
+    """Reset jobs stuck in `running` state back to `pending`.
+
+    A job is stuck when it has been `running` for longer than
+    `threshold_minutes` — the worker that claimed it crashed or was
+    restarted before it could mark the job completed or failed.
+    Resetting to `pending` makes the next available worker pick it up
+    and rerun it cleanly.
+
+    Returns the count of jobs reset.
+    """
+    from datetime import timedelta
+
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=threshold_minutes)
+
+    async with get_session_factory()() as session:
+        result = await session.execute(
+            update(CompileJobRow)
+            .where(CompileJobRow.status == "running")
+            .where(CompileJobRow.started_at < cutoff)
+            .values(status="pending", started_at=None)
+        )
+        await session.commit()
+        count = result.rowcount or 0  # type: ignore[attr-defined]
+        logger.info("compile_jobs_stuck_reset", reset=count, threshold_minutes=threshold_minutes)
+        return count


### PR DESCRIPTION
## Summary

- Adds `reset_stuck_jobs(threshold_minutes=30)` to `compile_jobs_durable.py` — finds jobs in `running` state whose `started_at` exceeds the threshold and resets them to `pending` with `started_at=NULL`, so the next worker retries
- Adds `POST /admin/jobs/reset-stuck?threshold_minutes=30` endpoint in `admin.py` — returns `{ reset: <count> }`

## Context

Stuck jobs occur when a worker crashes or a server is restarted mid-compile. The job stays `running` forever (no automatic recovery). Previously the only fix was raw SQL. This endpoint makes it self-serviceable from the admin UI.

## Test plan

- [ ] `POST /admin/jobs/reset-stuck` with a stuck job returns `{ "reset": 1 }` and the job appears as `pending`
- [ ] With no stuck jobs returns `{ "reset": 0 }`
- [ ] `threshold_minutes` query param respected (e.g. `?threshold_minutes=1` resets jobs running > 1 min)
- [ ] CI green