### PR TITLE
feat: expose limit/offset pagination on GET /v1/resolutions (#332)

### DIFF
--- a/server/api/resolutions.py
+++ b/server/api/resolutions.py
@@ -54,9 +54,13 @@ async def create_resolution(
 async def list_resolutions(
     subject_id: str = Query(..., min_length=1),
     status: str | None = Query(None, pattern=r"^(open|resolved|unresolved)$"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
     session: AsyncSession = Depends(get_session),
     tenant_id: str | None = Depends(get_tenant_id),
 ):
     """List resolution records for a subject, optionally filtered by status."""
-    rows = await repo.list_resolutions(session, subject_id, tenant_id=tenant_id, status=status)
+    rows = await repo.list_resolutions(
+        session, subject_id, tenant_id=tenant_id, status=status, limit=limit, offset=offset
+    )
     return [ResolutionResponse.from_row(r) for r in rows]

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -871,13 +871,14 @@ async def list_resolutions(
     tenant_id: str | None = None,
     status: str | None = None,
     limit: int = 50,
+    offset: int = 0,
 ) -> Sequence[ResolutionRow]:
     """List resolutions for a subject, optionally filtered by status."""
     stmt = select(ResolutionRow).where(ResolutionRow.subject_id == subject_id)
     stmt = _tenant_filter(stmt, ResolutionRow.tenant_id, tenant_id)
     if status:
         stmt = stmt.where(ResolutionRow.status == status)
-    stmt = stmt.order_by(ResolutionRow.updated_at.desc()).limit(limit)
+    stmt = stmt.order_by(ResolutionRow.updated_at.desc()).limit(limit).offset(offset)
     result = await session.execute(stmt)
     return result.scalars().all()
 

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -878,7 +878,13 @@ async def list_resolutions(
     stmt = _tenant_filter(stmt, ResolutionRow.tenant_id, tenant_id)
     if status:
         stmt = stmt.where(ResolutionRow.status == status)
-    stmt = stmt.order_by(ResolutionRow.updated_at.desc()).limit(limit).offset(offset)
+    # `id` breaks ties between rows sharing an updated_at (bulk writes in one
+    # transaction share a single now()), so OFFSET pages never skip or repeat rows.
+    stmt = (
+        stmt.order_by(ResolutionRow.updated_at.desc(), ResolutionRow.id.desc())
+        .limit(limit)
+        .offset(offset)
+    )
     result = await session.execute(stmt)
     return result.scalars().all()
 

--- a/tests/integration/test_resolutions_pagination.py
+++ b/tests/integration/test_resolutions_pagination.py
@@ -88,3 +88,36 @@ async def test_offset_skips_the_correct_number_of_rows(session_factory, subject_
     assert len(first_page) == 2
     assert len(second_page) == 1
     assert {r.id for r in first_page}.isdisjoint({r.id for r in second_page})
+
+@pytest.mark.anyio
+async def test_route_exposes_limit_and_offset(client, subject_id):
+    """The #332 fix is the route wiring, so exercise GET /v1/resolutions itself."""
+    for i in range(3):
+        resp = await client.post(
+            "/v1/resolutions",
+            json={
+                "subject_id": subject_id,
+                "session_id": f"sess-page-{i}",
+                "status": "resolved",
+                "resolution_summary": f"resolution {i}",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+    first = await client.get(
+        "/v1/resolutions", params={"subject_id": subject_id, "limit": 2, "offset": 0}
+    )
+    assert first.status_code == 200, first.text
+    assert len(first.json()) == 2
+
+    second = await client.get(
+        "/v1/resolutions", params={"subject_id": subject_id, "limit": 2, "offset": 2}
+    )
+    assert second.status_code == 200, second.text
+    assert len(second.json()) == 1
+
+    seen = {r["session_id"] for r in first.json()} | {r["session_id"] for r in second.json()}
+    assert seen == {"sess-page-0", "sess-page-1", "sess-page-2"}
+
+    bad = await client.get("/v1/resolutions", params={"subject_id": subject_id, "limit": 0})
+    assert bad.status_code == 422

--- a/tests/integration/test_resolutions_pagination.py
+++ b/tests/integration/test_resolutions_pagination.py
@@ -1,0 +1,90 @@
+"""Regression: GET /v1/resolutions must actually page — limit/offset were
+accepted at the repo layer but never exposed on the route (#332), so a
+subject with more resolutions than the hardcoded page size could never
+retrieve the rest. This walks every page with a small limit and asserts
+every resolution is returned exactly once, in stable order.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+
+from server.db import repositories as repo
+from server.db.tables import ResolutionRow
+
+
+@pytest.mark.anyio
+async def test_offset_pagination_returns_every_resolution_exactly_once(
+    session_factory, subject_id
+):
+    n = 5
+    base = dt.datetime(2020, 6, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+    ids = [uuid.uuid4() for _ in range(n)]
+    async with session_factory() as session:
+        for i, rid in enumerate(ids):
+            session.add(
+                ResolutionRow(
+                    id=rid,
+                    subject_id=subject_id,
+                    session_id=f"sess-{i}",
+                    status="resolved",
+                    resolution_summary=f"resolution {i}",
+                    resolved_at=base,
+                    # updated_at is the ORDER BY key; space these out so page
+                    # boundaries are deterministic instead of relying on
+                    # same-millisecond insert order.
+                    updated_at=base + dt.timedelta(minutes=i),
+                )
+            )
+        await session.commit()
+
+    seen: list[uuid.UUID] = []
+    limit = 2
+    offset = 0
+    for _ in range(n + 3):  # safety bound against an infinite loop
+        async with session_factory() as session:
+            rows = await repo.list_resolutions(
+                session, subject_id, tenant_id=None, limit=limit, offset=offset
+            )
+        if not rows:
+            break
+        seen.extend(r.id for r in rows)
+        if len(rows) < limit:
+            break
+        offset += limit
+
+    assert sorted(seen) == sorted(ids), "every resolution must be returned across pages"
+    assert len(seen) == len(set(seen)), "no resolution may be returned twice"
+
+
+@pytest.mark.anyio
+async def test_offset_skips_the_correct_number_of_rows(session_factory, subject_id):
+    base = dt.datetime(2020, 6, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+    async with session_factory() as session:
+        for i in range(3):
+            session.add(
+                ResolutionRow(
+                    id=uuid.uuid4(),
+                    subject_id=subject_id,
+                    session_id=f"sess-{i}",
+                    status="resolved",
+                    updated_at=base + dt.timedelta(minutes=i),
+                )
+            )
+        await session.commit()
+
+    async with session_factory() as session:
+        first_page = await repo.list_resolutions(
+            session, subject_id, tenant_id=None, limit=2, offset=0
+        )
+    async with session_factory() as session:
+        second_page = await repo.list_resolutions(
+            session, subject_id, tenant_id=None, limit=2, offset=2
+        )
+
+    assert len(first_page) == 2
+    assert len(second_page) == 1
+    assert {r.id for r in first_page}.isdisjoint({r.id for r in second_page})


### PR DESCRIPTION
## Description
`GET /v1/resolutions` ignored the repo layer's existing `limit` param entirely
and had no `offset` support at all, so a subject with more resolutions than
the hardcoded page size could never retrieve the rest. This exposes bounded
`limit`/`offset` query params on the route, mirroring the existing
`/v1/subjects` pagination pattern, and adds `offset` support to
`repo.list_resolutions`.

## Related Issue
Closes #332

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance (refactoring, dependencies, CI, etc.)
- [ ] 🧪 Test improvement

## Changes Made
- Added `offset: int = 0` param to `repo.list_resolutions`, applied via `.offset(offset)` after the existing `.limit(limit)`
- Exposed `limit` (`ge=1, le=200`, default 50) and `offset` (`ge=0`, default 0) as query params on `GET /v1/resolutions`, matching the `/v1/subjects` convention
- Added `tests/integration/test_resolutions_pagination.py`: one test walks every page with a small limit and asserts every resolution is returned exactly once with no duplicates, another confirms `offset` skips the correct row count

## Testing
- [x] Unit tests pass locally
- [x] Integration tests pass locally
- [ ] Manual testing completed
- [x] New tests added for new functionality

### Test Commands Run
```bash
docker compose up db -d
ruff check server/api/resolutions.py server/db/repositories.py tests/integration/test_resolutions_pagination.py
pytest tests/integration/test_resolutions_pagination.py -v
pytest tests/test_route_limits_invariant.py tests/test_resolutions.py -v
```

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass
- [x] I have checked for breaking changes

## Screenshots / Recordings
N/A — backend API change, no UI.

## Additional Notes
`offset` defaults to `0` and all 4 existing internal callers of
`repo.list_resolutions` (`handoff.py`, `health.py`, `sla.py`, `context.py`)
use keyword arguments and never passed `offset` before, so this is fully
backward-compatible for them.