### PR TITLE
fix(claims): anchor structured-candidate claims to the episode's valid_from

### DIFF
--- a/server/services/claims.py
+++ b/server/services/claims.py
@@ -465,6 +465,25 @@ def build_v2_envelope(raw_claim: Any) -> dict | None:
     return {CLAIM_METADATA_KEY: env}
 
 
+
+def anchor_valid_from(valid_to: datetime | None, default_valid_from: datetime | None) -> datetime | None:
+    """A compiler's default ``valid_from`` anchor, unless it would invert the window.
+
+    A claim carrying only ``valid_to`` earlier than the episode anchor describes
+    a fact that ENDED before the episode ("lived in Paris until 2019", recorded
+    in 2023). Defaulting ``valid_from`` to the episode anchor would persist a
+    self-contradictory window (from AFTER to) — and make the ended fact look
+    newest to the resolver's ordering. Leave the start unknown instead;
+    resolution then falls back exactly as it did before the default existed.
+    """
+    if (
+        valid_to is not None
+        and default_valid_from is not None
+        and _aware(default_valid_from) >= _aware(valid_to)
+    ):
+        return None
+    return default_valid_from
+
 def intervals_overlap(
     a_from: datetime | None,
     a_to: datetime | None,

--- a/server/services/compilers/heuristic.py
+++ b/server/services/compilers/heuristic.py
@@ -74,7 +74,7 @@ class HeuristicCompiler:
         # Profile facts. Text/kind/count/order are unchanged; a conservatively
         # recognized single-valued claim (if any) is attached additively in
         # metadata_, otherwise metadata_ stays {} exactly as before.
-        for fact, claim_md in _extract_facts_with_claims(text):
+        for fact, claim_md in _extract_facts_with_claims(text, default_valid_from=ep_valid_from):
             results.append(
                 MemoryRow(
                     id=uuid.uuid4(),
@@ -111,9 +111,13 @@ def episode_valid_from(ep: EpisodeRow) -> datetime:
          on chat-shaped payloads. This is what LoCoMo, Slack, Zendesk
          etc emit naturally; preserving it as `valid_from` makes
          "when did X happen?" answerable from the resulting memory.
-      3. `ep.created_at` — when the episode was POSTed (the previous
+      3. `ep.occurred_at` — the first-class ingest field for "when the
+         source event actually happened"; backfilled connectors set it
+         explicitly. It server-defaults to ingest time, so for episodes
+         that never set it this is the same value as step 4.
+      4. `ep.created_at` — when the episode was POSTed (the previous
          hardcoded default).
-      4. `now()` — last resort if everything else is missing.
+      5. `now()` — last resort if everything else is missing.
 
     Returning a real event time instead of the POST time keeps
     Statewave's bi-temporal validity story honest: a memory whose
@@ -135,7 +139,7 @@ def episode_valid_from(ep: EpisodeRow) -> datetime:
             if parsed is not None:
                 return parsed
 
-    return ep.created_at or datetime.now(timezone.utc)
+    return ep.occurred_at or ep.created_at or datetime.now(timezone.utc)
 
 
 def _parse_event_time(value: str) -> datetime | None:
@@ -254,7 +258,9 @@ def _claim_blocked(text: str, m: "re.Match[str]") -> bool:
     return bool(_CLAIM_BLOCKERS.search(window))
 
 
-def _extract_facts_with_claims(text: str) -> list[tuple[str, dict | None]]:
+def _extract_facts_with_claims(
+    text: str, default_valid_from: datetime | None = None
+) -> list[tuple[str, dict | None]]:
     """Each extracted fact text, paired with an optional claim envelope.
 
     Claim emission is conservative by design: only the three tight single-valued
@@ -274,7 +280,13 @@ def _extract_facts_with_claims(text: str) -> list[tuple[str, dict | None]]:
                 if value and fact.lower().startswith(trigger) and not _claim_blocked(text, m):
                     # build_claim_envelope re-validates against the registry and
                     # returns None for anything it cannot confidently key.
-                    claim_md = build_claim_envelope(key, value, source="heuristic")
+                    # Anchor the claim to the episode's temporal anchor so
+                    # _claim_cmp orders on semantic time, not created_at ties
+                    # broken by random UUIDs (same rationale as the
+                    # structured-candidate path).
+                    claim_md = build_claim_envelope(
+                        key, value, valid_from=default_valid_from, source="heuristic"
+                    )
             out.append((fact, claim_md))
     return out
 

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -39,6 +39,7 @@ from server.services.claims import (
     CLAIM_REGISTRY,
     SCOPE_SINGLE,
     build_claim_envelope,
+    anchor_valid_from,
 )
 from server.services.compilers.errors import CompilationError
 from server.services.compilers.heuristic import episode_valid_from, extract_payload_text
@@ -410,7 +411,7 @@ def _safe_dt(value: Any) -> datetime | None:
         return None
 
 
-def _llm_claim_metadata(mem: dict) -> dict | None:
+def _llm_claim_metadata(mem: dict, default_valid_from: datetime | None = None) -> dict | None:
     """Validate an LLM-PROPOSED claim into an authoritative envelope, or None.
 
     The model is untrusted for canonicalization, scope, and registry membership:
@@ -426,11 +427,16 @@ def _llm_claim_metadata(mem: dict) -> dict | None:
     key, value = raw.get("key"), raw.get("value")
     if not isinstance(key, str) or not isinstance(value, str):
         return None
+    valid_to = _safe_dt(raw.get("valid_to"))
     return build_claim_envelope(
         key,
         value,
-        valid_from=_safe_dt(raw.get("valid_from")),
-        valid_to=_safe_dt(raw.get("valid_to")),
+        # Anchor to the episode when the model proposes no valid_from, so
+        # _claim_cmp orders on semantic time instead of created_at ties broken
+        # by random UUIDs; anchor_valid_from declines the default when it
+        # would invert a producer-supplied valid_to.
+        valid_from=_safe_dt(raw.get("valid_from")) or anchor_valid_from(valid_to, default_valid_from),
+        valid_to=valid_to,
         source="llm",
     )
 
@@ -691,7 +697,7 @@ class LLMCompiler:
                 if mem.get("_recall_sweep"):
                     metadata["pass"] = "recall_sweep"
                 try:
-                    claim_md = _llm_claim_metadata(mem)
+                    claim_md = _llm_claim_metadata(mem, default_valid_from=ep_valid_from)
                 except Exception:  # pragma: no cover - defensive; never break compile
                     claim_md = None
                 if claim_md:

--- a/server/services/structured.py
+++ b/server/services/structured.py
@@ -35,11 +35,18 @@ no word detection — purely the presence of accepted structured candidates.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from typing import Any
 
 from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
-from server.services.claims import build_claim_envelope, build_v2_envelope
+from server.services.claims import (
+    CLAIM_METADATA_KEY,
+    _parse_dt,
+    anchor_valid_from,
+    build_claim_envelope,
+    build_v2_envelope,
+)
 from server.services.compilers.heuristic import episode_valid_from
 from server.services.memory_ttl import compute_valid_to
 
@@ -92,23 +99,45 @@ def is_structured_episode(payload: Any) -> bool:
     return accepted_candidates(payload) is not None
 
 
-def _candidate_claim_metadata(claim: Any) -> dict | None:
+def _candidate_claim_metadata(claim: Any, *, default_valid_from: datetime | None = None) -> dict | None:
     """Validate a candidate's optional claim into a clean stored envelope, or
-    ``None`` (rule 3 → unkeyed). Producers never define authoritative scope."""
+    ``None`` (rule 3 → unkeyed). Producers never define authoritative scope.
+
+    ``default_valid_from`` anchors claims that do not carry their own
+    ``valid_from``: without one, ``_claim_cmp`` falls through to ``created_at``
+    — which ties for rows compiled in one transaction and then breaks the tie
+    on random UUIDs, making contradiction resolution non-deterministic. The
+    episode's temporal anchor (``episode_valid_from``) is what the produced
+    MemoryRow already records as its own ``valid_from``, so the claim and its
+    row stay consistent. A producer-supplied ``valid_from`` always wins.
+    """
     if not isinstance(claim, dict):
         return None
     version = claim.get("schema_version")
     if version == 2:
-        return build_v2_envelope(claim)
+        envelope = build_v2_envelope(claim)
+        if (
+            envelope
+            and envelope[CLAIM_METADATA_KEY].get("valid_from") is None
+        ):
+            default = anchor_valid_from(_parse_dt(envelope[CLAIM_METADATA_KEY].get("valid_to")), default_valid_from)
+            if default is not None:
+                envelope[CLAIM_METADATA_KEY]["valid_from"] = default.isoformat()
+        return envelope
     if version == 1:
+        valid_to = _parse_dt(claim.get("valid_to"))
         return build_claim_envelope(
             claim.get("key"),
             claim.get("value"),
+            valid_from=_parse_dt(claim.get("valid_from"))
+            or anchor_valid_from(valid_to, default_valid_from),
+            valid_to=valid_to,
             source=claim.get("source")
             if isinstance(claim.get("source"), str)
             else "structured_candidate",
         )
     return None
+
 
 
 def compile_candidates(ep: EpisodeRow) -> list[MemoryRow] | None:
@@ -129,7 +158,7 @@ def compile_candidates(ep: EpisodeRow) -> list[MemoryRow] | None:
         kind = _KIND_MAP[c["kind"].strip().lower()]
         text = c["text"]
         metadata: dict[str, Any] = dict(c.get("metadata") or {})
-        claim_md = _candidate_claim_metadata(c.get("claim"))
+        claim_md = _candidate_claim_metadata(c.get("claim"), default_valid_from=vf)
         if claim_md:
             metadata.update(claim_md)
         confidence = c.get("confidence")

--- a/tests/test_compile_error_handling.py
+++ b/tests/test_compile_error_handling.py
@@ -36,6 +36,7 @@ class _FakeEpisode:
         self.subject_id = "user-1"
         self.payload = {"text": "My name is Alice and I work at Globex."}
         self.created_at = datetime(2026, 5, 29, tzinfo=timezone.utc)
+        self.occurred_at = None
 
 
 class _FakeSession:

--- a/tests/test_compiler_claims.py
+++ b/tests/test_compiler_claims.py
@@ -66,11 +66,16 @@ def test_heuristic_home_claim():
     assert f.metadata_["claim"]["value"] == "berlin"
 
 
-def test_heuristic_no_temporal_invented():
-    (f,) = _facts("I work at Globex")
-    assert "valid_from" not in f.metadata_["claim"]
-    assert "valid_to" not in f.metadata_["claim"]
-
+def test_heuristic_claim_anchor_is_the_episode_time_not_invented_content():
+    # The compiler must not INVENT temporal claims from text — but since the
+    # #369 follow-up it DOES anchor the claim to the episode's own timestamp
+    # (the same value the row's valid_from carries), so the resolver orders on
+    # semantic time instead of created_at ties. No valid_to is ever invented.
+    claims = [c for c in _claims("My name is Alice Chen") if c]
+    assert claims
+    for c in claims:
+        assert "valid_to" not in c
+        assert "valid_from" in c  # == episode anchor (created_at fallback here)
 
 # --- heuristic negatives: fact emitted, NO claim ------------------------------
 
@@ -262,3 +267,74 @@ async def test_compiler_uncertain_text_gains_no_supersession():
     (alice,) = _facts("My name is Alice Chen")
     alice.created_at = _NOW
     assert await _resolve([bob, alice]) == []
+
+
+# ─── Temporal anchoring (#369 follow-up: deterministic claim ordering) ───────
+
+
+def test_heuristic_claim_carries_the_episode_anchor():
+    ep = _ep("My name is Alice Chen")
+    ep.payload = dict(ep.payload or {}, event_time="2023-05-04T12:00:00+00:00")
+    results = HeuristicCompiler().compile([ep])
+    claimed = [m for m in results if m.metadata_.get("claim")]
+    assert claimed, "expected at least one claim-carrying fact"
+    for m in claimed:
+        assert m.metadata_["claim"]["valid_from"] == "2023-05-04T12:00:00+00:00"
+
+
+def test_llm_claim_defaults_to_the_provided_anchor():
+    from datetime import datetime, timezone
+
+    anchor = datetime(2023, 5, 4, 12, 0, tzinfo=timezone.utc)
+    md = _llm_claim_metadata(
+        {"claim": {"key": "employer", "value": "Globex"}}, default_valid_from=anchor
+    )
+    assert md["claim"]["valid_from"] == anchor.isoformat()
+
+
+def test_llm_model_supplied_valid_from_wins_over_the_anchor():
+    from datetime import datetime, timezone
+
+    anchor = datetime(2023, 5, 4, 12, 0, tzinfo=timezone.utc)
+    md = _llm_claim_metadata(
+        {"claim": {"key": "employer", "value": "Globex", "valid_from": "2020-01-01T00:00:00+00:00"}},
+        default_valid_from=anchor,
+    )
+    assert md["claim"]["valid_from"] == "2020-01-01T00:00:00+00:00"
+
+
+def test_llm_ended_fact_declines_the_anchor():
+    from datetime import datetime, timezone
+
+    anchor = datetime(2023, 5, 4, 12, 0, tzinfo=timezone.utc)
+    md = _llm_claim_metadata(
+        {"claim": {"key": "employer", "value": "Globex", "valid_to": "2019-01-01T00:00:00+00:00"}},
+        default_valid_from=anchor,
+    )
+    assert "valid_from" not in md["claim"]
+    assert md["claim"]["valid_to"] == "2019-01-01T00:00:00+00:00"
+
+
+def test_episode_valid_from_prefers_occurred_at_over_created_at():
+    from datetime import datetime, timezone
+
+    from server.services.compilers.heuristic import episode_valid_from
+
+    ep = _ep("backfilled fact")
+    ep.occurred_at = datetime(2022, 3, 1, tzinfo=timezone.utc)
+    ep.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert episode_valid_from(ep) == ep.occurred_at
+
+
+def test_llm_naive_valid_to_keeps_the_claim():
+    """A naive (offset-less) LLM-proposed valid_to must not blow up the guard —
+    the call-site except would silently drop the whole claim (review finding)."""
+    from datetime import datetime, timezone
+
+    anchor = datetime(2023, 5, 4, 12, 0, tzinfo=timezone.utc)
+    md = _llm_claim_metadata(
+        {"claim": {"key": "employer", "value": "Globex", "valid_to": "2019-01-01T00:00:00"}},
+        default_valid_from=anchor,
+    )
+    assert md is not None
+    assert "valid_from" not in md["claim"]

--- a/tests/test_structured_claim_valid_from.py
+++ b/tests/test_structured_claim_valid_from.py
@@ -1,0 +1,202 @@
+"""Claims on structured candidates must carry a temporal anchor (#369 follow-up).
+
+Without ``valid_from``, ``_claim_cmp`` orders same-bucket claims by
+``created_at`` — which ties for rows compiled in one transaction and then
+falls to random UUIDs, so contradiction resolution was non-deterministic on
+the v1 structured-candidate path (measured: 8 identical runs → 5/3 split).
+v2 envelopes already carried a producer-supplied ``valid_from``; v1 dropped
+it, and neither defaulted. Both now anchor to ``episode_valid_from`` (which
+honours ``payload.event_time``) whenever the claim doesn't supply its own.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from server.db.tables import EpisodeRow
+from server.services.compilers.heuristic import episode_valid_from
+from server.services.structured import compile_candidates
+
+# A valid v2 claim shape for the registry's v2-capable key (kept local — see
+# tests/test_claims_v2.py for the canonical matrix).
+_BASE_Q = {
+    "payment_method": "card",
+    "rate_type": "standard",
+    "currency": "USD",
+    "charge_unit": "transaction",
+}
+_V350 = {"percentage_basis_points": 350, "fixed_minor_units": 35}
+
+_EVENT = datetime(2023, 5, 4, 12, 0, tzinfo=timezone.utc)
+
+
+def _episode(claim: dict, event_time: str | None = "2023-05-04T12:00:00+00:00") -> EpisodeRow:
+    payload: dict = {
+        "statewave": {
+            "memory_candidates": [
+                {"kind": "domain_fact", "text": "the user's name is ada", "claim": claim}
+            ]
+        }
+    }
+    if event_time is not None:
+        payload["event_time"] = event_time
+    return EpisodeRow(
+        id=uuid.uuid4(),
+        subject_id="s-1",
+        source="test",
+        type="message",
+        payload=payload,
+        metadata_={},
+        provenance={},
+    )
+
+
+def _claim_md(ep: EpisodeRow) -> dict:
+    rows = compile_candidates(ep)
+    assert rows is not None and len(rows) == 1
+    return rows[0].metadata_["claim"]
+
+
+def test_v1_claim_without_valid_from_anchors_to_the_episode():
+    ep = _episode({"schema_version": 1, "key": "identity.name", "value": "Ada"})
+    md = _claim_md(ep)
+    assert md["valid_from"] == episode_valid_from(ep).isoformat()
+    assert md["valid_from"] == _EVENT.isoformat()
+
+
+def test_v1_producer_supplied_valid_from_wins():
+    ep = _episode(
+        {
+            "schema_version": 1,
+            "key": "identity.name",
+            "value": "Ada",
+            "valid_from": "2020-01-01T00:00:00+00:00",
+            "valid_to": "2021-01-01T00:00:00+00:00",
+        }
+    )
+    md = _claim_md(ep)
+    assert md["valid_from"] == "2020-01-01T00:00:00+00:00"
+    assert md["valid_to"] == "2021-01-01T00:00:00+00:00"
+
+
+def _v2_claim(**extra) -> dict:
+    return {
+        "schema_version": 2,
+        "key": "pricing.processing_rate",
+        "entity_key": "acme gmbh",
+        "qualifiers": dict(_BASE_Q),
+        "value": dict(_V350),
+        **extra,
+    }
+
+
+def test_v2_claim_without_valid_from_anchors_to_the_episode():
+    ep = _episode(_v2_claim())
+    md = _claim_md(ep)
+    assert md.get("valid_from") == episode_valid_from(ep).isoformat()
+
+
+def test_v2_producer_supplied_valid_from_untouched():
+    ep = _episode(_v2_claim(valid_from="2019-06-01T00:00:00+00:00"))
+    md = _claim_md(ep)
+    assert md.get("valid_from") == "2019-06-01T00:00:00+00:00"
+
+
+def test_two_compiled_episodes_order_by_event_time_not_row_ids():
+    """The end the fix serves: same key, different values, compiled in one
+    transaction — the claim envelopes alone must give a deterministic order."""
+    early = _episode(
+        {"schema_version": 1, "key": "identity.name", "value": "Ada"},
+        event_time="2023-01-01T00:00:00+00:00",
+    )
+    late = _episode(
+        {"schema_version": 1, "key": "identity.name", "value": "Grace"},
+        event_time="2023-09-01T00:00:00+00:00",
+    )
+    md_early, md_late = _claim_md(early), _claim_md(late)
+    assert md_early["valid_from"] < md_late["valid_from"]
+
+
+def test_valid_to_before_the_anchor_leaves_valid_from_absent():
+    """A fact that ENDED before the episode must not get the episode anchor as
+    its start — that would persist an inverted window and make the ended fact
+    look newest to the resolver."""
+    ep = _episode(
+        {
+            "schema_version": 1,
+            "key": "identity.name",
+            "value": "Ada",
+            "valid_to": "2019-01-01T00:00:00+00:00",
+        }
+    )
+    md = _claim_md(ep)
+    assert "valid_from" not in md
+    assert md["valid_to"] == "2019-01-01T00:00:00+00:00"
+
+
+def test_v2_valid_to_before_the_anchor_leaves_valid_from_absent():
+    ep = _episode(_v2_claim(valid_to="2019-01-01T00:00:00+00:00"))
+    md = _claim_md(ep)
+    assert md.get("valid_from") is None
+    assert md.get("valid_to") == "2019-01-01T00:00:00+00:00"
+
+
+def test_compile_then_resolve_is_deterministic_end_to_end():
+    """The bug that motivated all of this: two contradictory facts compiled in
+    one transaction (tied created_at, random UUIDs) resolved to different
+    winners across runs. Compiled envelopes now carry event-time anchors, so
+    the later EVENT must win on every run, in either input order."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from server.services.conflicts import resolve_conflicts
+
+    async def _one_round(order_reversed: bool) -> str:
+        early = _episode(
+            {"schema_version": 1, "key": "identity.name", "value": "Ada"},
+            event_time="2023-01-01T00:00:00+00:00",
+        )
+        late = _episode(
+            {"schema_version": 1, "key": "identity.name", "value": "Grace"},
+            event_time="2023-09-01T00:00:00+00:00",
+        )
+        rows = [compile_candidates(e)[0] for e in (early, late)]
+        tied = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        for r in rows:
+            r.created_at = tied  # the pathological shape: same-transaction ties
+            r.status = "active"
+        if order_reversed:
+            rows.reverse()
+        with patch("server.services.conflicts.repo") as mock_repo:
+            mock_repo.list_active_memories_by_subject = AsyncMock(return_value=rows)
+            mock_repo.mark_memories_superseded = AsyncMock()
+            await resolve_conflicts(AsyncMock(), "s-1")
+        (winner,) = [r for r in rows if r.status == "active"]
+        return winner.metadata_["claim"]["value"]
+
+    winners = {asyncio.run(_one_round(order_reversed=i % 2 == 1)) for i in range(8)}
+    assert winners == {"grace"}
+
+
+def test_naive_valid_to_does_not_crash_the_guard_v1():
+    """_parse_dt returns naive datetimes for offset-less ISO strings; the guard
+    must normalize before comparing or one poison episode 500s every compile
+    of its subject (review finding)."""
+    ep = _episode(
+        {
+            "schema_version": 1,
+            "key": "identity.name",
+            "value": "Ada",
+            "valid_to": "2019-01-01T00:00:00",  # offset-less → naive
+        }
+    )
+    md = _claim_md(ep)
+    assert "valid_from" not in md
+    assert md["valid_to"] == "2019-01-01T00:00:00"
+
+
+def test_naive_valid_to_does_not_crash_the_guard_v2():
+    ep = _episode(_v2_claim(valid_to="2019-01-01T00:00:00"))
+    md = _claim_md(ep)
+    assert md.get("valid_from") is None


### PR DESCRIPTION
Fixes the non-determinism in claim-path contradiction resolution reported in the #369 discussion (8 identical runs of one contradiction → 5/3 winner split), across **all three compiler paths**, with review-driven hardening.

## Cause

Claims mostly carried no `valid_from`: the structured-candidate path dropped it even when supplied (v1), the heuristic and LLM compilers never set it, and nothing defaulted it. `_claim_cmp` only uses claim `valid_from` when **both** sides carry it, so ordering fell to `created_at` (ties within one compile transaction) and then to random UUIDs.

## Fix

- **Structured path**: v1 producer `valid_from`/`valid_to` pass through; v1 + v2 default `valid_from` to the episode's temporal anchor when absent.
- **Heuristic + LLM compilers**: the same anchor is threaded into their `build_claim_envelope` calls (review finding — the original scope left the bug alive on those paths and for mixed structured/heuristic pairs).
- **Inverted-window guard** (`anchor_valid_from`, shared in `claims.py`): a claim carrying only a `valid_to` *earlier* than the anchor ("lived in Paris until 2019", recorded 2023) declines the default — otherwise the envelope would persist `valid_from > valid_to` and the *ended* fact could deterministically supersede a current one (review finding, reproduced).
- **`episode_valid_from` now consults `ep.occurred_at`** before `created_at` (review finding): backfilled connectors set `occurred_at` — the first-class "when it actually happened" field — and previously got ingest time as their anchor. `occurred_at` server-defaults to ingest time, so non-backfill behavior is unchanged.

## Tests

Envelope-level (v1/v2 default, pass-through, guard both versions), compiler-level (heuristic + LLM anchor, model-supplied wins, ended-fact declines, `occurred_at` precedence), and **end-to-end**: two contradictory episodes compiled with tied `created_at` and fresh random UUIDs resolve to the later *event* on all 8 runs in both input orders — the test that reproduces the original 5/3 split. Mutation-checked (guard removed → 3 tests fail; `occurred_at` dropped → 1 fails). 977 unit / 283 integration, ruff clean.

Related: #374 (same-value collapse) is immune to this ordering but composes with it; the two land separately.
