### PR TITLE
chore: bump version to v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Statewave is the open-source memory runtime that gives AI agents reproducible, p
 
 _If Statewave is useful to you, a ⭐ on the repo helps others discover it._
 
-> **v1.3.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
+> **v1.4.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
 
 ## 🎯 Try it
 
@@ -295,7 +295,7 @@ pytest tests/ -v
 
 ## Current limitations
 
-Statewave is in active development (v1.3.0). Honest status:
+Statewave is in active development (v1.4.0). Honest status:
 
 - **Rate limiting is per-IP** — distributed (Postgres-backed), but keyed by IP only, not per-tenant or per-API-key yet
 - **Multi-tenant is app-layer** — query-scoped data isolation (v0.5) + per-tenant config / policy bundles / receipts (v0.8) + HMAC-signed audit + tenant region pin (v0.9), but no Postgres RLS yet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "statewave"
-version = "1.3.0"
+version = "1.4.0"
 description = "Open-source memory runtime for AI agents — durable, structured context with provenance."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Version bump for the v1.4.0 release train — tenant-scoping fixes, admin ops surface, bootstrap resilience. See the CHANGELOG entries on the tagged release for the shipped-content roll-up.

- **pyproject.toml** — 1.3.0 → 1.4.0
- **README.md** — status blurb + active-development line to v1.4.0

Companion statewave-docs updates already merged: [statewave-docs#78](https://github.com/smaramwbc/statewave-docs/pull/78) (banners → 1.4.x, overview.md v1.4 history entry, test-counts label) and [statewave-docs#79](https://github.com/smaramwbc/statewave-docs/pull/79) (product.md status line → 1.4.0, `docs_product_status` pattern fix).

## Test plan

- [x] Local dry-run of `statewave-docs/tools/check-versions.py` against a bumped pyproject: `✓ all mechanical surfaces match truth (server v1.4.0)`
- [ ] CI green on this PR (unit + integration + smoke)
- [ ] Post-merge: push `v1.4.0` tag on the merge commit — release workflow (verify-workspace-versions + verify-proof-figures + GH Release) and Docker publish workflow both green