### PR TITLE
Fix/295 response mapping

### DIFF
--- a/server/api/episodes.py
+++ b/server/api/episodes.py
@@ -54,18 +54,7 @@ async def create_episode(
         {"id": str(row.id), "subject_id": row.subject_id},
         tenant_id=tenant_id,
     )
-    return EpisodeResponse(
-        id=row.id,
-        subject_id=row.subject_id,
-        source=row.source,
-        type=row.type,
-        payload=row.payload,
-        metadata=row.metadata_,
-        provenance=row.provenance,
-        session_id=row.session_id,
-        occurred_at=row.occurred_at,
-        created_at=row.created_at,
-    )
+    return EpisodeResponse.from_row(row)
 
 
 @router.post(
@@ -113,19 +102,5 @@ async def create_episodes_batch(
         )
         return BatchCreateEpisodesResponse(
             episodes_created=len(rows),
-            episodes=[
-                EpisodeResponse(
-                    id=r.id,
-                    subject_id=r.subject_id,
-                    source=r.source,
-                    type=r.type,
-                    payload=r.payload,
-                    metadata=r.metadata_,
-                    provenance=r.provenance,
-                    session_id=r.session_id,
-                    occurred_at=r.occurred_at,
-                    created_at=r.created_at,
-                )
-                for r in rows
-            ],
+            episodes=[EpisodeResponse.from_row(r) for r in rows],
         )

--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -551,22 +551,9 @@ async def search_memories(
 
 
 def _to_response(row) -> MemoryResponse:
-    return MemoryResponse(
-        id=row.id,
-        subject_id=row.subject_id,
-        kind=row.kind,
-        content=row.content,
-        summary=row.summary,
-        confidence=row.confidence,
-        valid_from=row.valid_from,
-        valid_to=row.valid_to,
-        source_episode_ids=row.source_episode_ids or [],
-        metadata=row.metadata_,
-        status=row.status,
-        sensitivity_labels=list(getattr(row, "sensitivity_labels", None) or []),
-        created_at=row.created_at,
-        updated_at=row.updated_at,
-    )
+    # Thin delegate kept so the 6 existing call sites in this file don't need
+    # touching; the actual field mapping now lives in one place (#295).
+    return MemoryResponse.from_row(row)
 
 
 @router.patch("/{memory_id}/labels", response_model=MemoryResponse)

--- a/server/api/resolutions.py
+++ b/server/api/resolutions.py
@@ -43,17 +43,7 @@ async def create_resolution(
     result = await repo.upsert_resolution(session, row)
     await session.commit()
 
-    return ResolutionResponse(
-        id=result.id,
-        subject_id=result.subject_id,
-        session_id=result.session_id,
-        status=result.status,
-        resolution_summary=result.resolution_summary,
-        resolved_at=result.resolved_at,
-        metadata=result.metadata_,
-        created_at=result.created_at,
-        updated_at=result.updated_at,
-    )
+    return ResolutionResponse.from_row(result)
 
 
 @router.get(
@@ -69,17 +59,4 @@ async def list_resolutions(
 ):
     """List resolution records for a subject, optionally filtered by status."""
     rows = await repo.list_resolutions(session, subject_id, tenant_id=tenant_id, status=status)
-    return [
-        ResolutionResponse(
-            id=r.id,
-            subject_id=r.subject_id,
-            session_id=r.session_id,
-            status=r.status,
-            resolution_summary=r.resolution_summary,
-            resolved_at=r.resolved_at,
-            metadata=r.metadata_,
-            created_at=r.created_at,
-            updated_at=r.updated_at,
-        )
-        for r in rows
-    ]
+    return [ResolutionResponse.from_row(r) for r in rows]

--- a/server/api/templates.py
+++ b/server/api/templates.py
@@ -96,15 +96,4 @@ async def apply_memory_template(
         tenant_id=tenant_id,
     )
 
-    return EpisodeResponse(
-        id=row.id,
-        subject_id=row.subject_id,
-        source=row.source,
-        type=row.type,
-        payload=row.payload,
-        metadata=row.metadata_,
-        provenance=row.provenance,
-        session_id=row.session_id,
-        occurred_at=row.occurred_at,
-        created_at=row.created_at,
-    )
+    return EpisodeResponse.from_row(row)

--- a/server/api/timeline.py
+++ b/server/api/timeline.py
@@ -23,38 +23,6 @@ async def get_timeline(
     memories = await repo.list_memories_by_subject(session, subject_id, tenant_id=tenant_id)
     return TimelineResponse(
         subject_id=subject_id,
-        episodes=[
-            EpisodeResponse(
-                id=e.id,
-                subject_id=e.subject_id,
-                source=e.source,
-                type=e.type,
-                payload=e.payload,
-                metadata=e.metadata_,
-                provenance=e.provenance,
-                session_id=e.session_id,
-                occurred_at=e.occurred_at,
-                created_at=e.created_at,
-            )
-            for e in episodes
-        ],
-        memories=[
-            MemoryResponse(
-                id=m.id,
-                subject_id=m.subject_id,
-                kind=m.kind,
-                content=m.content,
-                summary=m.summary,
-                confidence=m.confidence,
-                valid_from=m.valid_from,
-                valid_to=m.valid_to,
-                source_episode_ids=m.source_episode_ids or [],
-                metadata=m.metadata_,
-                status=m.status,
-                sensitivity_labels=list(m.sensitivity_labels or []),
-                created_at=m.created_at,
-                updated_at=m.updated_at,
-            )
-            for m in memories
-        ],
+        episodes=[EpisodeResponse.from_row(e) for e in episodes],
+        memories=[MemoryResponse.from_row(m) for m in memories],
     )

--- a/server/schemas/responses.py
+++ b/server/schemas/responses.py
@@ -23,6 +23,27 @@ class EpisodeResponse(BaseModel):
     occurred_at: datetime
     created_at: datetime
 
+    @classmethod
+    def from_row(cls, row: Any) -> "EpisodeResponse":
+        """Build a response from an `EpisodeRow` ORM instance.
+
+        Single source of truth for the ORM->schema field mapping (#295) —
+        every router that returns an episode should call this instead of
+        re-listing the fields inline.
+        """
+        return cls(
+            id=row.id,
+            subject_id=row.subject_id,
+            source=row.source,
+            type=row.type,
+            payload=row.payload,
+            metadata=row.metadata_,
+            provenance=row.provenance,
+            session_id=row.session_id,
+            occurred_at=row.occurred_at,
+            created_at=row.created_at,
+        )
+
 
 class BatchCreateEpisodesResponse(BaseModel):
     episodes_created: int
@@ -50,6 +71,31 @@ class MemoryResponse(BaseModel):
     )
     created_at: datetime
     updated_at: datetime
+
+    @classmethod
+    def from_row(cls, row: Any) -> "MemoryResponse":
+        """Build a response from a `MemoryRow` ORM instance.
+
+        Single source of truth for the ORM->schema field mapping (#295) —
+        every router that returns a memory should call this instead of
+        re-listing the fields inline.
+        """
+        return cls(
+            id=row.id,
+            subject_id=row.subject_id,
+            kind=row.kind,
+            content=row.content,
+            summary=row.summary,
+            confidence=row.confidence,
+            valid_from=row.valid_from,
+            valid_to=row.valid_to,
+            source_episode_ids=row.source_episode_ids or [],
+            metadata=row.metadata_,
+            status=row.status,
+            sensitivity_labels=list(getattr(row, "sensitivity_labels", None) or []),
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
 
 
 class CompileMemoriesResponse(BaseModel):
@@ -152,6 +198,26 @@ class ResolutionResponse(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
     updated_at: datetime
+
+    @classmethod
+    def from_row(cls, row: Any) -> "ResolutionResponse":
+        """Build a response from a `ResolutionRow` ORM instance.
+
+        Single source of truth for the ORM->schema field mapping (#295) —
+        every router that returns a resolution should call this instead of
+        re-listing the fields inline.
+        """
+        return cls(
+            id=row.id,
+            subject_id=row.subject_id,
+            session_id=row.session_id,
+            status=row.status,
+            resolution_summary=row.resolution_summary,
+            resolved_at=row.resolved_at,
+            metadata=row.metadata_,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
 
 
 class ResolutionSummaryItem(BaseModel):


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Response-schema construction from ORM rows was duplicated across five
routers (`episodes.py`, `templates.py`, `timeline.py`, `memories.py`,
`resolutions.py`) — the same field list hand-built field-by-field in
up to 4 places per model, with no single source of truth. This adds a
`from_row()` classmethod to `EpisodeResponse`, `MemoryResponse`, and
`ResolutionResponse` and points every router at it instead, so a
model/schema change only needs to be made once.

## Related Issue
<!-- Link to the issue this PR addresses, e.g., "Closes #123" or "Relates to #456" -->
Closes #295

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🔧 Maintenance (refactoring, dependencies, CI, etc.)
- [ ] 🧪 Test improvement

## Changes Made
<!-- List the main changes made in this PR -->
- Added `from_row()` classmethod to `EpisodeResponse`, `MemoryResponse`, and `ResolutionResponse` in `server/schemas/responses.py`
- Updated `episodes.py`, `templates.py`, and `timeline.py` to build episode/memory responses via `from_row()` instead of inline field lists
- Updated `memories.py`'s `_to_response()` to delegate to `MemoryResponse.from_row()` (its 6 internal call sites are unchanged)
- Updated `resolutions.py`'s `create_resolution` and `list_resolutions` to use `ResolutionResponse.from_row()`

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests pass locally
- [x] Integration tests pass locally
- [ ] Manual testing completed
- [ ] New tests added for new functionality

### Test Commands Run
```bash
ruff check server/schemas/responses.py server/api/episodes.py server/api/templates.py server/api/timeline.py server/api/memories.py server/api/resolutions.py
pytest tests/ -v   # with docker compose up db -d running
```

## Checklist
<!-- Mark completed items with an "x" -->
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass
- [x] I have checked for breaking changes

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->
N/A — non-visual backend refactor.

## Additional Notes
<!-- Any additional context or notes for reviewers -->
No new tests were added since this is a pure refactor — response shapes
and existing field-mapping behavior are unchanged (including `None`-safe
defaults for `source_episode_ids` and `sensitivity_labels`), and the
existing test suite (which already exercises these response models,
e.g. `test_resolutions.py::test_resolution_response_fields` and
`test_memory_templates.py::test_apply_creates_episode_with_provenance`)
covers that the mapping still round-trips correctly.