### PR TITLE
fix(scripts): show complete version help

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -154,7 +154,10 @@ def cmd_check() -> int:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("version", nargs="?", help="new version, e.g. 0.8.0")
     group.add_argument("--check", action="store_true", help="verify only, do not edit")

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,0 +1,26 @@
+"""Regression tests for the version bump script."""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from scripts import bump_version
+
+
+class BumpVersionHelpTests(unittest.TestCase):
+    def test_help_includes_complete_module_docstring(self):
+        script = Path(bump_version.__file__).resolve()
+        result = subprocess.run(
+            [sys.executable, str(script), "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(bump_version.__doc__.strip(), result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Restores the complete `bump_version.py --help` description so maintainers can see the documented usage and exit codes.

## Related Issue

Closes #292

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test improvement

## Changes Made

- Pass the complete module docstring to `argparse` with preserved formatting.
- Add a regression test for the command help output.

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass locally
- [x] Manual testing completed
- [x] New tests added for new functionality

### Test Commands Run

```bash
.\\.venv\\Scripts\\python.exe -m unittest tests.test_bump_version
.\\.venv\\Scripts\\ruff.exe check scripts\\bump_version.py tests\\test_bump_version.py
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix/feature works
- [ ] All existing tests pass
- [x] I have checked for breaking changes

## Screenshots / Recordings

Not applicable.

## Additional Notes

The change preserves the existing required `version` / `--check` argument behavior.