### PR TITLE
chore(lint): pin the ruff rule set explicitly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,15 @@ packages = ["server"]
 target-version = "py311"
 line-length = 100
 
+[tool.ruff.lint]
+# Pin the rule set explicitly instead of inheriting ruff's defaults, which
+# change between releases: 0.16 widened the default selection from 59 rules to
+# 413 and turned a routine version bump into 460 lint errors. These four
+# prefixes are exactly what ruff enforced by default through 0.15, so this
+# records the rules we already meet rather than changing the lint contract.
+# Widening the selection is tracked separately in #314.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"


### PR DESCRIPTION
Unblocks the recurring ruff version bump (#315, previously #306/#313).

## Problem

`[tool.ruff]` sets no `lint.select`, so the project inherits ruff's **default** rule set — and that default changes between releases. Ruff 0.16 widened it from 59 rules to 413, so `ruff check server/ tests/` goes from clean to **460 errors** and the required `test` job fails at the lint step. Dependabot has now opened this bump three times.

## Fix

Select `E4`/`E7`/`E9`/`F` explicitly — exactly what ruff enforced by default through 0.15. The enforced contract is unchanged; this records the rules we already meet.

## Verified

| check | result |
|---|---|
| `ruff check server/ tests/` on **0.16.0** with this config | ✅ All checks passed |
| `ruff check server/ tests/` on **0.15.21** with this config | ✅ All checks passed (safe to land before the bump) |
| E711 / E721 / F403 / F405 still caught | ✅ confirmed against a probe file |

That last row matters: ruff 0.16's new defaults are **not** a superset of 0.15's — they silently *drop* E711 (none-comparison), E721 (type-comparison) and F403 (star-import). Merging the bump without this would have quietly reduced coverage even if the 460 errors were fixed.

Deliberately widening the rule set is a separate decision, tracked in #314.
