### PR TITLE
feat(claims): let tenants register their own single-valued claim keys

### DIFF
--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -24,6 +24,7 @@ from server.services.embeddings.backfill import schedule_embedding_backfill
 from server.services.conflicts import resolve_conflicts
 from server.services import webhooks
 from server.services import compile_jobs
+from server.services.claims import load_tenant_claim_keys
 from server.core.tracing import span
 from server.core.dependencies import get_tenant_id
 
@@ -78,14 +79,19 @@ async def _compile_one_batch(
         return [], 0, 0
 
     compiler = get_compiler()
+    # The tenant's own registered claim vocabulary (#376). Loaded once per
+    # batch and handed to the compiler, because the compiler has no session of
+    # its own. Empty unless an operator registered keys, so this is inert by
+    # default.
+    claim_keys = await load_tenant_claim_keys(session, tenant_id)
     # A CompilationError here propagates intentionally: nothing below this
     # point runs, so the episodes are never marked compiled or committed.
     if hasattr(compiler, "compile_async"):
-        new_rows = await compiler.compile_async(list(episodes))
+        new_rows = await compiler.compile_async(list(episodes), claim_keys=claim_keys)
     else:
         loop = asyncio.get_running_loop()
         new_rows = await loop.run_in_executor(
-            None, functools.partial(compiler.compile, list(episodes))
+            None, functools.partial(compiler.compile, list(episodes), claim_keys=claim_keys)
         )
 
     # Near-duplicate dedup (runs BEFORE reconcile). Full-conversation windowed

--- a/server/schemas/requests.py
+++ b/server/schemas/requests.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import re
+
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from server.core.identifiers import SessionId, SubjectId
 
@@ -179,6 +181,15 @@ class LLMCompleteRequest(BaseModel):
     temperature: float | None = Field(None, ge=0.0, le=2.0)
 
 
+#: Upper bound on a tenant's own claim vocabulary. Generous for a real product
+#: surface, low enough that the config document stays small and reviewable.
+_MAX_TENANT_CLAIM_KEYS = 64
+
+#: Lowercase dotted segments, at least one dot — namespaced so a tenant key
+#: reads as clearly theirs and cannot collide with a bare built-in name.
+_TENANT_CLAIM_KEY_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+$")
+
+
 class TenantConfigPatch(BaseModel):
     """Partial update to `tenant_configs.config`. Every known key is
     optional — `None` means "don't change this key", a supplied
@@ -203,6 +214,24 @@ class TenantConfigPatch(BaseModel):
 
     model_config = {"extra": "forbid"}
 
+    claim_keys: dict[str, Literal["single", "multi"]] | None = Field(
+        None,
+        description=(
+            "Claim keys this tenant registers for its own vocabulary, mapped to "
+            "their cardinality (#376). `single` means one live value at a time — "
+            "a newer observation supersedes the older, so repeated observations "
+            "stay one durable fact instead of growing without bound. `multi` "
+            "means values coexist.\n\n"
+            "Declaring a key here is an operator action, deliberately NOT "
+            "something an episode payload can do: cardinality must be "
+            "authoritative rather than producer-supplied (#236), or a caller "
+            "could mislabel a multi-valued key as `single` and collapse rows "
+            "that should coexist.\n\n"
+            "Built-in keys always win, so registering `identity.name` is "
+            "rejected rather than silently shadowing the built-in. Keys must be "
+            "namespaced (at least one dot) and lowercase."
+        ),
+    )
     receipts: Literal["always", "on_request", "never"] | None = Field(
         None,
         description=(
@@ -301,3 +330,33 @@ class TenantConfigPatch(BaseModel):
             "prior GET if not."
         ),
     )
+
+    @field_validator("claim_keys")
+    @classmethod
+    def _validate_claim_keys(cls, value: dict | None) -> dict | None:
+        """Reject at the boundary what JSONB will not type-check later.
+
+        A typo here would otherwise become a live key that silently never
+        matches anything a consumer sends — the exact unbounded-growth failure
+        this feature exists to remove.
+        """
+        if value is None:
+            return None
+        from server.services.claims import CLAIM_ALIASES, CLAIM_REGISTRY
+
+        if len(value) > _MAX_TENANT_CLAIM_KEYS:
+            raise ValueError(
+                f"at most {_MAX_TENANT_CLAIM_KEYS} claim keys may be registered per tenant"
+            )
+        for key in value:
+            if key in CLAIM_REGISTRY or key in CLAIM_ALIASES:
+                raise ValueError(
+                    f"{key!r} is a built-in claim key and cannot be redefined; "
+                    "choose a namespaced key of your own"
+                )
+            if not _TENANT_CLAIM_KEY_RE.match(key):
+                raise ValueError(
+                    f"{key!r} is not a valid claim key: use lowercase dotted "
+                    "segments with at least one dot, e.g. 'guide.walkthrough'"
+                )
+        return value

--- a/server/services/claims.py
+++ b/server/services/claims.py
@@ -29,7 +29,7 @@ import json
 import math
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, Mapping
 
 import structlog
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -143,19 +143,92 @@ CLAIM_ALIASES: dict[str, str] = {
 }
 
 
-def canonicalize_key(raw_key: str | None) -> str | None:
+#: Keys a tenant registered for itself, keyed by canonical key. Supplied by the
+#: caller (loaded from ``tenant_configs.config.claim_keys``) rather than read
+#: from a global, so resolution stays a pure function of its inputs and one
+#: tenant's vocabulary can never leak into another's.
+TenantClaimKeys = Mapping[str, ClaimDefinition]
+
+
+
+
+async def load_tenant_claim_keys(session, tenant_id: str | None) -> dict[str, ClaimDefinition]:
+    """Build the tenant's own claim vocabulary from ``tenant_configs``.
+
+    Returns an empty mapping for the untenanted case and for a tenant that has
+    registered nothing — which is exactly the behaviour before #376, so the
+    feature is inert until an operator opts in.
+
+    Values are re-validated here rather than trusted from JSONB: the row could
+    predate a schema change, or have been written by direct SQL. An entry that
+    no longer makes sense is dropped with a log line instead of raising, so one
+    bad row can never break compilation for the whole tenant.
+    """
+    if not tenant_id:
+        return {}
+    from server.db import repositories as repo
+
+    row = await repo.get_tenant_config(session, tenant_id)
+    raw = ((row.config if row else None) or {}).get("claim_keys") or {}
+    if not isinstance(raw, dict):
+        logger.info("tenant_claim_keys_invalid", tenant_id=tenant_id, reason="not_a_mapping")
+        return {}
+
+    out: dict[str, ClaimDefinition] = {}
+    for key, scope in raw.items():
+        if key in CLAIM_REGISTRY:
+            continue  # a built-in always wins; never shadowed
+        if not isinstance(key, str) or scope not in (SCOPE_SINGLE, SCOPE_MULTI):
+            logger.info(
+                "tenant_claim_keys_invalid", tenant_id=tenant_id, key=str(key), scope=str(scope)
+            )
+            continue
+        out[key] = ClaimDefinition(key, scope)
+    return out
+
+
+def _definition_for(
+    canonical: str, extra_keys: TenantClaimKeys | None = None
+) -> ClaimDefinition:
+    """The authoritative definition for a canonical key.
+
+    Built-ins first, so a tenant key can never shadow one (see
+    :func:`canonicalize_key`). Only ever called with a key that
+    ``canonicalize_key`` already accepted, so the lookup cannot miss.
+    """
+    spec = CLAIM_REGISTRY.get(canonical)
+    if spec is not None:
+        return spec
+    return (extra_keys or {})[canonical]
+
+
+def canonicalize_key(
+    raw_key: str | None, extra_keys: TenantClaimKeys | None = None
+) -> str | None:
     """Map an envelope key (or approved alias) to a registered canonical key.
 
     Returns ``None`` for anything not explicitly registered — so unknown or
     drifted keys (employer vs works_at vs company are handled; arbitrary
     strings are not) never become authoritative contradiction buckets.
+
+    ``extra_keys`` carries the tenant's own registered vocabulary (#376). The
+    built-in registry always wins: a tenant cannot redefine `identity.name`,
+    so shipping a new built-in can never be silently shadowed by a tenant that
+    happened to pick the same name. Declaration is an operator action against
+    `PATCH /admin/tenants/{id}/config`, never something an episode payload can
+    do — cardinality stays authoritative rather than producer-supplied (#236).
     """
     if not raw_key or not isinstance(raw_key, str):
         return None
     key = raw_key.strip()
     if key in CLAIM_REGISTRY:
         return key
-    return CLAIM_ALIASES.get(key)
+    alias = CLAIM_ALIASES.get(key)
+    if alias is not None:
+        return alias
+    if extra_keys and key in extra_keys:
+        return key
+    return None
 
 
 def normalize_value(value: Any) -> str | None:
@@ -304,7 +377,9 @@ class ResolvedClaim:
     bucket: tuple = ()
 
 
-def resolve_claim(metadata: dict | None) -> ResolvedClaim | None:
+def resolve_claim(
+    metadata: dict | None, extra_keys: TenantClaimKeys | None = None
+) -> ResolvedClaim | None:
     """Parse + validate ``metadata['claim']`` into a :class:`ResolvedClaim`.
 
     Returns ``None`` (→ legacy behavior) for every unsafe case: no envelope,
@@ -319,14 +394,14 @@ def resolve_claim(metadata: dict | None) -> ResolvedClaim | None:
 
     version = raw.get("schema_version")
     if version == 1:
-        return _resolve_v1(raw)
+        return _resolve_v1(raw, extra_keys)
     if version == 2:
-        return _resolve_v2(raw)
+        return _resolve_v2(raw, extra_keys)
     logger.info("claim_envelope_unsupported_version", version=version)
     return None
 
 
-def _resolve_v1(raw: dict) -> ResolvedClaim | None:
+def _resolve_v1(raw: dict, extra_keys: TenantClaimKeys | None = None) -> ResolvedClaim | None:
     try:
         env = ClaimEnvelope.model_validate(raw)
     except ValidationError:
@@ -336,13 +411,13 @@ def _resolve_v1(raw: dict) -> ResolvedClaim | None:
             raw_key=raw.get("key") if isinstance(raw.get("key"), str) else None,
         )
         return None
-    canonical = canonicalize_key(env.key)
+    canonical = canonicalize_key(env.key, extra_keys)
     if canonical is None:
         return None
     value = normalize_value(env.value)
     if value is None:
         return None
-    spec = CLAIM_REGISTRY[canonical]
+    spec = _definition_for(canonical, extra_keys)
     return ResolvedClaim(
         canonical_key=canonical,
         value=value,
@@ -353,11 +428,11 @@ def _resolve_v1(raw: dict) -> ResolvedClaim | None:
     )
 
 
-def _resolve_v2(raw: dict) -> ResolvedClaim | None:
-    canonical = canonicalize_key(raw.get("key"))
+def _resolve_v2(raw: dict, extra_keys: TenantClaimKeys | None = None) -> ResolvedClaim | None:
+    canonical = canonicalize_key(raw.get("key"), extra_keys)
     if canonical is None:
         return None
-    definition = CLAIM_REGISTRY[canonical]
+    definition = _definition_for(canonical, extra_keys)
     if not definition.supports_v2:
         logger.info("claim_envelope_invalid", reason="v2_unsupported_key", raw_key=canonical)
         return None
@@ -387,6 +462,7 @@ def build_claim_envelope(
     key: str,
     value: str,
     *,
+    extra_keys: TenantClaimKeys | None = None,
     valid_from: datetime | None = None,
     valid_to: datetime | None = None,
     confidence: float | None = None,
@@ -399,7 +475,7 @@ def build_claim_envelope(
     Compilers must treat a ``None`` return as "uncertain — emit the memory
     without a claim".
     """
-    canonical = canonicalize_key(key)
+    canonical = canonicalize_key(key, extra_keys)
     normalized = normalize_value(value)
     if canonical is None or normalized is None:
         return None
@@ -407,7 +483,7 @@ def build_claim_envelope(
         "schema_version": CLAIM_SCHEMA_VERSION,
         "key": canonical,
         "value": normalized,  # store the normalized value (resolver compares on it)
-        "scope": CLAIM_REGISTRY[canonical].scope,
+        "scope": _definition_for(canonical, extra_keys).scope,
         "source": source,
     }
     if valid_from is not None:
@@ -419,7 +495,9 @@ def build_claim_envelope(
     return {CLAIM_METADATA_KEY: env}
 
 
-def build_v2_envelope(raw_claim: Any) -> dict | None:
+def build_v2_envelope(
+    raw_claim: Any, extra_keys: TenantClaimKeys | None = None
+) -> dict | None:
     """Validate a producer-supplied v2 claim and return a CLEAN storable
     envelope, or ``None`` if it is not authoritative.
 
@@ -430,10 +508,10 @@ def build_v2_envelope(raw_claim: Any) -> dict | None:
     """
     if not isinstance(raw_claim, dict):
         return None
-    canonical = canonicalize_key(raw_claim.get("key"))
+    canonical = canonicalize_key(raw_claim.get("key"), extra_keys)
     if canonical is None:
         return None
-    definition = CLAIM_REGISTRY[canonical]
+    definition = _definition_for(canonical, extra_keys)
     if not definition.supports_v2:
         return None
     entity = canonical_entity_key(raw_claim.get("entity_key"))

--- a/server/services/compilers/__init__.py
+++ b/server/services/compilers/__init__.py
@@ -6,7 +6,7 @@ The get_compiler() factory returns the active compiler based on config.
 
 from __future__ import annotations
 
-from typing import Protocol, Sequence
+from typing import Any, Mapping, Protocol, Sequence
 
 from server.db.tables import EpisodeRow, MemoryRow
 from server.services.compilers.errors import CompilationError
@@ -17,7 +17,9 @@ __all__ = ["BaseCompiler", "CompilationError", "get_compiler"]
 class BaseCompiler(Protocol):
     """Protocol that all memory compilers must satisfy."""
 
-    def compile(self, episodes: Sequence[EpisodeRow]) -> list[MemoryRow]:
+    def compile(
+        self, episodes: Sequence[EpisodeRow], *, claim_keys: Mapping[str, Any] | None = None
+    ) -> list[MemoryRow]:
         """Derive memory rows from a batch of episodes.
 
         Contract:

--- a/server/services/compilers/heuristic.py
+++ b/server/services/compilers/heuristic.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import re
 import uuid
 from datetime import datetime, timezone
-from typing import Sequence
+from typing import Any, Mapping, Sequence
 
 from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
@@ -24,10 +24,12 @@ from server.services.memory_ttl import compute_valid_to
 class HeuristicCompiler:
     """Pattern-based memory compiler. Implements BaseCompiler protocol."""
 
-    def compile(self, episodes: Sequence[EpisodeRow]) -> list[MemoryRow]:
+    def compile(
+        self, episodes: Sequence[EpisodeRow], *, claim_keys: Mapping[str, Any] | None = None
+    ) -> list[MemoryRow]:
         memories: list[MemoryRow] = []
         for ep in episodes:
-            memories.extend(self._compile_episode(ep))
+            memories.extend(self._compile_episode(ep, claim_keys))
         # Auto-labeling runs post-construction: detectors only need
         # `content`, and running them once at the end keeps a single
         # apply path that's easy to test in isolation. Gated on the
@@ -36,13 +38,15 @@ class HeuristicCompiler:
             apply_suggestions(memories)
         return memories
 
-    def _compile_episode(self, ep: EpisodeRow) -> list[MemoryRow]:
+    def _compile_episode(
+        self, ep: EpisodeRow, claim_keys: Mapping[str, Any] | None = None
+    ) -> list[MemoryRow]:
         # Structured memory candidates short-circuit the heuristic path: compile
         # the producer-supplied atomic facts deterministically, NO catch-all
         # episode_summary. Lazy import avoids a heuristic<->structured cycle.
         from server.services.structured import compile_candidates
 
-        structured = compile_candidates(ep)
+        structured = compile_candidates(ep, claim_keys)
         if structured is not None:
             return structured
 

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from typing import Any, Sequence
+from typing import Any, Sequence, Mapping
 
 import structlog
 
@@ -470,7 +470,9 @@ class LLMCompiler:
     def __init__(self, model: str = "gpt-4o-mini") -> None:
         self._model = model
 
-    def compile(self, episodes: Sequence[EpisodeRow]) -> list[MemoryRow]:
+    def compile(
+        self, episodes: Sequence[EpisodeRow], *, claim_keys: Mapping[str, Any] | None = None
+    ) -> list[MemoryRow]:
         """Sync entry point — not supported for the LLM compiler.
 
         LLM extraction is fundamentally async (network round-trips,
@@ -490,7 +492,9 @@ class LLMCompiler:
             "compiler. See server/api/memories.py for the dispatch logic."
         )
 
-    async def compile_async(self, episodes: Sequence[EpisodeRow]) -> list[MemoryRow]:
+    async def compile_async(
+        self, episodes: Sequence[EpisodeRow], *, claim_keys: Mapping[str, Any] | None = None
+    ) -> list[MemoryRow]:
         """Async compile — batches episodes and processes in parallel.
 
         Returns the extracted memories (possibly empty when the episodes
@@ -505,7 +509,7 @@ class LLMCompiler:
         structured_memories: list[MemoryRow] = []
         episode_texts: list[tuple[EpisodeRow, str]] = []
         for ep in episodes:
-            structured = compile_candidates(ep)
+            structured = compile_candidates(ep, claim_keys)
             if structured is not None:
                 structured_memories.extend(structured)
                 continue

--- a/server/services/conflicts.py
+++ b/server/services/conflicts.py
@@ -45,6 +45,7 @@ from server.services.claims import (
     ResolvedClaim,
     intervals_overlap,
     resolve_claim,
+    load_tenant_claim_keys,
 )
 from server.services.tokenization import EDGE_PUNCT, tokenize
 
@@ -89,9 +90,15 @@ async def resolve_conflicts(
     # authoritative for the claim path; anything else (no claim, malformed,
     # unknown key, unsupported version, multi-valued) resolves to None here and
     # is handled exactly as today by the legacy lexical path.
+    # The tenant's own registered vocabulary (#376), read once per resolve so
+    # a consumer key is as authoritative for supersession as a built-in one.
+    # Empty for an untenanted server or a tenant that registered nothing —
+    # i.e. inert until an operator opts in.
+    extra_keys = await load_tenant_claim_keys(session, tenant_id)
+
     claims: dict[uuid.UUID, ResolvedClaim] = {}
     for m in memories:
-        rc = resolve_claim(m.metadata_)
+        rc = resolve_claim(m.metadata_, extra_keys)
         if rc is not None and rc.scope == SCOPE_SINGLE:
             claims[m.id] = rc
 

--- a/server/services/structured.py
+++ b/server/services/structured.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Mapping
 
 from server.core.config import settings
 from server.db.tables import EpisodeRow, MemoryRow
@@ -99,7 +99,12 @@ def is_structured_episode(payload: Any) -> bool:
     return accepted_candidates(payload) is not None
 
 
-def _candidate_claim_metadata(claim: Any, *, default_valid_from: datetime | None = None) -> dict | None:
+def _candidate_claim_metadata(
+    claim: Any,
+    *,
+    default_valid_from: datetime | None = None,
+    claim_keys: Mapping[str, Any] | None = None,
+) -> dict | None:
     """Validate a candidate's optional claim into a clean stored envelope, or
     ``None`` (rule 3 → unkeyed). Producers never define authoritative scope.
 
@@ -115,7 +120,7 @@ def _candidate_claim_metadata(claim: Any, *, default_valid_from: datetime | None
         return None
     version = claim.get("schema_version")
     if version == 2:
-        envelope = build_v2_envelope(claim)
+        envelope = build_v2_envelope(claim, claim_keys)
         if (
             envelope
             and envelope[CLAIM_METADATA_KEY].get("valid_from") is None
@@ -129,6 +134,7 @@ def _candidate_claim_metadata(claim: Any, *, default_valid_from: datetime | None
         return build_claim_envelope(
             claim.get("key"),
             claim.get("value"),
+            extra_keys=claim_keys,
             valid_from=_parse_dt(claim.get("valid_from"))
             or anchor_valid_from(valid_to, default_valid_from),
             valid_to=valid_to,
@@ -140,7 +146,9 @@ def _candidate_claim_metadata(claim: Any, *, default_valid_from: datetime | None
 
 
 
-def compile_candidates(ep: EpisodeRow) -> list[MemoryRow] | None:
+def compile_candidates(
+    ep: EpisodeRow, claim_keys: Mapping[str, Any] | None = None
+) -> list[MemoryRow] | None:
     """Compile an episode's accepted structured candidates into atomic memories,
     or ``None`` if the episode has none (caller uses the legacy path).
 
@@ -158,7 +166,9 @@ def compile_candidates(ep: EpisodeRow) -> list[MemoryRow] | None:
         kind = _KIND_MAP[c["kind"].strip().lower()]
         text = c["text"]
         metadata: dict[str, Any] = dict(c.get("metadata") or {})
-        claim_md = _candidate_claim_metadata(c.get("claim"), default_valid_from=vf)
+        claim_md = _candidate_claim_metadata(
+            c.get("claim"), default_valid_from=vf, claim_keys=claim_keys
+        )
         if claim_md:
             metadata.update(claim_md)
         confidence = c.get("confidence")

--- a/tests/integration/test_tenant_claim_keys_e2e.py
+++ b/tests/integration/test_tenant_claim_keys_e2e.py
@@ -1,0 +1,117 @@
+"""#376's acceptance experiment, end to end against a real database.
+
+An operator registers `guide.walkthrough` as single-valued in
+`tenant_configs.config.claim_keys`; a consumer then observes the same logical
+fact four times with alternating values through the structured path. The
+registered key must behave exactly like a built-in: deterministic supersession
+down to ONE active row carrying the latest value. Without the registration the
+same four writes leave four active rows — the unbounded growth the issue
+reports.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import delete
+
+from server.db import repositories as repo
+from server.db.tables import EpisodeRow, MemoryRow, TenantConfigRow
+from server.services.claims import load_tenant_claim_keys
+from server.services.compilers.heuristic import HeuristicCompiler
+from server.services.conflicts import resolve_conflicts
+
+pytestmark = pytest.mark.anyio
+
+_TENANT = f"t-claimkeys-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup(session_factory):
+    yield
+    async with session_factory() as session:
+        await session.execute(delete(MemoryRow).where(MemoryRow.tenant_id == _TENANT))
+        await session.execute(delete(EpisodeRow).where(EpisodeRow.tenant_id == _TENANT))
+        await session.execute(
+            delete(TenantConfigRow).where(TenantConfigRow.tenant_id == _TENANT)
+        )
+        await session.commit()
+
+
+def _episode(subject_id: str, value: str, when: str, text: str) -> EpisodeRow:
+    return EpisodeRow(
+        id=uuid.uuid4(),
+        subject_id=subject_id,
+        tenant_id=_TENANT,
+        source="test",
+        type="message",
+        payload={
+            "event_time": when,
+            "statewave": {
+                "memory_candidates": [
+                    {
+                        "kind": "domain_fact",
+                        "text": text,
+                        "claim": {
+                            "schema_version": 1,
+                            "key": "guide.walkthrough",
+                            "value": value,
+                        },
+                    }
+                ]
+            },
+        },
+        metadata_={},
+        provenance={},
+    )
+
+
+async def _run(session_factory, subject_id: str, registered: bool) -> list[MemoryRow]:
+    async with session_factory() as session:
+        if registered:
+            session.add(
+                TenantConfigRow(
+                    tenant_id=_TENANT,
+                    config={"claim_keys": {"guide.walkthrough": "single"}},
+                )
+            )
+            await session.commit()
+
+        claim_keys = await load_tenant_claim_keys(session, _TENANT)
+        texts = [
+            "kicked off the walkthrough",
+            "wrapped it up end to end",
+            "back into the tour again",
+            "finished every last step",
+        ]
+        episodes = [
+            _episode(subject_id, v, f"2026-0{i + 1}-01T00:00:00+00:00", texts[i])
+            for i, v in enumerate(["started", "done", "started", "done"])
+        ]
+        rows = HeuristicCompiler().compile(episodes, claim_keys=claim_keys)
+        for r in rows:
+            r.tenant_id = _TENANT
+            session.add(r)
+        await session.commit()
+
+        await resolve_conflicts(session, subject_id, tenant_id=_TENANT)
+        await session.commit()
+        active = await repo.list_active_memories_by_subject(
+            session, subject_id, tenant_id=_TENANT
+        )
+        return list(active)
+
+
+async def test_registered_key_bounds_state_to_one_active_row(session_factory):
+    active = await _run(session_factory, f"s-{uuid.uuid4().hex[:8]}", registered=True)
+    assert len(active) == 1
+    assert active[0].metadata_["claim"]["value"] == "done"  # the latest event wins
+
+
+async def test_without_registration_the_same_writes_grow_unbounded(session_factory):
+    """The pre-#376 behaviour, pinned as the contrast: no registration, no
+    claim attached, four active rows."""
+    active = await _run(session_factory, f"s-{uuid.uuid4().hex[:8]}", registered=False)
+    assert len(active) == 4
+    assert all("claim" not in (m.metadata_ or {}) for m in active)

--- a/tests/test_compile_error_handling.py
+++ b/tests/test_compile_error_handling.py
@@ -52,6 +52,18 @@ class _FakeSession:
     async def commit(self) -> None:
         self.commits += 1
 
+    async def execute(self, _stmt):
+        """No rows for any SELECT — enough for the tenant-config read that
+        `_compile_one_batch` now makes to load a tenant's own claim keys
+        (#376). A tenant with no config row is the dominant case."""
+
+        class _Empty:
+            @staticmethod
+            def scalar_one_or_none():
+                return None
+
+        return _Empty()
+
     async def refresh(self, row) -> None:  # pragma: no cover - no rows in these tests
         pass
 
@@ -104,7 +116,7 @@ async def test_failed_batch_does_not_consume_episodes(monkeypatch):
         marked.append(ids)
 
     class _RaisingCompiler:
-        async def compile_async(self, _eps):
+        async def compile_async(self, _eps, **_kw):
             raise CompilationError("LLM compilation failed: no reachable key")
 
     monkeypatch.setattr(api_memories.repo, "list_uncompiled_episodes", fake_list)
@@ -146,7 +158,7 @@ async def test_legitimate_empty_extraction_still_marks_compiled(monkeypatch):
         return None
 
     class _EmptyCompiler:
-        async def compile_async(self, _eps):
+        async def compile_async(self, _eps, **_kw):
             return []  # legitimate "extracted nothing"
 
     monkeypatch.setattr(api_memories.repo, "list_uncompiled_episodes", fake_list)

--- a/tests/test_tenant_claim_keys.py
+++ b/tests/test_tenant_claim_keys.py
@@ -1,0 +1,112 @@
+"""Consumers can register their own single-valued claim keys (#376).
+
+Before this, `CLAIM_REGISTRY` was a hardcoded dict of nine keys and
+`canonicalize_key` returned None for anything else — so a consumer's own
+vocabulary was not merely non-authoritative, the claim was dropped entirely
+and its memories grew without bound.
+
+Cardinality is declared by an operator through
+`PATCH /admin/tenants/{id}/config`, never by the episode payload: a producer
+that could label its own key `single` could collapse rows that must coexist,
+which is the invariant #236 established.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from server.services.claims import (
+    SCOPE_MULTI,
+    SCOPE_SINGLE,
+    ClaimDefinition,
+    build_claim_envelope,
+    canonicalize_key,
+    resolve_claim,
+)
+
+_GUIDE = {"guide.walkthrough": ClaimDefinition("guide.walkthrough", SCOPE_SINGLE)}
+
+
+def test_unregistered_key_is_still_dropped_without_registration():
+    """The default is unchanged: opt-in only."""
+    assert canonicalize_key("guide.walkthrough") is None
+    assert build_claim_envelope("guide.walkthrough", "done") is None
+
+
+def test_registered_key_resolves_and_carries_its_declared_cardinality():
+    assert canonicalize_key("guide.walkthrough", _GUIDE) == "guide.walkthrough"
+    env = build_claim_envelope("guide.walkthrough", "feature-x@build-y", extra_keys=_GUIDE)
+    assert env is not None
+    claim = env["claim"]
+    assert claim["key"] == "guide.walkthrough"
+    assert claim["scope"] == SCOPE_SINGLE  # from the registration, not the payload
+
+    resolved = resolve_claim(env, _GUIDE)
+    assert resolved is not None
+    assert resolved.canonical_key == "guide.walkthrough"
+    assert resolved.scope == SCOPE_SINGLE
+
+
+def test_a_tenant_cannot_shadow_a_built_in_key():
+    """Shipping a new built-in must never be silently overridden by a tenant
+    that happened to pick the same name — the built-in always wins."""
+    shadow = {"identity.name": ClaimDefinition("identity.name", SCOPE_MULTI)}
+    resolved = resolve_claim(
+        {"claim": {"schema_version": 1, "key": "identity.name", "value": "ada"}}, shadow
+    )
+    assert resolved is not None
+    assert resolved.scope == SCOPE_SINGLE  # the built-in's cardinality, not the tenant's
+
+
+def test_multi_registration_does_not_supersede():
+    """A key registered `multi` must not enter the single-valued path."""
+    keys = {"guide.tag": ClaimDefinition("guide.tag", SCOPE_MULTI)}
+    resolved = resolve_claim(
+        {"claim": {"schema_version": 1, "key": "guide.tag", "value": "beta"}}, keys
+    )
+    assert resolved is not None
+    assert resolved.scope == SCOPE_MULTI
+
+
+def test_one_tenants_vocabulary_cannot_leak_into_another():
+    """Resolution is a pure function of its inputs — no global registry
+    mutation — so a key registered for tenant A is unknown to tenant B."""
+    env = build_claim_envelope("guide.walkthrough", "done", extra_keys=_GUIDE)
+    assert resolve_claim(env, _GUIDE) is not None
+    assert resolve_claim(env, {}) is None
+    assert resolve_claim(env, None) is None
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ({"claim_keys": {"guide.walkthrough": "single"}}, {"guide.walkthrough": SCOPE_SINGLE}),
+        ({"claim_keys": {"guide.x": "nonsense"}}, {}),          # bad cardinality dropped
+        ({"claim_keys": {"identity.name": "multi"}}, {}),        # built-in never shadowed
+        ({"claim_keys": "not-a-mapping"}, {}),
+        ({}, {}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_loader_revalidates_whatever_is_in_jsonb(raw, expected, monkeypatch):
+    """The row could predate a schema change or have been written by direct
+    SQL, so one bad entry must never break compilation for the whole tenant."""
+    from server.services import claims as claims_mod
+
+    class _Row:
+        config = raw
+
+    async def fake_get(_session, _tenant):
+        return _Row()
+
+    monkeypatch.setattr("server.db.repositories.get_tenant_config", fake_get)
+    out = await claims_mod.load_tenant_claim_keys(object(), "tenant-a")
+    assert {k: v.scope for k, v in out.items()} == expected
+
+
+@pytest.mark.asyncio
+async def test_loader_is_inert_without_a_tenant():
+    """Untenanted servers do no config read at all."""
+    from server.services import claims as claims_mod
+
+    assert await claims_mod.load_tenant_claim_keys(None, None) == {}


### PR DESCRIPTION
Closes #376 with the tenant-config registry — chosen over a reserved key namespace because the deciding question is *who is authoritative for cardinality*. #236 established that a producer must never declare scope (a mislabelled `single` collapses rows that must coexist), and a namespace like `x.single.*` hands that authority to the episode payload permanently, bakes cardinality into the key string so it can never change without stranding stored claims, and lets typos silently mint keys — the unbounded growth this issue exists to remove.

## What ships

**`PATCH /admin/tenants/{id}/config` gains `claim_keys`** — a mapping of namespaced key → declared cardinality:

```json
{ "claim_keys": { "guide.walkthrough": "single", "guide.persona": "multi" } }
```

Validated at the API boundary, where every other tenant-config key is validated and for the same reason (nothing type-checks JSONB later): dotted lowercase with at least one dot, built-ins rejected rather than silently shadowed, at most 64 keys.

**A registered key behaves exactly like a built-in** on the structured ingestion path and in supersession. End to end against Postgres: four alternating writes to `guide.walkthrough` with varied wording collapse to **one active row carrying the latest value**; the identical writes without the registration leave four active rows and no claim metadata — both directions pinned as integration tests.

## Design properties, each pinned by a test that fails under mutation

- **Built-ins always win.** A tenant registering `identity.name` is rejected at PATCH time, and even a stale JSONB row cannot shadow one at resolution time — so shipping a new built-in key can never be silently overridden by a tenant that happened to pick the same name.
- **No hidden state.** Resolution stays a pure function of its inputs: the vocabulary is loaded once per compile batch / conflict resolve and passed down explicitly (the `BaseCompiler` protocol gains an optional `claim_keys` kwarg). One tenant's keys structurally cannot leak into another's, and the untenanted path performs no config read at all — the feature is inert until an operator opts in, which also keeps it bench-neutral by construction.
- **The payload still cannot declare cardinality.** Only the operator surface can; the envelope's own `scope` field remains ignored in favour of the registry, built-in or tenant.
- **LLM-proposed claims deliberately do not see tenant keys.** An untrusted model must not mint authoritative consumer claims; only the structured path, where the producer supplies its key explicitly, resolves them. The heuristic compiler's fixed pattern list is unaffected either way.
- **The loader re-validates JSONB.** A row written by direct SQL or predating a schema change drops its bad entries with a log line instead of breaking compilation for the tenant.

## Scope

1,007 unit + 285 integration tests pass, ruff clean. Migration story for a later cardinality change is deliberately minimal for now: the config is the authority at resolve time, so flipping a key's cardinality changes behaviour for subsequent compiles/resolves without touching stored rows — a recompile pass for historical rows can be added if a real consumer needs it.

Docs follow in a statewave-docs companion PR.
