### PR TITLE
feat(admin): job ops — reset stuck, delete individual, fix empty subject 404

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -537,7 +537,21 @@ async def get_subject_detail(
         mem_count = await session.scalar(mem_count_stmt) or 0
 
         if ep_count == 0 and mem_count == 0:
-            raise HTTPException(status_code=404, detail=f"Subject '{subject_id}' not found")
+            # Subject is known (e.g. referenced in compile_jobs) but has no data yet.
+            # Return zeroed stats rather than 404 so the admin UI can render the page.
+            return SubjectDetailResponse(
+                subject_id=subject_id,
+                tenant_id=tenant_id,
+                summary=SubjectSummary(
+                    episode_count=0,
+                    memory_count=0,
+                    session_count=0,
+                    first_seen_at=None,
+                    last_activity_at=None,
+                ),
+                health=None,
+                sla=None,
+            )
 
         # Get timestamps
         time_stmt = select(
@@ -2757,6 +2771,24 @@ async def purge_compile_jobs(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return {"deleted": deleted}
+
+
+@router.delete("/jobs/{job_id}")
+async def delete_compile_job(job_id: str):
+    """Delete a single terminal compile job by ID.
+
+    Only completed or failed jobs can be deleted — pending/running jobs
+    may still be held by the worker.
+    """
+    from server.services.compile_jobs_durable import delete_job
+
+    try:
+        found = await delete_job(job_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if not found:
+        raise HTTPException(status_code=404, detail=f"Job '{job_id}' not found")
+    return {"deleted": 1}
 
 
 @router.post("/jobs/reset-stuck")

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -537,8 +537,20 @@ async def get_subject_detail(
         mem_count = await session.scalar(mem_count_stmt) or 0
 
         if ep_count == 0 and mem_count == 0:
-            # Subject is known (e.g. referenced in compile_jobs) but has no data yet.
-            # Return zeroed stats rather than 404 so the admin UI can render the page.
+            # Subject has no episodes or memories. Return 200 with zeroed stats only
+            # if it is referenced by at least one compile job (e.g. a staging subject
+            # that was purged after a successful build-swap cycle). Otherwise 404 —
+            # the subject genuinely does not exist.
+            from server.db.tables import CompileJobRow
+
+            job_exists_stmt = select(func.count()).select_from(CompileJobRow).where(
+                CompileJobRow.subject_id == subject_id
+            )
+            if tenant_id:
+                job_exists_stmt = job_exists_stmt.where(CompileJobRow.tenant_id == tenant_id)
+            job_count = await session.scalar(job_exists_stmt) or 0
+            if job_count == 0:
+                raise HTTPException(status_code=404, detail=f"Subject '{subject_id}' not found")
             return SubjectDetailResponse(
                 subject_id=subject_id,
                 tenant_id=tenant_id,

--- a/server/services/compile_jobs_durable.py
+++ b/server/services/compile_jobs_durable.py
@@ -307,6 +307,28 @@ async def purge_jobs(
         return count
 
 
+async def delete_job(job_id: str) -> bool:
+    """Delete a single terminal compile job by ID.
+
+    Returns True if the job was found and deleted, False if not found.
+    Raises ValueError if the job is not in a terminal state (completed/failed).
+    """
+    async with get_session_factory()() as session:
+        row = await session.get(CompileJobRow, job_id)
+        if row is None:
+            return False
+        if row.status not in TERMINAL_JOB_STATUSES:
+            raise ValueError(
+                f"Cannot delete job {job_id!r} with status {row.status!r} — "
+                "only terminal jobs (completed, failed) can be deleted"
+            )
+        subject_id = row.subject_id
+        await session.delete(row)
+        await session.commit()
+        logger.info("compile_job_deleted", job_id=job_id, subject_id=subject_id)
+        return True
+
+
 async def reset_stuck_jobs(threshold_minutes: int = 30) -> int:
     """Reset jobs stuck in `running` state back to `pending`.
 


### PR DESCRIPTION
## Summary

- `POST /admin/jobs/reset-stuck` — resets jobs stuck in `running` state (worker crashed) back to `pending` so they are retried
- `DELETE /admin/jobs/{job_id}` — deletes a single terminal (completed/failed) job; pending/running rejected with 400
- `GET /admin/subjects/{id}` no longer returns 404 for subjects with zero episodes AND zero memories — returns zeroed stats instead so the admin detail page renders for empty subjects (e.g. `*-staging` after a successful build-swap-purge cycle)

## Test plan

- [ ] Reset stuck: verify jobs with `status=running` older than 30 min flip to `status=pending` after POST
- [ ] Delete job: `DELETE /admin/jobs/<completed-id>` returns `{"deleted":1}`; `DELETE /admin/jobs/<pending-id>` returns 400
- [ ] Empty subject: `GET /admin/subjects/some-empty-subject` returns 200 with zeroed counts instead of 404