### PR TITLE
fix(compile): split and retry a batch whose extraction output won't parse

### DIFF
--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -42,6 +42,7 @@ from server.services.claims import (
     anchor_valid_from,
 )
 from server.services.compilers.errors import CompilationError
+from server.services.llm import LLMResponseError
 from server.services.compilers.heuristic import episode_valid_from, extract_payload_text
 from server.services.memory_ttl import compute_valid_to
 
@@ -441,6 +442,22 @@ def _llm_claim_metadata(mem: dict, default_valid_from: datetime | None = None) -
     )
 
 
+
+def _format_episode_blocks(batch: list[tuple[EpisodeRow, str]]) -> str:
+    """Render a batch as the prompt's episode blocks.
+
+    Each block is annotated with the episode's resolved reference timestamp
+    (`episode_valid_from` — the same anchor used for the memory's `valid_from`),
+    so the model resolves "today"/relative phrases against the real episode date
+    instead of inventing one (issue #115).
+    """
+    blocks = []
+    for i, (ep, text) in enumerate(batch):
+        ref_label = episode_valid_from(ep).strftime("%Y-%m-%d (%A)")
+        blocks.append(f"--- Episode {i} | recorded {ref_label} ---\n{text}")
+    return "\n\n".join(blocks)
+
+
 class LLMCompiler:
     """Async LLM memory compiler with batching + parallelism. Implements BaseCompiler protocol.
 
@@ -595,6 +612,40 @@ class LLMCompiler:
 
         return batches
 
+    async def _extract_with_split_retry(
+        self,
+        batch: list[tuple[EpisodeRow, str]],
+        combined_text: str,
+    ) -> list[dict]:
+        """Extract one batch, halving and retrying if the output will not parse.
+
+        A truncated or malformed body is not a failed round-trip: the model
+        answered, the answer is just unusable — and it is usually unusable
+        because THIS combination of episodes provoked an over-long response.
+        Splitting shrinks each response, so one awkward episode costs itself
+        rather than every episode batched with it (issue #375). Transport,
+        auth and timeout failures are deliberately NOT retried here; they mean
+        extraction could not run at all, and the caller must see them.
+        """
+        try:
+            return await self._call_llm_async(combined_text, len(batch))
+        except LLMResponseError:
+            if len(batch) == 1:
+                raise  # irreducible — _process_batch names the episode
+            mid = len(batch) // 2
+            halves = (batch[:mid], batch[mid:])
+            logger.info(
+                "llm_batch_split_retry",
+                episode_count=len(batch),
+                halves=[len(h) for h in halves],
+            )
+            out: list[dict] = []
+            for half in halves:
+                out.extend(
+                    await self._extract_with_split_retry(half, _format_episode_blocks(half))
+                )
+            return out
+
     async def _process_batch(
         self,
         batch: list[tuple[EpisodeRow, str]],
@@ -610,14 +661,27 @@ class LLMCompiler:
             # this the model has no reference point and falls back to a
             # plausible-looking default (commonly the LoCoMo sample's
             # "25 May 2023") — see issue #115.
-            episode_blocks = []
-            for i, (ep, text) in enumerate(batch):
-                ref_label = episode_valid_from(ep).strftime("%Y-%m-%d (%A)")
-                episode_blocks.append(f"--- Episode {i} | recorded {ref_label} ---\n{text}")
-            combined_text = "\n\n".join(episode_blocks)
+            combined_text = _format_episode_blocks(batch)
 
             try:
-                raw_memories = await self._call_llm_async(combined_text, len(batch))
+                raw_memories = await self._extract_with_split_retry(batch, combined_text)
+            except LLMResponseError as exc:
+                # A single episode whose extraction output will not parse, even
+                # alone. Still a raise (issue #201: never silently consume an
+                # episode), but the message names the offending episode so it
+                # can be quarantined instead of leaving the whole subject stuck
+                # behind an opaque "provider misconfigured" (issue #375).
+                (poison_ep, _), = batch
+                logger.warning(
+                    "llm_batch_unparseable",
+                    episode_id=str(poison_ep.id),
+                    subject_id=poison_ep.subject_id,
+                    exc_info=True,
+                )
+                raise CompilationError(
+                    f"LLM returned unusable output for episode {poison_ep.id} even on its "
+                    f"own, so it cannot be extracted: {exc}"
+                ) from exc
             except Exception as exc:
                 # A failed provider round-trip (auth, timeout, 5xx, no key)
                 # means extraction could not RUN — it is NOT a legitimate
@@ -752,10 +816,14 @@ class LLMCompiler:
                 temperature=0.1,
                 max_tokens=max_tokens,
             )
+        except llm_adapter.LLMResponseError:
+            # The provider ANSWERED, the body is just unusable (truncated or
+            # malformed JSON). Keep the type: `_process_batch` splits the batch
+            # and retries on this, where a transport failure must abort instead.
+            raise
         except llm_adapter.StatewaveLLMError as exc:
-            # Same surface as the previous httpx-based path: caller
-            # (_process_batch) catches generic Exception and falls
-            # through to an empty memory list.
+            # Transport/auth/timeout — extraction could not RUN. Same surface as
+            # the previous httpx-based path.
             raise RuntimeError(str(exc)) from exc
 
         # acomplete_json forces response_format=json_object, so the

--- a/server/services/llm.py
+++ b/server/services/llm.py
@@ -404,7 +404,14 @@ async def acomplete_json(
     try:
         return json.loads(cleaned)
     except json.JSONDecodeError as exc:
-        raise LLMResponseError(f"LLM returned invalid JSON: {cleaned[:200]}") from exc
+        raise LLMResponseError(
+            # The TAIL is the diagnostic part: a truncated body's first 200
+            # characters look perfectly well-formed, which reads as a syntax
+            # problem rather than a length one (issue #375).
+            f"LLM returned invalid JSON ({len(cleaned)} chars): "
+            f"{cleaned[:120]}…{cleaned[-120:]}" if len(cleaned) > 240
+            else f"LLM returned invalid JSON ({len(cleaned)} chars): {cleaned}"
+        ) from exc
 
 
 # Generic free-form tool the JSON-forced path uses. We don't constrain

--- a/tests/test_llm_batch_split_retry.py
+++ b/tests/test_llm_batch_split_retry.py
@@ -1,0 +1,153 @@
+"""A truncated LLM response must not cost the whole subject (issue #375).
+
+`acomplete_json` raises `LLMResponseError` when the provider's body will not
+parse. That is a different class of failure from a transport/auth error: the
+model answered, the answer is just unusable — typically because this particular
+combination of episodes provoked an over-long response. Splitting the batch
+shrinks each response, so one awkward episode costs itself rather than every
+episode batched with it.
+
+Before this, `_call_llm_async` flattened every provider error to `RuntimeError`,
+so `_process_batch` could not tell the two apart and aborted the entire compile
+— leaving the subject with zero memories and no way to recover, since a retry
+re-ran the same batch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.db.tables import EpisodeRow
+from server.services.compilers.errors import CompilationError
+from server.services.compilers.llm import LLMCompiler
+from server.services.llm import LLMResponseError
+
+pytestmark = pytest.mark.asyncio
+
+_NOW = datetime(2026, 5, 4, tzinfo=timezone.utc)
+
+
+def _ep(text: str) -> EpisodeRow:
+    return EpisodeRow(
+        id=uuid.uuid4(),
+        subject_id="user-1",
+        source="test",
+        type="conversation",
+        payload={"text": text},
+        metadata_={},
+        provenance={},
+        created_at=_NOW,
+        occurred_at=_NOW,
+    )
+
+
+def _memory(content: str) -> dict:
+    return {"kind": "profile_fact", "content": content, "summary": content}
+
+
+async def test_irreducible_episode_raises_rather_than_being_swallowed(caplog):
+    """An episode whose output will not parse even alone still raises — issue
+    #201's guarantee that a failure never silently consumes episodes."""
+    poison = _ep("poison")
+
+    async def fake_call(text: str, count: int):
+        raise LLMResponseError("LLM returned invalid JSON (3693 chars): {…")
+
+    compiler = LLMCompiler()
+    with patch.object(compiler, "_call_llm_async", new=AsyncMock(side_effect=fake_call)):
+        with pytest.raises(LLMResponseError):
+            await compiler._extract_with_split_retry([(poison, "poison")], "poison")
+
+
+async def test_process_batch_names_the_offending_episode(caplog):
+    """The whole point of #375: the operator learns WHICH episode is poison
+    instead of an opaque \"provider unavailable or misconfigured\"."""
+    poison = _ep("poison")
+
+    async def fake_call(text: str, count: int):
+        raise LLMResponseError("LLM returned invalid JSON (3693 chars): {…")
+
+    compiler = LLMCompiler()
+    sem = asyncio.Semaphore(1)
+    with patch.object(compiler, "_call_llm_async", new=AsyncMock(side_effect=fake_call)):
+        with pytest.raises(CompilationError) as excinfo:
+            await compiler._process_batch([(poison, "poison")], sem)
+
+    assert str(poison.id) in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, LLMResponseError)
+
+
+async def test_split_recovers_when_the_smaller_halves_parse():
+    """The realistic case: the combination was too long, the halves are fine."""
+    a, b = _ep("alpha"), _ep("beta")
+    batch = [(a, "alpha"), (b, "beta")]
+    calls: list[int] = []
+
+    async def fake_call(text: str, count: int):
+        calls.append(count)
+        if count > 1:
+            raise LLMResponseError("LLM returned invalid JSON (3693 chars): {…")
+        return [_memory(text)]
+
+    compiler = LLMCompiler()
+    with patch.object(compiler, "_call_llm_async", new=AsyncMock(side_effect=fake_call)):
+        out = await compiler._extract_with_split_retry(batch, "alpha\n\nbeta")
+
+    assert calls == [2, 1, 1]  # tried together, then each alone
+    # Both halves produced a memory: the poison combination cost nothing.
+    assert len(out) == 2
+    contents = " ".join(m["content"] for m in out)
+    assert "alpha" in contents and "beta" in contents
+
+
+async def test_transport_failures_are_not_split_retried():
+    """A round-trip that could not RUN must abort immediately (issue #201) —
+    splitting would just multiply a provider outage into N failing calls."""
+    a, b = _ep("alpha"), _ep("beta")
+    calls: list[int] = []
+
+    async def fake_call(text: str, count: int):
+        calls.append(count)
+        raise RuntimeError("LLM completion timed out after 60.0s")
+
+    compiler = LLMCompiler()
+    with patch.object(compiler, "_call_llm_async", new=AsyncMock(side_effect=fake_call)):
+        with pytest.raises(RuntimeError):
+            await compiler._extract_with_split_retry([(a, "alpha"), (b, "beta")], "alpha\n\nbeta")
+
+    assert calls == [2]  # no split, no retry
+
+
+async def test_call_llm_async_preserves_the_unparseable_type():
+    """The root cause of #375: `_call_llm_async` used to flatten EVERY provider
+    error to a bare RuntimeError, so `_process_batch` structurally could not
+    tell "answered with unusable output" from "could not reach the provider" —
+    and treated both as fatal. The type must survive to reach the split path."""
+    compiler = LLMCompiler()
+
+    with patch(
+        "server.services.llm.acomplete_json",
+        new=AsyncMock(side_effect=LLMResponseError("LLM returned invalid JSON (3693 chars): {…")),
+    ):
+        with pytest.raises(LLMResponseError):
+            await compiler._call_llm_async("some text", 1)
+
+
+async def test_call_llm_async_still_flattens_transport_errors():
+    """Transport/auth failures keep their existing surface — only the
+    unparseable-output case is singled out."""
+    from server.services.llm import StatewaveLLMError
+
+    compiler = LLMCompiler()
+    with patch(
+        "server.services.llm.acomplete_json",
+        new=AsyncMock(side_effect=StatewaveLLMError("LLM completion timed out after 60.0s")),
+    ):
+        with pytest.raises(RuntimeError) as excinfo:
+            await compiler._call_llm_async("some text", 1)
+    assert not isinstance(excinfo.value, LLMResponseError)


### PR DESCRIPTION
Fixes #375.

## The bug

One truncated LLM response failed an **entire subject's** compile, leaving every episode uncompiled with no way to recover — a retry re-ran the same batch and hit the same body. Reproduced deterministically on a LongMemEval bench subject across four attempts, and it is what made that subject permanently uncompilable.

## Root cause: type erasure, not the token ceiling

The obvious reading is "the response hit `max_tokens`", and the existing mitigation was to raise the ceiling. That is not it: the failing batch was **3 episodes with `max_tokens` resolving to 16,000**, and the body stopped at roughly 900 tokens. Raising `STATEWAVE_LITELLM_COMPILE_MAX_TOKENS` to 32,000 changed nothing — same truncation, same offset.

The actual cause is that `_call_llm_async` caught every `StatewaveLLMError` and re-raised a bare `RuntimeError`. That flattened two different failures into one type, so `_process_batch` **structurally could not tell** "the provider answered, the body is unusable" from "the provider could not be reached". #201 correctly makes the latter fatal, so the former became fatal too.

## The fix

- `LLMResponseError` keeps its type through `_call_llm_async`; transport/auth/timeout errors keep their existing `RuntimeError` surface.
- `_process_batch` **splits the batch in half and retries** on the unparseable case, recursively. A body is usually unusable because *this combination* of episodes provoked an over-long response, so halving shrinks each response and the awkward episode costs itself rather than its batch-mates.
- Transport failures are deliberately **not** split-retried — that would multiply an outage into N failing calls.
- An episode that still will not parse alone is still a raise (nothing is silently consumed, per #201), but the message now **names the episode id** instead of an opaque "provider unavailable or misconfigured", so it can be quarantined.
- The JSON error reports length and a `head…tail` excerpt. For a truncated body the first 200 characters look perfectly well-formed — that is what made this read as a syntax problem rather than a length one.

## Tests

Six cases, each mutation-checked against the two halves of the fix:

- the real flattening bug — `_call_llm_async` must preserve `LLMResponseError` (fails if the type-preservation branch is removed);
- transport errors still flatten to `RuntimeError`;
- a 2-episode batch whose halves parse recovers, calling `[2, 1, 1]` (fails if the split is disabled);
- an irreducible single episode still raises;
- `_process_batch` names the offending episode id;
- transport failures are not split-retried.

996 unit + 283 integration tests pass, ruff clean.

## Not addressed here

Per-episode quarantine — letting the poison episode stay uncompiled while the rest of its 500-episode caller batch commits — needs an interface change, since `_compile_one_batch` marks the whole batch compiled together. Worth doing only if this recurs; the split makes it much rarer.
