### PR TITLE
ci: smoke-test the container image on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,57 @@ jobs:
 
       - name: Integration tests
         run: pytest tests/integration/ -v
+
+  # The test job installs the package from the source tree, so it never
+  # exercises the image we actually ship. A PR can be green and still produce a
+  # container that exits during boot — which docker-publish would then push as
+  # `latest`. Build the image and prove it serves /healthz before that happens.
+  docker-smoke:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: statewave
+          POSTGRES_PASSWORD: statewave
+          POSTGRES_DB: statewave
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U statewave"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build image
+        run: docker build -t statewave:smoke .
+
+      - name: Start container
+        run: |
+          docker run -d --name statewave-smoke --network host \
+            -e STATEWAVE_DATABASE_URL=postgresql+asyncpg://statewave:statewave@localhost:5432/statewave \
+            statewave:smoke
+
+      - name: Probe /healthz
+        run: |
+          for i in $(seq 1 90); do
+            if curl -fsS http://localhost:8100/healthz > /dev/null 2>&1; then
+              echo "Container healthy after ${i}s."
+              exit 0
+            fi
+            if [ -z "$(docker ps -q --filter name=statewave-smoke --filter status=running)" ]; then
+              echo "::error::Container exited during boot (code $(docker inspect -f '{{.State.ExitCode}}' statewave-smoke))."
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "::error::Timed out waiting for /healthz."
+          exit 1
+
+      - name: Container logs
+        if: always()
+        run: docker logs statewave-smoke || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,22 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Install third-party dependencies first, from the manifest alone, so this
+# layer stays cached when only application code changes. `server/` is not
+# present yet, so the wheel built here contains no application code — this step
+# is only about the dependencies.
 COPY pyproject.toml README.md ./
 RUN pip install --no-cache-dir ".[llm]"
 
 COPY . .
 
-RUN pip install --no-cache-dir ".[llm]" && chmod +x start.sh
+# Now install the application package itself. This step is NOT redundant: the
+# install above ran before `COPY . .`, so `server/` is missing from site-packages
+# until this point. `start.sh` runs `alembic upgrade head`, and the alembic
+# console script does not put the working directory on sys.path, so dropping
+# this line makes the container exit with ModuleNotFoundError before uvicorn
+# starts. `--no-deps` because the dependencies are already installed above.
+RUN pip install --no-cache-dir --no-deps . && chmod +x start.sh
 
 EXPOSE 8100
 


### PR DESCRIPTION
Closes #293.

## Why

Two related gaps, both surfaced while reviewing #321:

1. **CI never touches the image we ship.** The `test` job runs `pip install -e ".[dev]"` against the source tree, so a Dockerfile change can pass every check and still produce a container that exits during boot — and `docker-publish` would push it as `latest` with no smoke test between build and push.
2. **The "duplicate" install in the Dockerfile looks removable, but isn't.** The first `pip install` runs *before* `COPY . .`, so hatchling (`packages = ["server"]`) builds a wheel with no application code. The second install is what actually puts `server/` into `site-packages`. `start.sh` runs `alembic upgrade head` first, and the alembic console script doesn't put the working directory on `sys.path` — so removing it makes the container exit before uvicorn starts.

## What

- **`docker-smoke` CI job** — builds the image, runs it against a pgvector service, waits for `/healthz`, and fails fast with container logs if the container exits first.
- **Dockerfile comments** explaining why both installs exist, so this doesn't read as dead code again.
- **`--no-deps`** on the second install, making it explicit that only the application package is installed there (dependencies come from the cached layer above).

## Verified locally

| image | result |
|---|---|
| current Dockerfile | ✅ healthy in ~3s |
| `--no-deps` variant (this PR) | ✅ healthy in ~2s, `server` present in site-packages |
| image with the second install removed (the #321 shape) | ❌ **container exited, code 1** |

That last row is the point: this job catches the exact regression that passed CI green.
