### PR TITLE
feat(conflicts): collapse same-value repeated observations by claim key

### DIFF
--- a/server/services/conflicts.py
+++ b/server/services/conflicts.py
@@ -13,9 +13,10 @@ Two paths, hybrid and strictly additive:
 
 * **Legacy path** (unchanged) — token-overlap (Jaccard) supersession for
   EVERYTHING else: unkeyed, malformed, unknown-key, unsupported-version,
-  multi-valued, and mixed keyed/unkeyed pairings, plus single-valued *same
-  value* duplicates (existing duplicate handling). Byte-identical to before for
-  any memory without a usable single-valued claim.
+  multi-valued, and mixed keyed/unkeyed pairings. Single-valued same-value
+  duplicates are collapsed by the claim path itself (#369), so the legacy pass
+  never touches keyed pairs. Byte-identical to before for any memory without a
+  usable single-valued claim.
 
 No opt-in flag, no schema change, no migration. The resolver runs only at
 compile time (``server.api.memories``); reads and server startup never invoke
@@ -97,8 +98,8 @@ async def resolve_conflicts(
     superseded_ids: list[uuid.UUID] = []
     # Claim path first; it marks losers status="superseded" in place, so the
     # legacy pass skips them via its existing status guard. The legacy pass
-    # additionally skips single-valued same-key *different-value* pairs so it
-    # can never undo a temporal coexistence the claim path established.
+    # additionally skips ALL single-valued keyed pairs so it can never undo a
+    # temporal-coexistence or duplicate call the claim path made (#369).
     superseded_ids.extend(_resolve_single_valued_claims(memories, claims))
     superseded_ids.extend(_legacy_resolve(memories, claims))
 
@@ -141,23 +142,38 @@ def _resolve_single_valued_claims(
                 if group[j].status != "active":
                     continue
                 cj = claims[group[j].id]
-                # Authoritative ONLY for a genuine contradiction: same bucket (by
-                # grouping) + DIFFERENT canonical value + OVERLAPPING validity.
-                # Same value is a duplicate (left to legacy dedup); non-
-                # overlapping windows coexist as history.
-                if ci.value == cj.value:
-                    continue
+                # Authoritative for same bucket + OVERLAPPING validity, in two
+                # flavours: a DIFFERENT canonical value is a contradiction, the
+                # SAME canonical value is a repeated observation — one fact, not
+                # N rows, regardless of wording (#369; previously left to the
+                # legacy lexical path, so a registered key's boundedness
+                # depended on Jaccard getting lucky with wording). Non-
+                # overlapping windows always coexist as history — the same
+                # value re-asserted for a later window is a re-assertion, not
+                # a duplicate.
                 if not _claim_overlap(group[i], ci, group[j], cj):
                     continue
                 superseded_ids.append(group[i].id)
                 group[i].status = "superseded"
-                group[i].valid_to = group[j].valid_from or datetime.now(timezone.utc)
+                # End the loser's window where the WINNER's claim says its
+                # validity starts — the same window _claim_cmp ordered on and
+                # _claim_overlap gated on; the row anchor is only a fallback.
+                # Clamp: a backfilled winner anchored before the loser's own
+                # valid_from must not fabricate a negative-length window.
+                end = _aware(cj.valid_from or group[j].valid_from or datetime.now(timezone.utc))
+                if group[i].valid_from is not None and end < _aware(group[i].valid_from):
+                    end = _aware(group[i].valid_from)
+                group[i].valid_to = end
                 logger.info(
                     "memory_superseded",
                     old_id=str(group[i].id),
                     new_id=str(group[j].id),
                     claim_key=ci.canonical_key,
-                    strategy="claim_contradiction",
+                    strategy=(
+                        "claim_contradiction"
+                        if ci.value != cj.value
+                        else "claim_duplicate"
+                    ),
                 )
                 break
     return superseded_ids
@@ -217,10 +233,9 @@ def _legacy_resolve(
             for j in range(i + 1, len(group)):
                 if group[j].status != "active":
                     continue
-                # The claim path owns single-valued same-key DIFFERENT-value
-                # pairs; never let lexical overlap undo its temporal/cardinality
-                # call. (Same-value duplicates are intentionally NOT skipped, so
-                # existing duplicate handling still dedups them.)
+                # The claim path owns every single-valued keyed pair —
+                # contradictions, duplicates, and temporal coexistence alike;
+                # never let lexical overlap undo its call (#369).
                 if _claim_owned_pair(group[i], group[j], claims):
                     continue
                 if _are_conflicting(group[i], group[j]):
@@ -242,12 +257,14 @@ def _claim_owned_pair(a: MemoryRow, b: MemoryRow, claims: dict[uuid.UUID, Resolv
     ca, cb = claims.get(a.id), claims.get(b.id)
     if ca is None or cb is None:
         return False  # a mixed keyed/unkeyed pair keeps existing legacy behavior
-    # The claim path owns EVERY pair of single-valued claims except an exact
-    # duplicate (same bucket + same value), which it defers to legacy dedup. In
-    # particular two DIFFERENT claim identities must coexist — lexical overlap
-    # between their texts must never supersede across distinct buckets (e.g.
-    # Stripe-card vs Stripe-ACH rates).
-    return not (ca.bucket == cb.bucket and ca.value == cb.value)
+    # The claim path owns EVERY pair of single-valued claims — contradictions,
+    # duplicates (it collapses those itself since #374), and temporal
+    # coexistence alike. Lexical overlap must never override its call: two
+    # DIFFERENT claim identities must coexist (e.g. Stripe-card vs Stripe-ACH
+    # rates), and a same-value pair the claim path deliberately left as
+    # non-overlapping history must not be re-superseded because the wording
+    # happens to be similar.
+    return True
 
 
 def _legacy_sort_key(m: MemoryRow) -> tuple[datetime, datetime, str]:

--- a/tests/test_claims_v2.py
+++ b/tests/test_claims_v2.py
@@ -210,10 +210,14 @@ async def test_negative_controls_coexist():
     assert res == []  # every distinct identity coexists; nothing superseded
 
 
-async def test_same_identity_same_value_not_a_contradiction():
+async def test_same_identity_same_value_collapses_as_duplicate():
     a = _mem("stripe a", _env(value=_V350), age=10)
     b = _mem("stripe b", _env(value=_V350), age=0)  # identical value, distinct text
-    assert await _resolve([a, b]) == []  # same value -> not a contradiction (coexist)
+    # Same value in the same bucket is not a contradiction — it is a repeated
+    # observation, and since #369's widening the claim path collapses it to one
+    # active row regardless of wording (strategy="claim_duplicate").
+    assert await _resolve([a, b]) == [a.id]
+    assert a.status == "superseded" and b.status == "active"
 
 
 async def test_distinct_buckets_with_identical_text_coexist():

--- a/tests/test_conflicts_claim_resolution.py
+++ b/tests/test_conflicts_claim_resolution.py
@@ -1,7 +1,7 @@
 """Hybrid claim-keyed conflict resolution — the new behavior + compat matrix.
 
 Covers the decision tree: single-valued + overlap + different value supersedes;
-non-overlap coexists (history); same value dedups via legacy; multi-valued and
+non-overlap coexists (history); same value collapses regardless of wording; multi-valued and
 unknown/mixed coexist; aliases normalize; determinism is input/DB-order
 independent; and the claim path PROTECTS temporal coexistence from lexical
 overlap that would otherwise wrongly supersede.
@@ -129,13 +129,117 @@ async def test_multi_valued_coexist():
     assert result == []
 
 
-async def test_same_key_same_value_deduped_by_legacy():
-    # Same canonical key + same normalized value = duplicate, handled by legacy
-    # dedup (high text overlap), NOT treated as a contradiction.
+async def test_same_key_same_value_identical_wording_collapses():
+    # Same canonical key + same normalized value = repeated observation; the
+    # claim path now collapses it directly (#369) — identical wording would
+    # also have been caught by legacy dedup, so this pins the unchanged
+    # observable outcome.
     older = _mem("I work at Globex", key="employer", value="Globex", age_days=10)
     newer = _mem("I work at Globex", key="employer", value="Globex", age_days=0)
     result, _ = await _resolve([older, newer])
     assert older.id in result
+
+
+async def test_same_value_varied_wording_collapses_to_one_active():
+    # The case legacy Jaccard MISSED (#369 blocker 2): same registered key,
+    # same canonical value, wording too different for lexical overlap. A
+    # bounded key's boundedness must not depend on phrasing.
+    rows = [
+        _mem("employment: Globex", key="employer", value="Globex", age_days=4),
+        _mem("the user is on Globex's payroll", key="employer", value="Globex", age_days=3),
+        _mem("works for Globex these days", key="employer", value="Globex", age_days=2),
+        _mem("Globex is their current gig", key="employer", value="Globex", age_days=1),
+        _mem("hired by Globex", key="employer", value="Globex", age_days=0),
+    ]
+    result, _ = await _resolve(rows)
+    active = [m for m in rows if m.status == "active"]
+    assert len(active) == 1
+    assert active[0].content == "hired by Globex"
+    assert len(result) == 4
+
+
+async def test_same_value_non_overlap_survives_even_with_identical_wording(caplog):
+    # The stronger invariant: identical text puts the pair squarely in legacy
+    # Jaccard range, and BEFORE the owned-pair widening the lexical pass would
+    # supersede the historical row anyway (and rewrite its window). The claim
+    # path's temporal call must be final for keyed pairs.
+    first = _mem(
+        "I work at Globex",
+        key="employer",
+        value="Globex",
+        valid_from=_dt(2020),
+        valid_to=_dt(2021),
+        age_days=10,
+    )
+    again = _mem(
+        "I work at Globex",
+        key="employer",
+        value="Globex",
+        valid_from=_dt(2023),
+        valid_to=_dt(2024),
+        age_days=0,
+    )
+    result, _ = await _resolve([first, again])
+    assert result == []
+    assert first.status == "active" and again.status == "active"
+    # The helper stores the window in the CLAIM envelope; the row's own
+    # valid_to must stay untouched (pre-fix, the legacy pass rewrote it).
+    assert first.valid_to is None
+
+
+async def test_duplicate_collapse_logs_its_own_strategy(caplog):
+    import logging
+
+    older = _mem("employment: Globex", key="employer", value="Globex", age_days=1)
+    newer = _mem("hired by Globex", key="employer", value="Globex", age_days=0)
+    with caplog.at_level(logging.INFO):
+        result, _ = await _resolve([older, newer])
+    assert older.id in result
+    assert any(
+        "claim_duplicate" in str(r.__dict__) for r in caplog.records
+    ), f"expected strategy=claim_duplicate; saw {[r.getMessage() for r in caplog.records]}"
+    assert not any("claim_contradiction" in str(r.__dict__) for r in caplog.records)
+
+
+async def test_same_value_one_windowed_one_not_collapses_to_the_open_row():
+    # Mixed shape: one row claim-windowed in the past, one open-ended (no claim
+    # window → falls back to its row window, which overlaps). The open-ended
+    # re-observation wins; the outcome must not depend on wording.
+    windowed = _mem(
+        "employment: Globex",
+        key="employer",
+        value="Globex",
+        valid_from=_dt(2020),
+        age_days=10,
+    )
+    open_ended = _mem("Globex is their current gig", key="employer", value="Globex", age_days=0)
+    result, _ = await _resolve([windowed, open_ended])
+    assert result == [windowed.id]
+    assert open_ended.status == "active"
+
+
+async def test_same_value_non_overlapping_windows_both_survive():
+    # A re-assertion for a LATER window is history, not a duplicate: the
+    # overlap gate (checked independently of value equality) must keep both.
+    first = _mem(
+        "worked at Globex",
+        key="employer",
+        value="Globex",
+        valid_from=_dt(2020),
+        valid_to=_dt(2021),
+        age_days=10,
+    )
+    again = _mem(
+        "back at Globex",
+        key="employer",
+        value="Globex",
+        valid_from=_dt(2023),
+        valid_to=_dt(2024),
+        age_days=0,
+    )
+    result, _ = await _resolve([first, again])
+    assert result == []
+    assert first.status == "active" and again.status == "active"
 
 
 # --- mixed keyed / unkeyed → legacy unchanged ---------------------------------
@@ -193,3 +297,16 @@ async def test_keyed_bucketing_scales_and_isolates_keys():
     # a bucket only the single newest value survives → (total - num_keys) losers.
     survivors = len(memories) - len(result)
     assert survivors == len(single_keys)
+
+
+async def test_naive_producer_valid_from_neither_crashes_nor_stamps_naive():
+    """_parse_dt accepts offset-less ISO strings and returns naive datetimes;
+    the clamp must normalize before comparing and stamp an aware valid_to
+    (review finding — TypeError on naive winner valid_from)."""
+    older = _mem("employment: Globex", key="employer", value="Globex", age_days=5)
+    newer = _mem("hired by Globex", key="employer", value="Globex", age_days=0)
+    # naive claim window on the winner
+    newer.metadata_["claim"]["valid_from"] = "2026-01-05T00:00:00"
+    result, _ = await _resolve([older, newer])
+    assert older.id in result
+    assert older.valid_to is not None and older.valid_to.tzinfo is not None


### PR DESCRIPTION
Implements the Blocker-2 widening from #369, as agreed in the maintainer discussion, with review-driven hardening.

## What changes

- `_resolve_single_valued_claims` no longer skips same-value pairs: same bucket + overlapping validity supersedes the older row whether the value differs (contradiction) or matches (repeated observation). Previously a registered key's boundedness depended on legacy Jaccard noticing the duplicate — i.e. on wording.
- **`_claim_owned_pair` now owns *all* keyed pairs** (review finding): the legacy lexical pass could re-supersede a same-value pair the claim path had deliberately left as non-overlapping history — with similar wording it destroyed temporal coexistence and rewrote the historical row's window. The claim path's call is now final for keyed pairs.
- **The loser's `valid_to` is stamped from the winner's *claim* window** (review finding), matching what ordering and overlap used, clamped so a backfilled winner can never fabricate a negative-length window.
- Duplicate collapses log `strategy="claim_duplicate"` — pinned by a caplog test (a mutant always logging `claim_contradiction` fails).

Invariants pinned by tests: same-value non-overlapping windows coexist **even with identical wording** (fails before the owned-pair widening); the historical row's window is untouched; 5 same-value varied-wording rows collapse to 1 active (fails on main); mixed windowed/open-ended same-value collapses to the open row; v2 buckets behave identically. Mutation-checked. 969 unit / 283 integration, ruff clean.

Safety argument (verified at code level): the group sorts ascending and always supersedes earlier rows in favour of later ones, so widening only removes duplicate rows carrying the winning value — never changes which value wins. Superseded rows keep `source_episode_ids`.

Part of #369 (Blocker 2); #373 provides the deterministic ordering underneath. Blocker 1 (registrable keys) remains open as a separate design round.
