### PR TITLE
feat: expose limit/offset pagination on GET /v1/timeline (#331)

### DIFF
--- a/server/api/timeline.py
+++ b/server/api/timeline.py
@@ -16,13 +16,28 @@ router = APIRouter(tags=["timeline"])
 @router.get("/v1/timeline", response_model=TimelineResponse, summary="Get subject timeline")
 async def get_timeline(
     subject_id: str = Query(...),
+    limit: int = Query(100, ge=1, le=200),
+    offset: int = Query(0, ge=0),
     session: AsyncSession = Depends(get_session),
     tenant_id: str | None = Depends(get_tenant_id),
 ):
-    episodes = await repo.list_episodes_by_subject(session, subject_id, tenant_id=tenant_id)
-    memories = await repo.list_memories_by_subject(session, subject_id, tenant_id=tenant_id)
+    # Fetch one extra row per collection to detect whether more pages
+    # remain, without a separate COUNT query (#331); trim back to `limit`
+    # before building the response.
+    episodes = await repo.list_episodes_by_subject(
+        session, subject_id, tenant_id=tenant_id, limit=limit + 1, offset=offset
+    )
+    memories = await repo.list_memories_by_subject(
+        session, subject_id, tenant_id=tenant_id, limit=limit + 1, offset=offset
+    )
+    episodes_has_more = len(episodes) > limit
+    memories_has_more = len(memories) > limit
+    episodes = episodes[:limit]
+    memories = memories[:limit]
     return TimelineResponse(
         subject_id=subject_id,
         episodes=[EpisodeResponse.from_row(e) for e in episodes],
         memories=[MemoryResponse.from_row(m) for m in memories],
+        episodes_has_more=episodes_has_more,
+        memories_has_more=memories_has_more,
     )

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -101,6 +101,7 @@ async def list_episodes_by_subject(
     *,
     tenant_id: str | None = None,
     limit: int = 100,
+    offset: int = 0,
     newest_first: bool = False,
 ) -> Sequence[EpisodeRow]:
     # Order by `occurred_at` (the source-event time) so backfilled episodes
@@ -113,12 +114,18 @@ async def list_episodes_by_subject(
     # bounded "recent activity" window MUST use it: with the default ascending
     # order, a `limit` smaller than the subject's lifetime episode count
     # returns the OLDEST `limit` rows — the opposite of recent.
+    #
+    # `offset` is applied within that same ordering, i.e. it pages through
+    # the newest-first window when `newest_first=True`, or the
+    # oldest-first window otherwise — it does not change which end of the
+    # timeline paging starts from.
     if newest_first:
         stmt = (
             select(EpisodeRow)
             .where(EpisodeRow.subject_id == subject_id)
-            .order_by(EpisodeRow.occurred_at.desc(), EpisodeRow.created_at.desc())
+            .order_by(EpisodeRow.occurred_at.desc(), EpisodeRow.created_at.desc(), EpisodeRow.id.desc())
             .limit(limit)
+            .offset(offset)
         )
         stmt = _tenant_filter(stmt, EpisodeRow.tenant_id, tenant_id)
         result = await session.execute(stmt)
@@ -129,8 +136,9 @@ async def list_episodes_by_subject(
     stmt = (
         select(EpisodeRow)
         .where(EpisodeRow.subject_id == subject_id)
-        .order_by(EpisodeRow.occurred_at.asc(), EpisodeRow.created_at.asc())
+        .order_by(EpisodeRow.occurred_at.asc(), EpisodeRow.created_at.asc(), EpisodeRow.id.asc())
         .limit(limit)
+        .offset(offset)
     )
     stmt = _tenant_filter(stmt, EpisodeRow.tenant_id, tenant_id)
     result = await session.execute(stmt)
@@ -154,7 +162,7 @@ async def list_episodes_by_session(
         select(EpisodeRow)
         .where(EpisodeRow.subject_id == subject_id)
         .where(EpisodeRow.session_id == session_id)
-        .order_by(EpisodeRow.occurred_at.asc(), EpisodeRow.created_at.asc())
+        .order_by(EpisodeRow.occurred_at.asc(), EpisodeRow.created_at.asc(), EpisodeRow.id.asc())
         .limit(limit)
     )
     stmt = _tenant_filter(stmt, EpisodeRow.tenant_id, tenant_id)
@@ -277,7 +285,7 @@ async def search_memories(
         stmt = stmt.where(MemoryRow.kind == kind)
     if query:
         stmt = stmt.where(MemoryRow.content.ilike(f"%{query}%"))
-    stmt = stmt.order_by(MemoryRow.created_at.desc()).limit(limit)
+    stmt = stmt.order_by(MemoryRow.created_at.desc(), MemoryRow.id.desc()).limit(limit)
     result = await session.execute(stmt)
     return result.scalars().all()
 
@@ -288,12 +296,14 @@ async def list_memories_by_subject(
     *,
     tenant_id: str | None = None,
     limit: int = 100,
+    offset: int = 0,
 ) -> Sequence[MemoryRow]:
     stmt = (
         select(MemoryRow)
         .where(MemoryRow.subject_id == subject_id)
-        .order_by(MemoryRow.created_at.asc())
+        .order_by(MemoryRow.created_at.asc(), MemoryRow.id.asc())
         .limit(limit)
+        .offset(offset)
     )
     stmt = _tenant_filter(stmt, MemoryRow.tenant_id, tenant_id)
     result = await session.execute(stmt)
@@ -321,7 +331,7 @@ async def list_active_memories_by_subject(
         select(MemoryRow)
         .where(MemoryRow.subject_id == subject_id)
         .where(MemoryRow.status == "active")
-        .order_by(MemoryRow.created_at.asc())
+        .order_by(MemoryRow.created_at.asc(), MemoryRow.id.asc())
         .limit(limit)
     )
     stmt = _unexpired(stmt)

--- a/server/schemas/responses.py
+++ b/server/schemas/responses.py
@@ -169,6 +169,8 @@ class TimelineResponse(BaseModel):
     subject_id: str
     episodes: list[EpisodeResponse]
     memories: list[MemoryResponse]
+    episodes_has_more: bool = False
+    memories_has_more: bool = False
 
 
 class DeleteSubjectResponse(BaseModel):

--- a/tests/integration/test_timeline_pagination.py
+++ b/tests/integration/test_timeline_pagination.py
@@ -11,13 +11,37 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import delete
 
 from server.db.tables import EpisodeRow, MemoryRow
 
 pytestmark = pytest.mark.anyio
 
 
+_SEEDED: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_seeded(session_factory):
+    """Delete the rows each test seeded.
+
+    The suite shares one database and a subject is derived from the episode and
+    memory rows that mention it, so a test that seeds and leaves permanently
+    enlarges `GET /v1/subjects` and eventually fails a test in another file.
+    The cost stays in the file that creates it.
+    """
+    yield
+    subject_ids, _SEEDED[:] = list(_SEEDED), []
+    if not subject_ids:
+        return
+    async with session_factory() as session:
+        await session.execute(delete(MemoryRow).where(MemoryRow.subject_id.in_(subject_ids)))
+        await session.execute(delete(EpisodeRow).where(EpisodeRow.subject_id.in_(subject_ids)))
+        await session.commit()
+
+
 async def _seed(session_factory, subject_id: str, n_episodes: int, n_memories: int):
+    _SEEDED.append(subject_id)
     async with session_factory() as session:
         episode_ids = []
         for i in range(n_episodes):
@@ -126,3 +150,73 @@ async def test_limit_out_of_bounds_is_422(client: AsyncClient, session_factory):
         "/v1/timeline", params={"subject_id": subject_id, "offset": -1}
     )
     assert response.status_code == 422
+
+async def test_exactly_limit_rows_is_not_has_more(client: AsyncClient, session_factory):
+    """The limit+1 sentinel exists for this boundary: a page that is exactly full
+    must still report has_more=False when nothing lies beyond it."""
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=3, n_memories=3)
+
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "limit": 3, "offset": 0}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["episodes"]) == 3 and body["episodes_has_more"] is False
+    assert len(body["memories"]) == 3 and body["memories_has_more"] is False
+
+
+async def test_offset_at_total_returns_an_empty_last_page(client: AsyncClient, session_factory):
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=4, n_memories=4)
+
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "limit": 4, "offset": 4}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["episodes"] == [] and body["episodes_has_more"] is False
+    assert body["memories"] == [] and body["memories_has_more"] is False
+
+
+async def test_memories_has_more_is_true_when_memories_exceed_the_page(
+    client: AsyncClient, session_factory
+):
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=1, n_memories=5)
+
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "limit": 2, "offset": 0}
+    )
+    body = response.json()
+    assert len(body["memories"]) == 2 and body["memories_has_more"] is True
+    assert len(body["episodes"]) == 1 and body["episodes_has_more"] is False
+
+
+async def test_rows_sharing_a_timestamp_page_without_gaps_or_repeats(
+    client: AsyncClient, session_factory
+):
+    """Rows written in one transaction share a single now() for created_at and
+    occurred_at, so ORDER BY on the timestamps alone is not a total order and
+    OFFSET pages could skip or repeat rows. The id tiebreak makes paging exact:
+    every seeded row must appear exactly once across the pages."""
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=23, n_memories=17)
+
+    seen_episodes: list[str] = []
+    seen_memories: list[str] = []
+    offset = 0
+    while True:
+        response = await client.get(
+            "/v1/timeline", params={"subject_id": subject_id, "limit": 5, "offset": offset}
+        )
+        assert response.status_code == 200
+        body = response.json()
+        seen_episodes += [e["id"] for e in body["episodes"]]
+        seen_memories += [m["id"] for m in body["memories"]]
+        if not body["episodes_has_more"] and not body["memories_has_more"]:
+            break
+        offset += 5
+
+    assert len(seen_episodes) == 23 and len(set(seen_episodes)) == 23
+    assert len(seen_memories) == 17 and len(set(seen_memories)) == 17

