### PR TITLE
feat(timeline): status=active filter for consumer-reachable surviving state

### DIFF
--- a/server/api/timeline.py
+++ b/server/api/timeline.py
@@ -34,6 +34,18 @@ async def get_timeline(
             "newest row, so `offset=limit` is the next-older page."
         ),
     ),
+    status: str = Query(
+        "all",
+        pattern="^(all|active)$",
+        description=(
+            "Memory rows to include: `all` (default — superseded and expired "
+            "rows are returned, matching the previous behaviour) or `active` "
+            "(only rows that are currently authoritative: status `active` and "
+            "not past their `valid_to`). Episodes are raw history and are "
+            "never filtered. Pagination and `memories_has_more` then count "
+            "only the included rows (#370)."
+        ),
+    ),
     session: AsyncSession = Depends(get_session),
     tenant_id: str | None = Depends(get_tenant_id),
 ):
@@ -63,6 +75,7 @@ async def get_timeline(
         limit=limit + 1,
         offset=offset,
         newest_first=newest_first,
+        active_only=status == "active",
     )
     episodes_has_more = len(episodes) > limit
     memories_has_more = len(memories) > limit

--- a/server/db/repositories.py
+++ b/server/db/repositories.py
@@ -302,6 +302,7 @@ async def list_memories_by_subject(
     limit: int = 100,
     offset: int = 0,
     newest_first: bool = False,
+    active_only: bool = False,
 ) -> Sequence[MemoryRow]:
     # `newest_first=True` selects the most-recent `limit` memories and returns
     # them in ascending chronological order, exactly as
@@ -316,6 +317,8 @@ async def list_memories_by_subject(
             .limit(limit)
             .offset(offset)
         )
+        if active_only:
+            stmt = _unexpired(stmt.where(MemoryRow.status == "active"))
         stmt = _tenant_filter(stmt, MemoryRow.tenant_id, tenant_id)
         result = await session.execute(stmt)
         rows = list(result.scalars().all())
@@ -329,6 +332,8 @@ async def list_memories_by_subject(
         .limit(limit)
         .offset(offset)
     )
+    if active_only:
+        stmt = _unexpired(stmt.where(MemoryRow.status == "active"))
     stmt = _tenant_filter(stmt, MemoryRow.tenant_id, tenant_id)
     result = await session.execute(stmt)
     return result.scalars().all()

