### PR TITLE
fix: declare numpy and httpx as runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,17 @@ dependencies = [
     "asyncpg>=0.31.0,<1",
     "alembic>=1.18.5,<2",
     "pgvector>=0.5.0,<1",
+    # Used directly by the conflict-detection and clustering admin endpoints.
+    # It used to arrive transitively via pgvector, but pgvector 0.5.0 dropped
+    # the dependency, so it has to be declared explicitly.
+    "numpy>=1.26,<3",
     "tiktoken>=0.13.0,<1",
     "structlog>=26.1.0,<27",
     "pyyaml>=6.0.3,<7",
+    # Used directly by webhook delivery. It happened to be installed via the
+    # `llm` extra's dependency graph, so a core-only install had no httpx and
+    # webhook delivery raised ModuleNotFoundError.
+    "httpx>=0.28.1,<1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_runtime_imports.py
+++ b/tests/test_runtime_imports.py
@@ -1,0 +1,84 @@
+"""Every module `server/` imports at runtime must actually be installed.
+
+Imports written inside a function body are only executed when that code path
+runs, so an undeclared dependency there survives startup, the test suite and
+the container smoke test, and only fails when a user hits the endpoint. That is
+exactly how `numpy` broke: it reached us transitively through pgvector, and
+pgvector 0.5.0 dropped it, leaving two admin endpoints raising
+ModuleNotFoundError in a released image.
+
+This walks the AST of `server/` and asserts every third-party module imported
+inside a function is importable, so the next dependency that silently
+disappears fails here instead of in production.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SERVER = _REPO_ROOT / "server"
+
+# Modules that are genuinely optional: they ship in an extra and every call
+# site guards the import (a `_HAS_*` flag or try/except ImportError), so the
+# server runs correctly without them.
+_OPTIONAL = {
+    "litellm",        # `llm` extra
+    "opentelemetry",  # `otel` extra, guarded by _HAS_OTEL in server/core/tracing.py
+}
+
+
+def _function_local_imports() -> set[tuple[str, str, int]]:
+    """Return (module, path, lineno) for every import inside a function body."""
+    found: set[tuple[str, str, int]] = set()
+
+    for path in sorted(_SERVER.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Import):
+                    names = [alias.name for alias in inner.names]
+                elif isinstance(inner, ast.ImportFrom):
+                    # Relative imports resolve within the package, not to a
+                    # distribution, so they cannot be a missing dependency.
+                    if inner.level or not inner.module:
+                        continue
+                    names = [inner.module]
+                else:
+                    continue
+
+                for name in names:
+                    top = name.split(".")[0]
+                    if top in sys.stdlib_module_names or top == "server":
+                        continue
+                    rel = path.relative_to(_REPO_ROOT).as_posix()
+                    found.add((top, rel, inner.lineno))
+
+    return found
+
+
+def test_function_local_imports_are_installed():
+    missing = sorted(
+        (module, path, lineno)
+        for module, path, lineno in _function_local_imports()
+        if module not in _OPTIONAL and importlib.util.find_spec(module) is None
+    )
+
+    assert not missing, "Undeclared runtime dependencies:\n" + "\n".join(
+        f"  {path}:{lineno} imports {module!r}, which is not installed"
+        for module, path, lineno in missing
+    )
+
+
+def test_directly_imported_packages_are_declared():
+    """Guard the two dependencies that were previously only transitive."""
+    for module in ("numpy", "httpx"):
+        assert importlib.util.find_spec(module) is not None, (
+            f"{module} is imported by server/ but is not installed; "
+            "it must stay declared in pyproject.toml"
+        )


### PR DESCRIPTION
`numpy` and `httpx` are imported directly by `server/`, but neither is declared. They arrived transitively — and one of those paths has already disappeared, so this is a live bug in the published image.

## numpy — currently broken in production

`server/api/admin.py` imports numpy in two endpoints, unguarded:

| | |
|---|---|
| `admin.py:1491` | `detect_memory_conflicts()` — `np.array`, `np.linalg.norm`, `np.dot` |
| `admin.py:1830` | `memory_clusters()` — `np.array`, `np.linalg.svd`, `np.zeros` |

numpy only ever reached us through pgvector, and **pgvector 0.5.0 dropped it** (`requires_dist` is `['numpy']` on 0.4.2, `None` on 0.5.0). `pyproject.toml` already requires `pgvector>=0.5.0`, so numpy is now guaranteed absent:

```console
$ uv pip compile --extra llm pyproject.toml     # current main
64 packages, numpy: 0 occurrences, pgvector==0.5.0

$ docker build -t main . && docker run --rm main python -c "import numpy"
ModuleNotFoundError: No module named 'numpy'
```

Both call sites early-return when there are no rows, which is why the test suite never reaches them — the endpoints raise as soon as they have data.

## httpx — breaks core-only installs

`server/services/webhooks.py:197` imports httpx in `_attempt_delivery()`. It is present only via the `llm` extra's dependency graph (litellm → httpx), so `pip install statewave` without extras resolves 34 packages with no httpx and webhook delivery raises the same way. The shipped image happens to be fine because the Dockerfile installs `.[llm]`.

## Why nothing caught it

Both imports sit inside function bodies, so they never execute at import time. Startup succeeds, `pytest` passes, and the container smoke test passes — the failure only surfaces on a request that reaches the code.

`tests/test_runtime_imports.py` closes that gap: it walks the AST of `server/`, collects every third-party module imported inside a function, and asserts each is importable. Modules that legitimately ship in an extra **and** are guarded at the call site are allowlisted (`litellm`; `opentelemetry`, which is gated behind `_HAS_OTEL` in `server/core/tracing.py`).

## Verified

| Check | Result |
|---|---|
| New test against an image built from `main` | ❌ 2 failed (correctly catches the bug) |
| New test against this branch | ✅ 2 passed |
| `import numpy` / `import httpx` in the built image | ✅ numpy 2.4.6, httpx 0.28.1 |
| Container boot + `/healthz` | ✅ healthy in ~2s |
| Image size | 132MB → 152MB (numpy) |

`numpy>=1.26,<3` covers the project's `requires-python = ">=3.11"`; the APIs in use are stable across 1.26 and 2.x.
