### PR TITLE
fix(docs): parse closing ATX heading hashes

### DIFF
--- a/scripts/docs_loader.py
+++ b/scripts/docs_loader.py
@@ -61,7 +61,7 @@ SUBJECT_ID = "statewave-support-docs"
 PACK_VERSION = 1
 DEFAULT_BASE_URL = "https://github.com/smaramwbc/statewave-docs/blob/main"
 
-_HEADING_RE = re.compile(r"^(#{1,3})\s+(.+?)\s*$")
+_HEADING_RE = re.compile(r"^(#{1,3})[ \t]+(.*?)(?:[ \t]+#+[ \t]*)?$")
 _FENCE_RE = re.compile(r"^\s*```")
 _SLUG_STRIP_RE = re.compile(r"[^a-z0-9\s-]")
 _SLUG_SPACE_RE = re.compile(r"\s+")

--- a/tests/test_docs_loader.py
+++ b/tests/test_docs_loader.py
@@ -70,6 +70,23 @@ leaf body
     assert by_title["Leaf"].heading_path == ("Top", "Middle", "Leaf")
 
 
+def test_atx_closing_hashes_are_excluded_from_titles():
+    md = "## Getting Started ##\n\nbody\n"
+
+    section = chunk_markdown(md, "x.md")[0]
+
+    assert section.title == "Getting Started"
+    assert section.heading_path == ("Getting Started",)
+    assert section.url.endswith("#getting-started")
+
+
+def test_heading_hash_without_a_preceding_space_is_preserved():
+    md = "## C#\n\nbody\n"
+
+    section = chunk_markdown(md, "x.md")[0]
+
+    assert section.title == "C#"
+
 def test_heading_only_sections_are_dropped():
     md = """# Doc
 


### PR DESCRIPTION
﻿## Description

Markdown headings with a closing hash sequence were stored with those hashes in their titles and breadcrumbs. The parser now follows ATX heading syntax while preserving a literal trailing hash when it is part of the title.

## Related Issue

Closes #298

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (refactoring, dependencies, CI, etc.)
- [x] Test improvement

## Changes Made

- Strip ATX closing hashes only when preceded by whitespace.
- Add coverage for a closing sequence and for the title C#.

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass locally
- [ ] Manual testing completed
- [x] New tests added for new functionality

### Test Commands Run

Ran the docs loader test module: 14 passed, 1 skipped. Ran Ruff on the changed files.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix/feature works
- [ ] All existing tests pass
- [x] I have checked for breaking changes

## Screenshots / Recordings

Not applicable.

## Additional Notes

The skipped test requires the optional sibling statewave-docs checkout.