--- a/tests/integration/test_timeline_active_only.py
+++ b/tests/integration/test_timeline_active_only.py
@@ -1,0 +1,167 @@
+"""GET /v1/timeline returned superseded and expired memories inside the
+caller's `limit` budget, with no consumer-reachable way to ask for only the
+surviving state (#370). `status=active` restricts the memories collection to
+rows that are currently authoritative — status `active` and not past their
+`valid_to` — while the default `all` keeps the previous behaviour unchanged.
+Episodes are raw history and are never filtered.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import delete
+
+from server.db.tables import EpisodeRow, MemoryRow
+
+pytestmark = pytest.mark.anyio
+
+
+_SEEDED: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_seeded(session_factory):
+    yield
+    subject_ids, _SEEDED[:] = list(_SEEDED), []
+    if not subject_ids:
+        return
+    async with session_factory() as session:
+        await session.execute(delete(MemoryRow).where(MemoryRow.subject_id.in_(subject_ids)))
+        await session.execute(delete(EpisodeRow).where(EpisodeRow.subject_id.in_(subject_ids)))
+        await session.commit()
+
+
+async def _seed(session_factory, subject_id: str, rows: list[dict]):
+    """Seed memories described by dicts of (status, expired) flags, in order."""
+    _SEEDED.append(subject_id)
+    async with session_factory() as session:
+        episode = EpisodeRow(
+            subject_id=subject_id,
+            source="test",
+            type="message",
+            payload={},
+            metadata_={},
+            provenance={},
+        )
+        session.add(episode)
+        await session.flush()
+        base = datetime.now(timezone.utc) - timedelta(minutes=len(rows))
+        for i, spec in enumerate(rows):
+            valid_to = None
+            if spec.get("expired"):
+                valid_to = datetime.now(timezone.utc) - timedelta(hours=1)
+            session.add(
+                MemoryRow(
+                    created_at=base + timedelta(seconds=i),
+                    subject_id=subject_id,
+                    kind="profile_fact",
+                    content=f"fact {i} ({spec['status']})",
+                    summary=f"fact {i}",
+                    confidence=1.0,
+                    source_episode_ids=[episode.id],
+                    metadata_={},
+                    status=spec["status"],
+                    valid_to=valid_to,
+                    sensitivity_labels=[],
+                    suggested_labels=[],
+                )
+            )
+        await session.commit()
+
+
+def _subject() -> str:
+    return f"tl-active-{uuid.uuid4().hex[:12]}"
+
+
+async def test_default_still_returns_every_row(client, session_factory):
+    subject_id = _subject()
+    await _seed(
+        session_factory,
+        subject_id,
+        [{"status": "superseded"}, {"status": "active"}, {"status": "active", "expired": True}],
+    )
+    resp = await client.get("/v1/timeline", params={"subject_id": subject_id})
+    assert resp.status_code == 200
+    assert len(resp.json()["memories"]) == 3
+
+
+async def test_status_active_returns_only_authoritative_rows(client, session_factory):
+    subject_id = _subject()
+    await _seed(
+        session_factory,
+        subject_id,
+        [
+            {"status": "superseded"},
+            {"status": "active"},
+            {"status": "active", "expired": True},
+            {"status": "expired"},
+            {"status": "active"},
+        ],
+    )
+    resp = await client.get(
+        "/v1/timeline", params={"subject_id": subject_id, "status": "active"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    texts = [m["content"] for m in body["memories"]]
+    assert texts == ["fact 1 (active)", "fact 4 (active)"]
+    assert body["memories_has_more"] is False
+    # episodes are raw history — never filtered by memory status
+    assert len(body["episodes"]) == 1
+
+
+async def test_pagination_counts_only_included_rows(client, session_factory):
+    """`limit`/`has_more` must apply to the filtered set: 99 superseded rows
+    ahead of the surviving fact cannot push it out of reach (#370's motivating
+    failure)."""
+    subject_id = _subject()
+    await _seed(
+        session_factory,
+        subject_id,
+        [{"status": "superseded"} for _ in range(99)] + [{"status": "active"}],
+    )
+    resp = await client.get(
+        "/v1/timeline",
+        params={"subject_id": subject_id, "status": "active", "limit": 1},
+    )
+    body = resp.json()
+    assert [m["content"] for m in body["memories"]] == ["fact 99 (active)"]
+    assert body["memories_has_more"] is False
+
+
+async def test_active_filter_composes_with_newest_first(client, session_factory):
+    subject_id = _subject()
+    await _seed(
+        session_factory,
+        subject_id,
+        [
+            {"status": "active"},
+            {"status": "superseded"},
+            {"status": "active"},
+            {"status": "superseded"},
+            {"status": "active"},
+        ],
+    )
+    resp = await client.get(
+        "/v1/timeline",
+        params={
+            "subject_id": subject_id,
+            "status": "active",
+            "newest_first": "true",
+            "limit": 2,
+        },
+    )
+    body = resp.json()
+    # the two most recent ACTIVE rows, ascending, with more remaining
+    assert [m["content"] for m in body["memories"]] == ["fact 2 (active)", "fact 4 (active)"]
+    assert body["memories_has_more"] is True
+
+
+async def test_unknown_status_is_rejected(client):
+    resp = await client.get(
+        "/v1/timeline", params={"subject_id": "whatever", "status": "superseded"}
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
Closes #370, taking the first of the two shapes the issue offers: a `status` filter on `GET /v1/timeline`, defaulting to `all` so existing consumers see no change.

## What it does

`GET /v1/timeline?subject_id=…&status=active` restricts the **memories** collection to rows that are currently authoritative — `status = "active"` and not past their `valid_to` (the same two predicates `list_active_memories_by_subject` applies, and the same expiry semantics retrieval already honours via `_unexpired`). Episodes are raw history and are never filtered.

The filter composes with the existing pagination: `limit`, `offset`, `newest_first` and `memories_has_more` all count only the included rows — so the issue's motivating failure (99 superseded rows pushing the one surviving fact out of a `limit` window) is gone: the surviving fact is page one, row one.

## Implementation

- `list_memories_by_subject` gains `active_only: bool = False`, applied in both ordering branches before pagination, reusing `_unexpired`.
- The route maps `status=active` onto it; `status` validates against `^(all|active)$` so a typo is a 422, not a silently unfiltered read.

## Tests

`tests/integration/test_timeline_active_only.py`, five cases against a real Postgres: default returns every row (compat), `active` excludes superseded/expired/`valid_to`-past rows while leaving episodes untouched, pagination counts only included rows (the 99-superseded scenario), composition with `newest_first` incl. `has_more`, and rejection of unknown `status` values. Full integration suite 283 passed; unit suite 964 passed; ruff clean.

## Not in scope

The deeper question in #369 (bounded latest-state-per-key) stays open — this only makes the state that supersession already produces reachable. SDK parity (`statewave-py`/`statewave-ts` param passthrough) and the docs contract entry can follow once the shape is confirmed.