--- a/tests/integration/test_timeline_pagination.py
+++ b/tests/integration/test_timeline_pagination.py
@@ -1,0 +1,128 @@
+"""GET /v1/timeline previously called the repo layer with no limit/offset
+exposed, silently capping at 100 episodes and 100 memories with no way
+to page further and no signal that the response was truncated (#331).
+This covers: bounded limit/offset params, has_more flags per collection,
+and that paging with offset returns every row exactly once.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from server.db.tables import EpisodeRow, MemoryRow
+
+pytestmark = pytest.mark.anyio
+
+
+async def _seed(session_factory, subject_id: str, n_episodes: int, n_memories: int):
+    async with session_factory() as session:
+        episode_ids = []
+        for i in range(n_episodes):
+            row = EpisodeRow(
+                subject_id=subject_id,
+                source="test",
+                type="message",
+                payload={"i": i},
+                metadata_={},
+                provenance={},
+            )
+            session.add(row)
+            episode_ids.append(row)
+        await session.flush()
+
+        for i in range(n_memories):
+            session.add(
+                MemoryRow(
+                    subject_id=subject_id,
+                    kind="profile_fact",
+                    content=f"memory {i}",
+                    summary=f"memory {i}",
+                    confidence=1.0,
+                    source_episode_ids=[episode_ids[0].id] if episode_ids else [],
+                    metadata_={},
+                    status="active",
+                    sensitivity_labels=[],
+                    suggested_labels=[],
+                )
+            )
+        await session.commit()
+
+
+async def test_has_more_is_true_when_a_collection_exceeds_the_page(
+    client: AsyncClient, session_factory
+):
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=5, n_memories=2)
+
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "limit": 3, "offset": 0}
+    )
+    assert response.status_code == 200
+    body = response.json()
+
+    assert len(body["episodes"]) == 3
+    assert body["episodes_has_more"] is True
+    assert len(body["memories"]) == 2
+    assert body["memories_has_more"] is False
+
+
+async def test_has_more_is_false_on_the_last_page(client: AsyncClient, session_factory):
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=5, n_memories=0)
+
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "limit": 3, "offset": 3}
+    )
+    assert response.status_code == 200
+    body = response.json()
+
+    assert len(body["episodes"]) == 2
+    assert body["episodes_has_more"] is False
+
+
+async def test_paging_with_offset_covers_every_episode_exactly_once(
+    client: AsyncClient, session_factory
+):
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=7, n_memories=0)
+
+    seen: list[str] = []
+    limit = 3
+    offset = 0
+    for _ in range(5):  # safety bound
+        response = await client.get(
+            "/v1/timeline", params={"subject_id": subject_id, "limit": limit, "offset": offset}
+        )
+        assert response.status_code == 200
+        body = response.json()
+        page = body["episodes"]
+        if not page:
+            break
+        seen.extend(e["id"] for e in page)
+        if not body["episodes_has_more"]:
+            break
+        offset += limit
+
+    assert len(seen) == 7
+    assert len(set(seen)) == 7
+
+
+async def test_limit_out_of_bounds_is_422(client: AsyncClient, session_factory):
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "limit": 0}
+    )
+    assert response.status_code == 422
+
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "limit": 500}
+    )
+    assert response.status_code == 422
+
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "offset": -1}
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
`GET /v1/timeline` called the repository layer with no `limit`/`offset`
exposed to the caller, silently capping at 100 episodes and 100 memories
with no way to page further and no signal that the response was
truncated. This exposes bounded `limit`/`offset` query params on the
route, matching the `/v1/subjects` convention, threaded through to
`list_episodes_by_subject`/`list_memories_by_subject`, plus an
`episodes_has_more`/`memories_has_more` flag per collection so clients
know when to page.

## Related Issue
<!-- Link to the issue this PR addresses, e.g., "Closes #123" or "Relates to #456" -->
Closes #331

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance (refactoring, dependencies, CI, etc.)
- [ ] 🧪 Test improvement

## Changes Made
<!-- List the main changes made in this PR -->
- Added `offset: int = 0` to `list_episodes_by_subject` and `list_memories_by_subject` in `server/db/repositories.py`, applied via `.offset(offset)`
- Exposed `limit` (`ge=1, le=200`, default 100 — preserving the prior implicit cap) and `offset` (`ge=0`, default 0) as query params on `GET /v1/timeline`
- Added `episodes_has_more`/`memories_has_more: bool = False` to `TimelineResponse`; computed by fetching `limit + 1` rows per collection and checking if that exceeded `limit`, avoiding a separate `COUNT` query
- Added `tests/integration/test_timeline_pagination.py`: covers `has_more=True` mid-list, `has_more=False` on the last page, full-coverage paging with no duplicates/gaps, and 422s for out-of-bounds `limit`/`offset`

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests pass locally
- [x] Integration tests pass locally
- [ ] Manual testing completed
- [x] New tests added for new functionality

### Test Commands Run
```bash
docker compose up db -d
ruff check server/api/timeline.py server/db/repositories.py server/schemas/responses.py tests/integration/test_timeline_pagination.py
pytest tests/integration/test_timeline_pagination.py -v
pytest tests/test_route_limits_invariant.py -v
```

## Checklist
<!-- Mark completed items with an "x" -->
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass
- [x] I have checked for breaking changes

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->
N/A — backend API change, no UI.

## Additional Notes
<!-- Any additional context or notes for reviewers -->
`offset` defaults to `0` and all 6 existing internal callers of
`list_episodes_by_subject`/`list_memories_by_subject`
(`entities.py`, `handoff.py`, `health.py`, `context.py`, `sla.py`, plus
this route itself) use keyword arguments and never passed `offset`
before, so this is fully backward-compatible for them. `has_more` is
computed via an over-fetch (`limit + 1`) rather than a separate `COUNT`
query, matching the pattern used for `has_more` elsewhere in the repo
(`server/api/memories.py`'s compile endpoint).