### PR TITLE
docs(deploy): clarify support pack seeding

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -10,11 +10,10 @@ primary_region = 'ord'
   STATEWAVE_LITELLM_MODEL = "gpt-4o-mini"
   STATEWAVE_LITELLM_EMBEDDING_MODEL = "text-embedding-3-small"
   STATEWAVE_EMBEDDING_DIMENSIONS = "1536"
-  # Production seeds the docs pack via the dedicated GitHub Actions
-  # refresh workflow (purge + rebuild on docs-repo push). The image
-  # itself doesn't bundle the corpus, so the start-time auto-bootstrap
-  # would silently skip — but disable it explicitly to avoid any
-  # confusion in the Fly logs.
+  # The optional /docs bootstrap is disabled in this image because there is
+  # no mounted documentation corpus. start.sh keeps the support subject
+  # current instead by idempotently reseeding the bundled starter pack after
+  # the API is ready.
   STATEWAVE_BOOTSTRAP_DOCS_PACK = "false"
 
 [http_service]


### PR DESCRIPTION
﻿## Description

Clarifies how the Fly deployment keeps the support documentation subject current. The previous comment described a retired GitHub Actions workflow, which conflicted with the in-process reseed behavior documented elsewhere.

## Related Issue

Closes #300

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (refactoring, dependencies, CI, etc.)
- [ ] Test improvement

## Changes Made

- Replaced the stale workflow description in fly.toml.
- Documented that the optional mounted /docs bootstrap is disabled for this image.
- Documented the idempotent startup reseed from the bundled support pack.

## Testing

- [ ] Unit tests pass locally
- [ ] Integration tests pass locally
- [x] Manual testing completed
- [ ] New tests added for new functionality

### Test Commands Run

Validated fly.toml with Python tomllib and ran git diff --check.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix/feature works
- [ ] All existing tests pass
- [x] I have checked for breaking changes

## Screenshots / Recordings

Not applicable.

## Additional Notes

The deployment setting remains unchanged. This PR only corrects the operational documentation beside it.
