### PR TITLE
feat(timeline): let GET /v1/timeline return the most recent records

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ See the full [getting started guide](https://github.com/smaramwbc/statewave-docs
 | `POST` | `/v1/memories/compile` | Compile memories from episodes (idempotent) |
 | `GET` | `/v1/memories/search` | Search by kind, text, or semantic similarity |
 | `POST` | `/v1/context` | Assemble ranked, token-bounded context bundle |
-| `GET` | `/v1/timeline` | Chronological subject timeline |
+| `GET` | `/v1/timeline` | Chronological subject timeline (`newest_first` for recent history) |
 | `GET` | `/v1/subjects` | List known subjects with episode/memory counts |
 | `DELETE` | `/v1/subjects/{id}` | Permanently delete all data for a subject |
 | `POST` | `/v1/resolutions` | Track issue resolution state per session |

--- a/server/api/timeline.py
+++ b/server/api/timeline.py
@@ -16,24 +16,62 @@ router = APIRouter(tags=["timeline"])
 @router.get("/v1/timeline", response_model=TimelineResponse, summary="Get subject timeline")
 async def get_timeline(
     subject_id: str = Query(...),
-    limit: int = Query(100, ge=1, le=200),
-    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=200, description="Rows per collection."),
+    offset: int = Query(
+        0,
+        ge=0,
+        description=(
+            "Rows to skip per collection, counted from the oldest end by default "
+            "or from the newest end when `newest_first=true`."
+        ),
+    ),
+    newest_first: bool = Query(
+        False,
+        description=(
+            "Page from the most recent records instead of the oldest ones. "
+            "Applies to both collections. Rows within a page are still returned "
+            "in ascending chronological order; `offset` then counts back from the "
+            "newest row, so `offset=limit` is the next-older page."
+        ),
+    ),
     session: AsyncSession = Depends(get_session),
     tenant_id: str | None = Depends(get_tenant_id),
 ):
-    # Fetch one extra row per collection to detect whether more pages
-    # remain, without a separate COUNT query (#331); trim back to `limit`
-    # before building the response.
+    # With the default ascending order a subject past `limit` rows returns its
+    # OLDEST rows and its recent history is unreachable through this route —
+    # the wrong half to lose for a consumer asking "what has happened lately".
+    # `newest_first` takes the window from the other end; the default stays
+    # False so an existing client sees no change.
+    #
+    # Fetch one extra row per collection to detect whether more pages remain
+    # without a separate COUNT query (#331). The repository returns ascending
+    # rows in both modes, so the surplus row is the LAST one when paging from
+    # the oldest end and the FIRST one when paging from the newest end — trim
+    # accordingly, or newest_first would silently drop the newest row.
     episodes = await repo.list_episodes_by_subject(
-        session, subject_id, tenant_id=tenant_id, limit=limit + 1, offset=offset
+        session,
+        subject_id,
+        tenant_id=tenant_id,
+        limit=limit + 1,
+        offset=offset,
+        newest_first=newest_first,
     )
     memories = await repo.list_memories_by_subject(
-        session, subject_id, tenant_id=tenant_id, limit=limit + 1, offset=offset
+        session,
+        subject_id,
+        tenant_id=tenant_id,
+        limit=limit + 1,
+        offset=offset,
+        newest_first=newest_first,
     )
     episodes_has_more = len(episodes) > limit
     memories_has_more = len(memories) > limit
