### PR TITLE
Fix/seed banner alignment 302

### DIFF
--- a/scripts/seed_demo_subjects.py
+++ b/scripts/seed_demo_subjects.py
@@ -381,6 +381,23 @@ def http_request(
         return e.code, payload
 
 
+def _print_seed_banner() -> None:
+    """Print a note banner, auto-sizing the box to the longest line."""
+    lines = [
+        "NOTE: this seeds the MINIMAL statewave-web hero visualization",
+        "data (~10 episodes/persona) — NOT the full demo agents.",
+        "For full demo personas (~44 episodes) use the bundled packs:",
+        "  python -m scripts.bootstrap_demo_packs",
+        "(or admin UI → Import demo agent memories). A fresh server",
+        "auto-imports them on boot unless STATEWAVE_BOOTSTRAP_DEMO_PACKS=false",
+    ]
+    width = max(len(line) for line in lines)
+    border = "─" * (width + 2)
+    sys.stderr.write(f"\n  ┌{border}┐\n")
+    for line in lines:
+        sys.stderr.write(f"  │ {line:<{width}} │\n")
+    sys.stderr.write(f"  └{border}┘\n\n")
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--url", default=DEFAULT_URL, help=f"Base API URL (default: {DEFAULT_URL})")
@@ -393,17 +410,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    sys.stderr.write(
-        "\n"
-        "  ┌──────────────────────────────────────────────────────────────────┐\n"
-        "  │  NOTE: this seeds the MINIMAL statewave-web hero visualization     │\n"
-        "  │  data (~10 episodes/persona) — NOT the full demo agents.           │\n"
-        "  │  For full demo personas (~44 episodes) use the bundled packs:      │\n"
-        "  │    python -m scripts.bootstrap_demo_packs                          │\n"
-        "  │  (or admin UI → Import demo agent memories). A fresh server         │\n"
-        "  │  auto-imports them on boot unless STATEWAVE_BOOTSTRAP_DEMO_PACKS=false│\n"
-        "  └──────────────────────────────────────────────────────────────────┘\n\n"
-    )
+    _print_seed_banner()
 
     if not API_KEY:
         print("ERROR: STATEWAVE_API_KEY env var required", file=sys.stderr)


### PR DESCRIPTION
## Description
`scripts/seed_demo_subjects.py` printed a hand-drawn Unicode box banner with manually space-padded lines. One line (`STATEWAVE_BOOTSTRAP_DEMO_PACKS=false`) was longer than the fixed border width, so its closing `│` didn't align with the rest of the box in a monospace terminal. This PR replaces the manual banner with a `_print_seed_banner()` helper that auto-sizes the box to the longest line and pads every line to match, so the borders always align regardless of future wording changes.
## Related Issue
Closes #302
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance (refactoring, dependencies, CI, etc.)
- [ ] 🧪 Test improvement
## Changes Made
- Added `_print_seed_banner()` helper function that computes box width from the longest line and pads every line to match
- Replaced the manually space-padded banner in `main()` with a call to `_print_seed_banner()`
- Fixed the misaligned closing `│` on the `STATEWAVE_BOOTSTRAP_DEMO_PACKS=false` line as a side effect of the auto-sizing
## Testing
- [ ] Unit tests pass locally
- [ ] Integration tests pass locally
- [x] Manual testing completed
- [ ] New tests added for new functionality
### Test Commands Run
```bash
python -m ruff check scripts/seed_demo_subjects.py
python scripts/seed_demo_subjects.py --dry-run
```
## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix/feature works
- [ ] All existing tests pass
- [x] I have checked for breaking changes
## Screenshots / Recordings
```
  ┌───────────────────────────────────────────────────────────────────────┐
  │ NOTE: this seeds the MINIMAL statewave-web hero visualization         │
  │ data (~10 episodes/persona) — NOT the full demo agents.               │
  │ For full demo personas (~44 episodes) use the bundled packs:          │
  │   python -m scripts.bootstrap_demo_packs                              │
  │ (or admin UI → Import demo agent memories). A fresh server            │
  │ auto-imports them on boot unless STATEWAVE_BOOTSTRAP_DEMO_PACKS=false │
  └───────────────────────────────────────────────────────────────────────┘
```
## Additional Notes
No test suite exists for this script (it's a standalone data-seeding utility, not covered by `tests/`), so verification was manual: `ruff check` passed, and running with `--dry-run` confirms all box borders now align correctly, including the previously-overflowing line.