### PR TITLE
fix(context): scope source episode lookups by tenant

### DIFF
--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -1353,17 +1353,26 @@ async def memory_compiler_trace(
             mem_uuid = _uuid.UUID(memory_id)
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid memory_id format")
-        row = await session.scalar(
+        stmt = (
             select(MemoryRow)
             .where(MemoryRow.id == mem_uuid)
             .where(MemoryRow.subject_id == subject_id)
         )
+        if tenant_id is not None:
+            stmt = stmt.where(MemoryRow.tenant_id == tenant_id)
+        row = await session.scalar(stmt)
         if row is None:
             raise HTTPException(status_code=404, detail="memory not found")
 
         episodes = []
         if row.source_episode_ids:
-            episodes = list(await get_episodes_by_ids(session, row.source_episode_ids))
+            episodes = list(
+                await get_episodes_by_ids(
+                    session,
+                    row.source_episode_ids,
+                    tenant_id=tenant_id,
+                )
+            )
 
     meta = row.metadata_ or {}
     compiler = meta.get("compiler", "unknown")

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -226,10 +226,13 @@ async def mark_episodes_compiled(
 async def get_episodes_by_ids(
     session: AsyncSession,
     ids: list[uuid.UUID],
+    *,
+    tenant_id: str | None = None,
 ) -> Sequence[EpisodeRow]:
     if not ids:
         return []
     stmt = select(EpisodeRow).where(EpisodeRow.id.in_(ids))
+    stmt = _tenant_filter(stmt, EpisodeRow.tenant_id, tenant_id)
     result = await session.execute(stmt)
     return result.scalars().all()
 

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -383,7 +383,11 @@ async def assemble_context(
             needed_episode_ids.add(sid)
     if needed_episode_ids:
         try:
-            src_episodes = await repo.get_episodes_by_ids(session, list(needed_episode_ids))
+            src_episodes = await repo.get_episodes_by_ids(
+                session,
+                list(needed_episode_ids),
+                tenant_id=tenant_id,
+            )
             ep_breadcrumb_by_id: dict[uuid.UUID, str] = {}
             for ep in src_episodes:
                 payload = ep.payload or {}

--- a/tests/test_admin_compiler_trace_tenant_scope.py
+++ b/tests/test_admin_compiler_trace_tenant_scope.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from server.api.admin import memory_compiler_trace
+
+
+class _FakeSession:
+    def __init__(self, row):
+        self.row = row
+        self.scalar_statement = None
+
+    async def scalar(self, statement):
+        self.scalar_statement = statement
+        return self.row
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _compiled(statement):
+    return statement.compile(dialect=postgresql.dialect())
+
+
+@pytest.mark.anyio
+async def test_memory_compiler_trace_scopes_memory_and_source_episodes_by_tenant(
+    monkeypatch,
+):
+    source_episode_id = uuid.uuid4()
+    row = SimpleNamespace(
+        id=uuid.uuid4(),
+        subject_id="shared-subject",
+        tenant_id="tenant-a",
+        kind="profile_fact",
+        content="tenant-scoped memory",
+        summary="tenant-scoped memory",
+        confidence=1.0,
+        status="active",
+        created_at=datetime.now(timezone.utc),
+        metadata_={},
+        source_episode_ids=[source_episode_id],
+    )
+    session = _FakeSession(row)
+    get_episodes_by_ids = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(
+        "server.db.engine.get_session_factory",
+        lambda: lambda: _FakeSessionContext(session),
+    )
+    monkeypatch.setattr(
+        "server.db.repositories.get_episodes_by_ids",
+        get_episodes_by_ids,
+    )
+
+    response = await memory_compiler_trace(
+        "shared-subject",
+        str(row.id),
+        tenant_id="tenant-a",
+    )
+
+    compiled = _compiled(session.scalar_statement)
+    assert "memories.tenant_id =" in str(compiled)
+    assert "tenant-a" in compiled.params.values()
+    get_episodes_by_ids.assert_awaited_once_with(
+        session,
+        [source_episode_id],
+        tenant_id="tenant-a",
+    )
+    assert response.memory_id == str(row.id)
+    assert response.reconstructed_input == []

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -358,6 +358,7 @@ def _mock_semantic_repos(
     async def _embed_query(_session_factory, _provider, _task):
         return [0.0] * 16  # shape doesn't matter — we mock the search
 
+    get_episodes_by_ids = AsyncMock(return_value=[])
     with (
         patch(
             "server.services.context.repo.search_memories",
@@ -387,11 +388,18 @@ def _mock_semantic_repos(
         ),
         patch(
             "server.services.context.repo.get_episodes_by_ids",
-            new_callable=AsyncMock,
-            return_value=[],
+            new=get_episodes_by_ids,
+        ),
+        patch(
+            "server.services.context.policy_service.resolve_active_bundle",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "server.services.receipts.repo.get_tenant_config",
+            new=AsyncMock(return_value=None),
         ),
     ):
-        yield
+        yield {"get_episodes_by_ids": get_episodes_by_ids}
 
 
 @pytest.mark.asyncio
@@ -519,3 +527,32 @@ async def test_lexical_bonus_does_not_override_strong_kind_signal_alone():
 
     assert str(fact.id) in result.provenance["fact_ids"]
     assert str(proc.id) in result.provenance["procedure_ids"]
+
+
+@pytest.mark.asyncio
+async def test_breadcrumb_source_episode_lookup_is_scoped_to_context_tenant():
+    episode_id = uuid.uuid4()
+    memory = _make_memory_row(
+        kind="procedure",
+        content="Install the tenant-scoped package from the private docs.",
+    )
+    memory.source_episode_ids = [episode_id]
+
+    with _mock_semantic_repos(
+        fact_rows=[],
+        procedure_rows=[memory],
+        summary_rows=[],
+        semantic_results=[],
+    ) as mocks:
+        session = AsyncMock()
+        await assemble_context(
+            session,
+            "statewave-support-docs",
+            "install private docs",
+            max_tokens=4000,
+            tenant_id="tenant-a",
+        )
+
+    mocks["get_episodes_by_ids"].assert_awaited_once_with(
+        session, [episode_id], tenant_id="tenant-a"
+    )

--- a/tests/test_tenant_scoping.py
+++ b/tests/test_tenant_scoping.py
@@ -6,11 +6,34 @@ signatures accept tenant_id correctly.
 
 from __future__ import annotations
 
+import uuid
 from unittest.mock import MagicMock
 
-from server.db.repositories import _tenant_filter
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from server.db.repositories import _tenant_filter, get_episodes_by_ids
 from server.db.tables import EpisodeRow, MemoryRow
 from server.core.dependencies import get_tenant_id
+
+
+class _ScalarRows:
+    def all(self):
+        return []
+
+
+class _ExecuteResult:
+    def scalars(self):
+        return _ScalarRows()
+
+
+class _CaptureSession:
+    def __init__(self):
+        self.statement = None
+
+    async def execute(self, statement):
+        self.statement = statement
+        return _ExecuteResult()
 
 
 class TestTenantFilter:
@@ -29,6 +52,17 @@ class TestTenantFilter:
         stmt.where.return_value = stmt
         _tenant_filter(stmt, EpisodeRow.tenant_id, "tenant-a")
         stmt.where.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_episodes_by_ids_applies_tenant_filter():
+    session = _CaptureSession()
+
+    await get_episodes_by_ids(session, [uuid.uuid4()], tenant_id="tenant-a")
+
+    compiled = session.statement.compile(dialect=postgresql.dialect())
+    assert "episodes.tenant_id =" in str(compiled)
+    assert "tenant-a" in compiled.params.values()
 
 
 class TestGetTenantIdDependency:


### PR DESCRIPTION
## Summary
- add optional tenant filtering to `get_episodes_by_ids`
- pass the active tenant into context breadcrumb/source-episode lookups
- scope admin compiler-trace memory lookup and reconstructed source episodes when `tenant_id` is provided

## Issue triage
- GitHub open issues in the Statewave workspace: 1 (`statewave#193`), currently blocked on access to a licensed Jira Data Center instance
- Issues are disabled on the related Statewave repos checked (`statewave-connectors`, `statewave-docs`, SDK/admin/example repos)
- This PR addresses a tenant-isolation item from the local audit backlog rather than an unblocked GitHub issue

## Tests
- `STATEWAVE_EMBEDDING_PROVIDER=stub STATEWAVE_COMPILER_TYPE=heuristic PYTHONUTF8=1 .\.venv\Scripts\python.exe -m pytest tests/test_context.py tests/test_tenant_scoping.py tests/test_tenant_scoping_invariant.py tests/test_admin_compiler_trace_tenant_scope.py -q`
- `.\.venv\Scripts\ruff.exe check server/api/admin.py server/services/context.py server/db/repositories.py tests/test_context.py tests/test_tenant_scoping.py tests/test_admin_compiler_trace_tenant_scope.py`
- `.\.venv\Scripts\python.exe -m py_compile server/api/admin.py server/services/context.py server/db/repositories.py tests/test_context.py tests/test_tenant_scoping.py tests/test_admin_compiler_trace_tenant_scope.py`
- `git diff --check && git diff --cached --check`