-    episodes = episodes[:limit]
-    memories = memories[:limit]
+    if newest_first:
+        episodes = episodes[1:] if episodes_has_more else episodes
+        memories = memories[1:] if memories_has_more else memories
+    else:
+        episodes = episodes[:limit]
+        memories = memories[:limit]
     return TimelineResponse(
         subject_id=subject_id,
         episodes=[EpisodeResponse.from_row(e) for e in episodes],

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -80,16 +80,20 @@ async def insert_episode(session: AsyncSession, row: EpisodeRow) -> EpisodeRow:
         if row in session:
             session.expunge(row)
         existing = (
-            await session.execute(
-                select(EpisodeRow).where(
-                    EpisodeRow.subject_id == row.subject_id,
-                    EpisodeRow.idempotency_key == row.idempotency_key,
-                    EpisodeRow.tenant_id.is_(None)
-                    if row.tenant_id is None
-                    else EpisodeRow.tenant_id == row.tenant_id,
+            (
+                await session.execute(
+                    select(EpisodeRow).where(
+                        EpisodeRow.subject_id == row.subject_id,
+                        EpisodeRow.idempotency_key == row.idempotency_key,
+                        EpisodeRow.tenant_id.is_(None)
+                        if row.tenant_id is None
+                        else EpisodeRow.tenant_id == row.tenant_id,
+                    )
                 )
             )
-        ).scalars().first()
+            .scalars()
+            .first()
+        )
         if existing is None:
             raise  # a non-idempotency constraint failed — don't swallow it
         return existing
@@ -297,7 +301,27 @@ async def list_memories_by_subject(
     tenant_id: str | None = None,
     limit: int = 100,
     offset: int = 0,
+    newest_first: bool = False,
 ) -> Sequence[MemoryRow]:
+    # `newest_first=True` selects the most-recent `limit` memories and returns
+    # them in ascending chronological order, exactly as
+    # `list_episodes_by_subject` does. Same reason: with the default ascending
+    # order a `limit` below the subject's lifetime count returns the OLDEST
+    # rows, so a bounded "recent" window is not otherwise expressible.
+    if newest_first:
+        stmt = (
+            select(MemoryRow)
+            .where(MemoryRow.subject_id == subject_id)
+            .order_by(MemoryRow.created_at.desc(), MemoryRow.id.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        stmt = _tenant_filter(stmt, MemoryRow.tenant_id, tenant_id)
+        result = await session.execute(stmt)
+        rows = list(result.scalars().all())
+        rows.reverse()  # newest-`limit` fetched desc → return ascending
+        return rows
+
     stmt = (
         select(MemoryRow)
         .where(MemoryRow.subject_id == subject_id)

--- a/tests/integration/test_timeline_newest_first.py
+++ b/tests/integration/test_timeline_newest_first.py
@@ -1,0 +1,177 @@
+"""`GET /v1/timeline` returned a subject's OLDEST records and nothing else.
+
+The repository caps each collection at 100 rows in ascending order, and the
+route exposed no way to change that, so once a subject passed 100 episodes its
+recent history became unreachable through this endpoint — the wrong half to
+lose for a consumer asking what has happened lately. `newest_first=true` takes
+the window from the other end. `/v1/context` and `/v1/handoff` already pass the
+same repository flag; this covers the route that could not.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete
+
+from server.db.tables import EpisodeRow, MemoryRow
+
+pytestmark = pytest.mark.anyio
+
+# Subjects seeded by the tests below, drained after each one. See `_cleanup_seeded`.
+_SEEDED: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_seeded(session_factory):
+    """Delete the rows each test seeded.
+
+    The suite shares one database and a subject is derived from the episode and
+    memory rows that mention it, so a test that seeds and leaves permanently
+    enlarges `GET /v1/subjects`. That listing pages at 50 by default and
+    `test_edge_cases.py::test_list_subjects` asserts its own subject is on the
+    first page — leaked subjects eventually fail a test in another file, which
+    is a miserable thing to debug. The cost stays in the file that creates it.
+    """
+    yield
+    subject_ids, _SEEDED[:] = list(_SEEDED), []
+    if not subject_ids:
+        return
+    async with session_factory() as session:
+        await session.execute(delete(MemoryRow).where(MemoryRow.subject_id.in_(subject_ids)))
+        await session.execute(delete(EpisodeRow).where(EpisodeRow.subject_id.in_(subject_ids)))
+        await session.commit()
+
+
+async def _seed(session_factory, subject_id: str, n_episodes: int, n_memories: int):
+    """Seed `n_episodes` + `n_memories` rows, each one minute after the last.
+
+    The timestamps are explicit because both columns default to `now()`, which
+    Postgres holds constant for a transaction: rows written in one commit would
+    share a timestamp, their relative order would be unspecified, and every
+    ordering assertion below would pass for the wrong reason.
+    """
+    _SEEDED.append(subject_id)
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with session_factory() as session:
+        first_episode = None
+        for i in range(n_episodes):
+            row = EpisodeRow(
+                subject_id=subject_id,
+                source="test",
+                type="message",
+                payload={"i": i},
+                occurred_at=base + timedelta(minutes=i),
+                metadata_={},
+                provenance={},
+            )
+            session.add(row)
+            if first_episode is None:
+                first_episode = row
+        await session.flush()
+
+        for i in range(n_memories):
+            session.add(
+                MemoryRow(
+                    subject_id=subject_id,
+                    kind="profile_fact",
+                    content=f"memory {i}",
+                    summary=f"memory {i}",
+                    confidence=1.0,
+                    created_at=base + timedelta(minutes=i),
+                    source_episode_ids=[first_episode.id] if first_episode is not None else [],
+                    metadata_={},
+                    status="active",
+                    sensitivity_labels=[],
+                    suggested_labels=[],
+                )
+            )
+        await session.commit()
+
+
+async def test_newest_first_returns_the_most_recent_window(client: AsyncClient, session_factory):
+    """Past the 100-row cap, the recent end is only reachable with the flag."""
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=105, n_memories=0)
+
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "newest_first": "true"}
+    )
+
+    assert response.status_code == 200
+    ordinals = [e["payload"]["i"] for e in response.json()["episodes"]]
+    assert len(ordinals) == 100
+    assert ordinals == list(range(5, 105))
+
+
+async def test_default_still_returns_the_oldest_window(client: AsyncClient, session_factory):
+    """Omitting the parameter must behave exactly as before."""
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=105, n_memories=0)
+
+    response = await client.get("/v1/timeline", params={"subject_id": subject_id})
+
+    ordinals = [e["payload"]["i"] for e in response.json()["episodes"]]
+    assert ordinals == list(range(0, 100))
+
+
+async def test_newest_first_page_is_still_ascending(client: AsyncClient, session_factory):
+    """Which end the window is taken from is separate from the order within it."""
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=6, n_memories=0)
+
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "newest_first": "true"}
+    )
+
+    occurred = [e["occurred_at"] for e in response.json()["episodes"]]
+    assert occurred == sorted(occurred)
+
+
+async def test_newest_first_applies_to_memories_too(client: AsyncClient, session_factory):
+    """The parameter is about the timeline, so it must not silently mean
+    "episodes only" — a caller asking for recent history and getting the oldest
+    memories back has no way to tell."""
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=0, n_memories=105)
+
+    response = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "newest_first": "true"}
+    )
+
+    contents = [m["content"] for m in response.json()["memories"]]
+    assert len(contents) == 100
+    assert contents[0] == "memory 5"
+    assert contents[-1] == "memory 104"
+
+
+async def test_newest_first_is_unaffected_below_the_cap(client: AsyncClient, session_factory):
+    """Under the cap both directions see the whole history, in the same order."""
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=7, n_memories=0)
+
+    default = await client.get("/v1/timeline", params={"subject_id": subject_id})
+    newest = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "newest_first": "true"}
+    )
+
+    assert [e["id"] for e in default.json()["episodes"]] == [
+        e["id"] for e in newest.json()["episodes"]
+    ]
+
+
+async def test_newest_first_respects_the_subject_boundary(client: AsyncClient, session_factory):
+    """A recent-window query must not widen to another subject."""
+    mine = f"test-{uuid.uuid4().hex[:12]}"
+    theirs = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, mine, n_episodes=3, n_memories=0)
+    await _seed(session_factory, theirs, n_episodes=3, n_memories=0)
+
+    response = await client.get("/v1/timeline", params={"subject_id": mine, "newest_first": "true"})
+
+    body = response.json()
+    assert body["subject_id"] == mine
+    assert len(body["episodes"]) == 3

--- a/tests/integration/test_timeline_pagination.py
+++ b/tests/integration/test_timeline_pagination.py
@@ -220,3 +220,44 @@ async def test_rows_sharing_a_timestamp_page_without_gaps_or_repeats(
 
     assert len(seen_episodes) == 23 and len(set(seen_episodes)) == 23
     assert len(seen_memories) == 17 and len(set(seen_memories)) == 17
+
+
+async def test_newest_first_pages_from_the_recent_end_without_dropping_the_newest_row(
+    client: AsyncClient, session_factory
+):
+    """newest_first + limit/offset: the first page is the `limit` most recent
+    rows (returned ascending), has_more reports the older rows beyond it, and
+    offset walks further back. The over-fetch sentinel must be trimmed from the
+    OLD end here — a naive [:limit] would silently drop the newest row."""
+    subject_id = f"test-{uuid.uuid4().hex[:12]}"
+    await _seed(session_factory, subject_id, n_episodes=7, n_memories=0)
+
+    full = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "limit": 200, "offset": 0}
+    )
+    all_ids = [e["id"] for e in full.json()["episodes"]]  # ascending, all 7
+    assert len(all_ids) == 7
+
+    page1 = await client.get(
+        "/v1/timeline",
+        params={"subject_id": subject_id, "limit": 3, "offset": 0, "newest_first": "true"},
+    )
+    body = page1.json()
+    assert [e["id"] for e in body["episodes"]] == all_ids[-3:]  # newest 3, still ascending
+    assert body["episodes_has_more"] is True
+
+    page2 = await client.get(
+        "/v1/timeline",
+        params={"subject_id": subject_id, "limit": 3, "offset": 3, "newest_first": "true"},
+    )
+    body = page2.json()
+    assert [e["id"] for e in body["episodes"]] == all_ids[-6:-3]
+    assert body["episodes_has_more"] is True
+
+    page3 = await client.get(
+        "/v1/timeline",
+        params={"subject_id": subject_id, "limit": 3, "offset": 6, "newest_first": "true"},
+    )
+    body = page3.json()
+    assert [e["id"] for e in body["episodes"]] == all_ids[:1]
+    assert body["episodes_has_more"] is False


### PR DESCRIPTION
## The problem

`GET /v1/timeline` passes no ordering flag, so it takes the repository default: the first 100 rows, ascending. Once a subject has more than 100 episodes, **its recent history is unreachable through this endpoint** — every request returns the same oldest hundred, and the gap widens for the rest of the subject's life.

For a consumer keeping a bounded "what has happened lately" window, that is the wrong half to lose. There was no parameter to ask for the other end.

This is not a new capability in the data layer. `list_episodes_by_subject` has supported `newest_first` since the ordering was introduced, and its own comment says callers wanting a bounded recent window *must* use it:

```python
# `newest_first=True` selects the most-recent `limit` episodes (then
# returns them in ascending chronological order). Callers that want a
# bounded "recent activity" window MUST use it: with the default ascending
# order, a `limit` smaller than the subject's lifetime episode count
# returns the OLDEST `limit` rows — the opposite of recent.
```

`/v1/context` (`services/context.py`) and `/v1/handoff` (`services/handoff.py`) already pass `newest_first=True`. The timeline route was the one caller that could not ask for it.

## The change

- `GET /v1/timeline?newest_first=true` takes the window from the newest end and still returns it in **ascending chronological order** — only *which* rows change, not how they are sorted.
- It applies to **both** collections. The parameter names the timeline, and having it silently mean "episodes only" would hand a caller the oldest memories with no way to tell. That needed the matching flag on `list_memories_by_subject`, added here mirroring the episode implementation.
- **The default is unchanged.** `newest_first` defaults to `false`, existing clients see byte-identical responses, and a test pins that.

## Tests

`tests/integration/test_timeline_newest_first.py`, six cases:

| Test | Asserts |
| --- | --- |
| `test_newest_first_returns_the_most_recent_window` | 105 episodes in → ordinals 5..104 out |
| `test_default_still_returns_the_oldest_window` | no parameter → ordinals 0..99, exactly as before |
| `test_newest_first_page_is_still_ascending` | which end ≠ what order |
| `test_newest_first_applies_to_memories_too` | memories honour it as well |
| `test_newest_first_is_unaffected_below_the_cap` | under 100 rows both directions agree |
| `test_newest_first_respects_the_subject_boundary` | the window does not widen to another subject |

Two of the six fail against the unmodified route (verified by reverting it); the other four are regression guards that must pass either way.

The seed helper writes explicit `occurred_at` / `created_at` values one minute apart, because both columns default to `now()` — which Postgres holds constant for a transaction, so rows written in one commit would share a timestamp and the ordering assertions would pass for the wrong reason.

The file also cleans up the subjects it seeds. A subject is derived from the rows that mention it, `GET /v1/subjects` pages at 50, and `test_edge_cases.py::test_list_subjects` asserts its own subject is on the first page — so a seeding test that leaves rows behind eventually fails a test in a different file.

## Verification

- `tests/integration/test_timeline_newest_first.py` — 6 passed.
- Run together with `test_golden_path`, `test_tenant_isolation`, `test_edge_cases`, `test_recent_episode_window`, `test_episode_leak`, `test_subject_delete_cleanup`, `test_idempotent_ingest` — 46 passed.
- Unit suite — 925 passed. `tests/test_config.py::test_compiler_type_default_is_valid` and `::test_embedding_provider_default_is_valid` fail in a whole-directory run both with and without this change (test-order pollution — they pass when that file runs alone); unrelated to this PR.
- `ruff check` and `ruff format --check` clean.

Run against a disposable pgvector instance, not the developer `.env` (`STATEWAVE_ENV_FILE=""`).

## Relationship to #362

Independent, but they touch the same function. #362 adds `limit`/`offset` and per-collection `has_more` flags; this adds `newest_first`. Either can merge first.

**One thing to watch when both are in.** #362 fetches `limit + 1` rows to detect a further page and trims with `episodes[:limit]`. Under `newest_first` the surplus row is the *oldest* one, so that trim would discard the newest record — precisely the row the caller asked for. It needs to become:

```python
episodes = episodes[-limit:] if newest_first else episodes[:limit]
```

I have the merged version of both changes, with tests covering that trim direction, and am happy to open it as a follow-up once #362 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)