### PR TITLE
docs: static Docker badge (avoid shields.io upstream rate-limit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
 [![PyPI](https://img.shields.io/pypi/v/statewave)](https://pypi.org/project/statewave/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/statewavedev/statewave)](https://hub.docker.com/r/statewavedev/statewave)
+[![Docker](https://img.shields.io/badge/docker-statewavedev%2Fstatewave-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/statewavedev/statewave)
 
 Statewave is the open-source memory runtime that gives AI agents reproducible, provenance-tagged context — without sampling-noise from query-time retrieval.
 


### PR DESCRIPTION
## What

Replaces the live shields.io `docker/pulls` badge with a static Docker badge.

## Why

The pull-count badge reads Docker Hub's metadata API through shields.io's shared infrastructure, which Docker Hub throttles frequently. When that happens the badge renders as **"rate limited by upstream service"** — a broken-looking badge on a public README. The static badge makes no API call, so it always renders cleanly, while still linking to the Docker Hub repository.

Image pulls go through the registry and were never affected — this is purely a cosmetic badge fix.
