### PR TITLE
chore: bump version to 1.5.0 (and propagate mirrors)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -90,7 +90,7 @@ body:
         - OS: [e.g., macOS 14.0, Ubuntu 22.04]
         - Python version: [e.g., 3.11.4]
         - Node.js version: [if applicable]
-        - Statewave version: [e.g., 1.0.0]
+        - Statewave version: [e.g., 1.5.0]
         - SDK version: [if using SDK]
         - Deployment: [local, Docker, Fly.io, etc.]
     validations:

--- a/.github/ISSUE_TEMPLATE/operator_issue.yml
+++ b/.github/ISSUE_TEMPLATE/operator_issue.yml
@@ -86,7 +86,7 @@ body:
       label: Environment
       description: Provide your environment details
       placeholder: |
-        - Statewave version: [e.g., 1.0.0]
+        - Statewave version: [e.g., 1.5.0]
         - Docker version: [if applicable]
         - Database: [PostgreSQL version]
         - Cloud region: [if applicable]

--- a/.github/ISSUE_TEMPLATE/sdk_issue.yml
+++ b/.github/ISSUE_TEMPLATE/sdk_issue.yml
@@ -87,7 +87,7 @@ body:
       label: Environment
       description: Provide your environment details
       placeholder: |
-        - SDK version: [e.g., 1.0.0]
+        - SDK version: [e.g., 1.5.0]
         - Python/Node.js version:
         - OS:
     validations:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Statewave is the open-source memory runtime that gives AI agents reproducible, p
 
 _If Statewave is useful to you, a ⭐ on the repo helps others discover it._
 
-> **v1.4.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
+> **v1.5.0** — actively developed. [Changelog](https://github.com/smaramwbc/statewave-docs/blob/main/CHANGELOG.md) · [Roadmap](https://github.com/smaramwbc/statewave-docs/blob/main/roadmap.md) · [Limitations](#current-limitations)
 
 ## 🎯 Try it
 
@@ -297,7 +297,7 @@ pytest tests/ -v
 
 ## Current limitations
 
-Statewave is in active development (v1.4.0). Honest status:
+Statewave is in active development (v1.5.0). Honest status:
 
 - **Rate limiting is per-IP** — distributed (Postgres-backed), but keyed by IP only, not per-tenant or per-API-key yet
 - **Multi-tenant is app-layer** — query-scoped data isolation (v0.5) + per-tenant config / policy bundles / receipts (v0.8) + HMAC-signed audit + tenant region pin (v0.9), but no Postgres RLS yet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "statewave"
-version = "1.4.0"
+version = "1.5.0"
 description = "Open-source memory runtime for AI agents — durable, structured context with provenance."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Release prep per `statewave-docs/tools/RELEASE-CHECKLIST.md`: truth (`pyproject.toml`) 1.4.0 → 1.5.0 together with the README status mirrors, plus the issue-template version examples (stuck at 1.0.0). The docs-side mirrors are in the companion statewave-docs PR; `check-versions.py` and `check-proof-figures.py` both pass on the pair. Tag `v1.5.0` follows once both are merged.