### PR TITLE
fix(preflight): add plain status output

### DIFF
--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -18,6 +18,7 @@ Exit codes:
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import os
 import sys
@@ -26,9 +27,21 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-async def main() -> int:
-    from server.services.migrations import check_migration_status
+def _status_prefix(kind: str, plain: bool) -> str:
+    if plain:
+        return {"error": "ERROR:", "success": "OK:", "warning": "WARN:"}[kind]
+    return {"error": "\u274c", "success": "\u2705", "warning": "\u26a0\ufe0f"}[kind]
 
+async def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--plain",
+        action="store_true",
+        help="use ASCII status prefixes instead of Unicode symbols",
+    )
+    args = parser.parse_args(argv)
+
+    from server.services.migrations import check_migration_status
     print("=" * 60)
     print("  Statewave Migration Preflight Check")
     print("=" * 60)
@@ -37,7 +50,7 @@ async def main() -> int:
     status = await check_migration_status()
 
     if status.error:
-        print(f"❌ ERROR: {status.error}")
+        print(f"{_status_prefix('error', args.plain)} ERROR: {status.error}")
         print()
         print("Action: Fix the error above before proceeding.")
         return 1
@@ -54,16 +67,16 @@ async def main() -> int:
         print()
 
     if status.is_compatible:
-        print("✅ Schema is up to date. No migration needed.")
+        print(f"{_status_prefix('success', args.plain)} Schema is up to date. No migration needed.")
         return 0
 
     if status.current_revision is None:
-        print("⚠️  Fresh database detected. All migrations will be applied.")
+        print(f"{_status_prefix('warning', args.plain)} Fresh database detected. All migrations will be applied.")
         print()
         print("  Recommendation: proceed with `alembic upgrade head`")
         return 0
 
-    print(f"⚠️  {status.pending_count} migration(s) pending.")
+    print(f"{_status_prefix('warning', args.plain)} {status.pending_count} migration(s) pending.")
     print()
     print("  Pre-migration checklist:")
     print("    1. Back up the database")
@@ -75,7 +88,7 @@ async def main() -> int:
     print("  Rollback if needed:")
     print(f"    alembic downgrade {status.current_revision}")
     print()
-    print("✅ Safe to proceed with migration.")
+    print(f"{_status_prefix('success', args.plain)} Safe to proceed with migration.")
     return 0
 
 

--- a/tests/test_preflight_output.py
+++ b/tests/test_preflight_output.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.preflight import _status_prefix  # noqa: E402
+
+
+def test_plain_status_prefixes_are_ascii():
+    assert _status_prefix("error", plain=True) == "ERROR:"
+    assert _status_prefix("success", plain=True) == "OK:"
+    assert _status_prefix("warning", plain=True) == "WARN:"
+
+
+def test_default_status_prefixes_remain_unicode_symbols():
+    assert _status_prefix("error", plain=False) == "\u274c"
+    assert _status_prefix("success", plain=False) == "\u2705"
+    assert _status_prefix("warning", plain=False) == "\u26a0\ufe0f"


### PR DESCRIPTION
﻿## Description

Preflight output relied on Unicode-only status symbols, which can be unreadable in terminals or log viewers with limited Unicode support. The new explicit plain mode keeps status output legible without changing the existing default presentation.

## Related Issue

Closes #301

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (refactoring, dependencies, CI, etc.)
- [x] Test improvement

## Changes Made

- Added a --plain option to scripts/preflight.py.
- Added stable ASCII prefixes for errors, warnings, and successful checks.
- Preserved the current Unicode symbols unless --plain is requested.
- Added unit coverage for both output modes.

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass locally
- [x] Manual testing completed
- [x] New tests added for new functionality

### Test Commands Run

Ran the focused test module: 2 passed. Ran Ruff on the changed files. Verified that the --plain option appears in the command help.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix/feature works
- [ ] All existing tests pass
- [x] I have checked for breaking changes

## Screenshots / Recordings

Not applicable.

## Additional Notes

The test run emitted an existing local pytest-cache permission warning after passing.
