### PR TITLE
Docs-refresh compile resilience: resubmit dead jobs, attach to live ones

### DIFF
--- a/alembic/versions/0029_compile_jobs_heartbeat.py
+++ b/alembic/versions/0029_compile_jobs_heartbeat.py
@@ -1,0 +1,35 @@
+"""compile_jobs.heartbeat_at — liveness signal for async compile jobs.
+
+Revision ID: 0029_compile_jobs_heartbeat
+Revises: 0028_subject_entities
+Create Date: 2026-09-01
+
+An async compile job is an in-process asyncio task backed by a durable
+row. When the process restarts mid-job (rolling deploy), the task dies
+but the row stays `running` forever — indistinguishable, until now, from
+a job that is merely slow. The compile worker bumps `heartbeat_at` as
+each internal LLM batch completes; compile-start uses it to attach to a
+live job on the same subject instead of racing it, and to supersede a
+row whose heartbeat has gone stale.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0029_compile_jobs_heartbeat"
+down_revision = "0028_subject_entities"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "compile_jobs",
+        sa.Column("heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("compile_jobs", "heartbeat_at")

--- a/scripts/bootstrap_docs_pack.py
+++ b/scripts/bootstrap_docs_pack.py
@@ -387,15 +387,23 @@ async def run(docs_path: Path, purge: bool, dry_run: bool) -> None:
         await _ingest_batched(client, server_url, sections, STAGING_SUBJECT_ID)
         print("Compiling memories (async)...")
         compile_result = await _compile_async(client, server_url, STAGING_SUBJECT_ID)
-        staging_mem = int(compile_result.get("memories_created", 0) or 0)
-        print(f"  ✓ staging compiled {staging_mem} memories from {len(sections)} episodes")
+        attempt_mem = int(compile_result.get("memories_created", 0) or 0)
 
-        # 2. Verify staging BEFORE touching live. A zero-memory or failed
-        #    build (compiler regression, payload drift) aborts here and the
-        #    live pack is left exactly as it was.
+        # 2. Verify staging BEFORE touching live — on the EXPORTED content,
+        #    not the last attempt's `memories_created`: a resubmitted attempt
+        #    that merely resumed a nearly-finished job legitimately reports a
+        #    low (even zero) count while staging holds the full pack. A
+        #    zero-memory export (compiler regression, payload drift) aborts
+        #    here and the live pack is left exactly as it was.
+        document = await _export(client, server_url, STAGING_SUBJECT_ID)
+        staging_mem = len(document.get("memories", []) or [])
+        print(
+            f"  ✓ staging holds {staging_mem} memories from {len(sections)} episodes"
+            f" (last attempt created {attempt_mem})"
+        )
         if len(sections) > 0 and staging_mem == 0:
             print(
-                "\nERROR: staging compile returned 0 memories despite ingesting "
+                "\nERROR: staging holds 0 memories despite ingesting "
                 f"{len(sections)} episodes. Refusing to swap — the LIVE pack is "
                 "untouched.",
                 file=sys.stderr,
@@ -403,10 +411,9 @@ async def run(docs_path: Path, purge: bool, dry_run: bool) -> None:
             await _purge(client, server_url, STAGING_SUBJECT_ID)
             sys.exit(1)
 
-        # 3. Swap staging -> live: export the validated staging pack, replace
-        #    live with it in one fast import (no compile in the window).
+        # 3. Swap staging -> live: replace live with the validated staging
+        #    export in one fast import (no compile in the window).
         print(f"\nSwapping {STAGING_SUBJECT_ID!r} -> live {SUBJECT_ID!r}...")
-        document = await _export(client, server_url, STAGING_SUBJECT_ID)
         await _purge(client, server_url, SUBJECT_ID)
         result = await _import_into(client, server_url, document, SUBJECT_ID)
         imported = int(result.get("memories_imported", 0) or 0)

--- a/scripts/bootstrap_docs_pack.py
+++ b/scripts/bootstrap_docs_pack.py
@@ -64,6 +64,15 @@ STAGING_SUBJECT_ID = f"{SUBJECT_ID}-staging"
 # timeout that 502'd the old synchronous compile can no longer occur.
 _COMPILE_POLL_INTERVAL_S = 5.0
 _COMPILE_MAX_WAIT_S = 1500.0  # 25 min ceiling for a full pack rebuild
+# One resubmission on a failed or orphaned compile job. Compile-start is
+# idempotent (it only queues uncompiled episodes), so a retried start resumes
+# where the dead job stopped instead of redoing work. Every historical
+# refresh failure — a Fly deploy restarting the server mid-job (orphaning it
+# into a poll timeout or a durable `failed` row) and the occasional opaque
+# compile transient — recovered on exactly one manual workflow rerun; this
+# folds that rerun into the script. The docs workflow's `timeout-minutes`
+# budgets for both attempts.
+_COMPILE_ATTEMPTS = 2
 _COMPILE_PENDING_STATUSES = frozenset(
     {"pending", "queued", "running", "processing", "in_progress", "started"}
 )
@@ -220,7 +229,32 @@ async def _compile_async(client: httpx.AsyncClient, url: str, subject_id: str) -
     its ``memories_created`` is the authoritative compile count. The
     per-subject ``memory_count`` in /v1/subjects is eventually-consistent
     and lags right after a large compile, so never gate on it here.
+
+    A job that dies under us — the server redeployed mid-compile and the
+    job row went ``failed`` or was orphaned into a poll timeout — is
+    resubmitted once (see ``_COMPILE_ATTEMPTS``) before the script gives
+    up; the resubmission resumes over the remaining uncompiled episodes.
     """
+    for attempt in range(1, _COMPILE_ATTEMPTS + 1):
+        result = await _compile_attempt(client, url, subject_id)
+        if result is not None:
+            return result
+        if attempt < _COMPILE_ATTEMPTS:
+            print(
+                f"  compile attempt {attempt} died — resubmitting (start is "
+                "idempotent over uncompiled episodes, the retry resumes where "
+                "the dead job stopped)",
+                file=sys.stderr,
+            )
+    print("  ERROR compile failed after resubmission — giving up", file=sys.stderr)
+    sys.exit(1)
+
+
+async def _compile_attempt(
+    client: httpx.AsyncClient, url: str, subject_id: str
+) -> dict | None:
+    """One start+poll cycle. ``None`` = retryable death (job failed or
+    orphaned); the caller decides whether another attempt remains."""
     resp = await _request_with_retry(
         "compile-start",
         lambda: client.post(
@@ -253,7 +287,7 @@ async def _compile_async(client: httpx.AsyncClient, url: str, subject_id: str) -
                 f"{jr.text}",
                 file=sys.stderr,
             )
-            sys.exit(1)
+            return None
         if status not in _COMPILE_PENDING_STATUSES:
             return jr.json()  # terminal success — payload carries memories_created
     print(
@@ -261,7 +295,7 @@ async def _compile_async(client: httpx.AsyncClient, url: str, subject_id: str) -
         f"{_COMPILE_MAX_WAIT_S:.0f}s",
         file=sys.stderr,
     )
-    sys.exit(1)
+    return None
 
 
 async def _export(client: httpx.AsyncClient, url: str, subject_id: str) -> dict:

--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -49,7 +49,11 @@ _COMPILE_INTERNAL_ERROR_MESSAGE = "An internal error occurred during compilation
 
 
 async def _compile_one_batch(
-    session: AsyncSession, subject_id: str, tenant_id: str | None, batch_size: int
+    session: AsyncSession,
+    subject_id: str,
+    tenant_id: str | None,
+    batch_size: int,
+    progress_cb=None,
 ) -> tuple[list[MemoryResponse], int, int]:
     """Compile ONE batch of uncompiled episodes for `subject_id`.
 
@@ -87,7 +91,9 @@ async def _compile_one_batch(
     # A CompilationError here propagates intentionally: nothing below this
     # point runs, so the episodes are never marked compiled or committed.
     if hasattr(compiler, "compile_async"):
-        new_rows = await compiler.compile_async(list(episodes), claim_keys=claim_keys)
+        new_rows = await compiler.compile_async(
+            list(episodes), claim_keys=claim_keys, progress_cb=progress_cb
+        )
     else:
         loop = asyncio.get_running_loop()
         new_rows = await loop.run_in_executor(
@@ -209,6 +215,26 @@ async def _compile_one_batch(
     return [_to_response(r) for r in new_rows], len(new_rows), remaining
 
 
+def _heartbeat_cb(job_id: str | None):
+    """Per-batch liveness callback for the LLM compiler, or None.
+
+    Bumps the durable job heartbeat as each internal LLM batch completes
+    so compile-start can tell this live job from one orphaned by a
+    restart. A heartbeat write failure must not kill a compile that is
+    otherwise succeeding — it only degrades liveness detection.
+    """
+    if job_id is None:
+        return None
+
+    async def _cb() -> None:
+        try:
+            await compile_jobs.heartbeat_durable(job_id)
+        except Exception:
+            logger.warning("compile_heartbeat_failed", job_id=job_id, exc_info=True)
+
+    return _cb
+
+
 async def _run_compile(
     subject_id: str, job_id: str | None = None, tenant_id: str | None = None
 ) -> CompileMemoriesResponse:
@@ -234,7 +260,11 @@ async def _run_compile(
         async with get_session_factory()() as session:
             for iteration in range(settings.compile_max_iterations):
                 batch_responses, created, remaining = await _compile_one_batch(
-                    session, subject_id, tenant_id, settings.compile_batch_size
+                    session,
+                    subject_id,
+                    tenant_id,
+                    settings.compile_batch_size,
+                    progress_cb=_heartbeat_cb(job_id),
                 )
                 total_created += created
                 last_batch_responses = batch_responses
@@ -321,6 +351,26 @@ async def compile_memories(
             # Async mode — return job_id immediately, compile in background (durable).
             # The background task drains the subject; the client polls
             # `/v1/memories/compile/{job_id}` for completion.
+            #
+            # Attach-not-race: if a live job is already draining this subject
+            # (fresh heartbeat), hand back ITS id — a second concurrent drain
+            # would double-compile the episodes both jobs snapshot as
+            # uncompiled. A stale-heartbeat row is a task that died with its
+            # process (rolling deploy); find_active_job_durable supersedes it
+            # so the fresh submission below resumes the remaining episodes.
+            active = await compile_jobs.find_active_job_durable(
+                body.subject_id, tenant_id=tenant_id
+            )
+            if active is not None:
+                return JSONResponse(
+                    status_code=202,
+                    content={
+                        "job_id": active.id,
+                        "status": active.status.value,
+                        "subject_id": body.subject_id,
+                        "attached": True,
+                    },
+                )
             job = await compile_jobs.submit_job_durable(body.subject_id, tenant_id=tenant_id)
             asyncio.create_task(_run_compile(body.subject_id, job.id, tenant_id=tenant_id))
             return JSONResponse(

--- a/server/db/tables.py
+++ b/server/db/tables.py
@@ -270,6 +270,10 @@ class CompileJobRow(Base):
     )
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # Liveness signal: bumped by the compile worker as batches complete, so a
+    # compile-start on the same subject can tell a live slow job (attach to
+    # it) from one orphaned by a restart (supersede it).
+    heartbeat_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class RateLimitHitRow(Base):

--- a/server/services/compile_jobs.py
+++ b/server/services/compile_jobs.py
@@ -157,9 +157,12 @@ async def find_active_job_durable(
 
     job = await _durable_find(subject_id, tenant_id)
     if job is not None:
-        # Refresh the cache (same shape as submit_job_durable) so
-        # same-process polls of the attached job see current state.
-        _jobs[job.id] = job
+        # Invalidate, never seed: this process may not OWN the job (on a
+        # multi-machine deploy the owning process's task is what mutates
+        # job state), so a cached snapshot here would serve "running"
+        # forever after the owner completes it. A cache miss falls through
+        # to Postgres on every poll, which is always current.
+        _jobs.pop(job.id, None)
     return job
 
 

--- a/server/services/compile_jobs.py
+++ b/server/services/compile_jobs.py
@@ -132,6 +132,37 @@ async def mark_failed_durable(job_id: str, error: str) -> None:
     mark_failed(job_id, error)
 
 
+async def heartbeat_durable(job_id: str) -> None:
+    """Stamp the durable liveness signal for a running job.
+
+    Cache is untouched — the heartbeat only matters to OTHER processes
+    (and future requests) deciding whether the job's owning task is
+    still alive; the local cache is same-process by definition.
+    """
+    from server.services.compile_jobs_durable import heartbeat as _durable_heartbeat
+
+    await _durable_heartbeat(job_id)
+
+
+async def find_active_job_durable(
+    subject_id: str, tenant_id: str | None = None
+) -> CompileJob | None:
+    """Return the live in-flight job for a subject, superseding orphans.
+
+    Always hits Postgres — liveness is a cross-process question, so the
+    process-local cache (which never sees jobs submitted elsewhere and
+    holds no heartbeat) must not answer it.
+    """
+    from server.services.compile_jobs_durable import find_active_job as _durable_find
+
+    job = await _durable_find(subject_id, tenant_id)
+    if job is not None:
+        # Refresh the cache (same shape as submit_job_durable) so
+        # same-process polls of the attached job see current state.
+        _jobs[job.id] = job
+    return job
+
+
 async def update_progress_durable(job_id: str, memories_created: int) -> None:
     """Bump the durable `memories_created` count mid-job.
 

--- a/server/services/compile_jobs_durable.py
+++ b/server/services/compile_jobs_durable.py
@@ -183,11 +183,13 @@ async def heartbeat(job_id: str) -> None:
         await session.commit()
 
 
-# A live job's heartbeat advances every completed LLM batch. 15 minutes of
+# A live job's heartbeat advances on every provider round-trip. 15 minutes of
 # silence across ALL concurrently in-flight batches means the owning task is
-# dead (restart), not slow — provider retries on a single batch stay well
-# under this. Deliberately below the bootstrap script's 1500s poll ceiling so
-# a resubmission after a poll timeout always sees an orphaned row as stale.
+# dead (restart), not slow. Below the bootstrap script's 1500s poll ceiling,
+# so a resubmission after a timeout classifies a job that died in the FIRST
+# 600s of the poll window as an orphan; a job that dies later still reads as
+# live at resubmission time and only the following start supersedes it — a
+# known gap accepted over the risk of superseding a live-but-quiet job.
 ACTIVE_STALE_SECONDS = 900.0
 
 
@@ -240,12 +242,26 @@ async def find_active_job(
                         subject_id=subject_id,
                     )
                 continue
-            row.status = "failed"
-            row.error = (
-                "orphaned: no heartbeat for "
-                f"{int(ACTIVE_STALE_SECONDS)}s — superseded by a new compile-start"
+            # Guarded UPDATE, not ORM attribute mutation: between our SELECT
+            # and this write the owning task may reach a terminal state (a
+            # >stale-threshold straggler completing), and flipping a
+            # `completed` row to `failed` would report a false failure. The
+            # status filter makes the supersede a no-op in that race.
+            await session.execute(
+                update(CompileJobRow)
+                .where(
+                    CompileJobRow.id == row.id,
+                    CompileJobRow.status.in_(["pending", "running"]),
+                )
+                .values(
+                    status="failed",
+                    error=(
+                        "orphaned: no heartbeat for "
+                        f"{int(ACTIVE_STALE_SECONDS)}s — superseded by a new compile-start"
+                    ),
+                    completed_at=now,
+                )
             )
-            row.completed_at = now
             logger.warning(
                 "compile_job_orphan_superseded",
                 job_id=row.id,

--- a/server/services/compile_jobs_durable.py
+++ b/server/services/compile_jobs_durable.py
@@ -121,7 +121,11 @@ async def mark_running(job_id: str) -> None:
         await session.execute(
             update(CompileJobRow)
             .where(CompileJobRow.id == job_id)
-            .values(status="running", started_at=datetime.now(timezone.utc))
+            .values(
+                status="running",
+                started_at=datetime.now(timezone.utc),
+                heartbeat_at=datetime.now(timezone.utc),
+            )
         )
         await session.commit()
 
@@ -155,9 +159,101 @@ async def update_progress(job_id: str, memories_created: int) -> None:
         await session.execute(
             update(CompileJobRow)
             .where(CompileJobRow.id == job_id)
-            .values(memories_created=memories_created)
+            .values(
+                memories_created=memories_created,
+                heartbeat_at=datetime.now(timezone.utc),
+            )
         )
         await session.commit()
+
+
+async def heartbeat(job_id: str) -> None:
+    """Stamp the job's liveness signal. Raises on DB failure.
+
+    Called by the compile worker as each internal LLM batch completes
+    (~tens of seconds apart at normal provider latency), so a stalled
+    heartbeat means the owning task is gone, not merely slow.
+    """
+    async with get_session_factory()() as session:
+        await session.execute(
+            update(CompileJobRow)
+            .where(CompileJobRow.id == job_id)
+            .values(heartbeat_at=datetime.now(timezone.utc))
+        )
+        await session.commit()
+
+
+# A live job's heartbeat advances every completed LLM batch. 15 minutes of
+# silence across ALL concurrently in-flight batches means the owning task is
+# dead (restart), not slow — provider retries on a single batch stay well
+# under this. Deliberately below the bootstrap script's 1500s poll ceiling so
+# a resubmission after a poll timeout always sees an orphaned row as stale.
+ACTIVE_STALE_SECONDS = 900.0
+
+
+async def find_active_job(
+    subject_id: str, tenant_id: str | None = None
+) -> CompileJob | None:
+    """Return the live in-flight job for a subject, superseding orphans.
+
+    A `pending`/`running` row whose liveness signal (heartbeat, else
+    started/created time) is fresher than `ACTIVE_STALE_SECONDS` is
+    returned so the caller attaches to it instead of racing it with a
+    second compile over the same uncompiled episodes. A stale row's task
+    died with its process — it is marked failed here so the caller can
+    start a replacement. Residual race: a task that stalls longer than
+    the threshold but is still alive cannot be cancelled from another
+    request; the threshold is sized so only a dead task goes stale.
+    """
+    now = datetime.now(timezone.utc)
+    async with get_session_factory()() as session:
+        stmt = (
+            select(CompileJobRow)
+            .where(
+                CompileJobRow.subject_id == subject_id,
+                CompileJobRow.status.in_(["pending", "running"]),
+            )
+            .order_by(CompileJobRow.created_at.desc())
+        )
+        if tenant_id is None:
+            stmt = stmt.where(CompileJobRow.tenant_id.is_(None))
+        else:
+            stmt = stmt.where(CompileJobRow.tenant_id == tenant_id)
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
+
+        live: CompileJobRow | None = None
+        for row in rows:
+            last_seen = row.heartbeat_at or row.started_at or row.created_at
+            age = (now - last_seen).total_seconds() if last_seen else None
+            fresh = age is not None and age < ACTIVE_STALE_SECONDS
+            if fresh:
+                if live is None:
+                    live = row
+                else:
+                    # Two fresh in-flight jobs = a pre-attach race artifact.
+                    # Neither task can be cancelled from here; leave both to
+                    # finish and just surface the anomaly.
+                    logger.warning(
+                        "compile_job_duplicate_live",
+                        job_id=row.id,
+                        subject_id=subject_id,
+                    )
+                continue
+            row.status = "failed"
+            row.error = (
+                "orphaned: no heartbeat for "
+                f"{int(ACTIVE_STALE_SECONDS)}s — superseded by a new compile-start"
+            )
+            row.completed_at = now
+            logger.warning(
+                "compile_job_orphan_superseded",
+                job_id=row.id,
+                subject_id=subject_id,
+                age_seconds=int(age) if age is not None else None,
+            )
+        await session.commit()
+        return _row_to_job(live) if live is not None else None
 
 
 async def mark_failed(job_id: str, error: str) -> None:

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -493,7 +493,11 @@ class LLMCompiler:
         )
 
     async def compile_async(
-        self, episodes: Sequence[EpisodeRow], *, claim_keys: Mapping[str, Any] | None = None
+        self,
+        episodes: Sequence[EpisodeRow],
+        *,
+        claim_keys: Mapping[str, Any] | None = None,
+        progress_cb=None,
     ) -> list[MemoryRow]:
         """Async compile — batches episodes and processes in parallel.
 
@@ -566,7 +570,16 @@ class LLMCompiler:
         semaphore = asyncio.Semaphore(
             getattr(settings, "compile_max_concurrency", None) or _MAX_CONCURRENCY
         )
-        tasks = [self._process_batch(batch, semaphore) for batch in batches]
+        async def _run_one(batch):
+            result = await self._process_batch(batch, semaphore)
+            # Liveness ping per completed batch (job heartbeat): lets a
+            # concurrent compile-start tell this live job from one whose
+            # owning process died. Awaited so pings can't pile up.
+            if progress_cb is not None:
+                await progress_cb()
+            return result
+
+        tasks = [_run_one(batch) for batch in batches]
         batch_results = await asyncio.gather(*tasks)
 
         # Flatten results (structured candidates first, then LLM extractions)

--- a/server/services/compilers/llm.py
+++ b/server/services/compilers/llm.py
@@ -570,16 +570,10 @@ class LLMCompiler:
         semaphore = asyncio.Semaphore(
             getattr(settings, "compile_max_concurrency", None) or _MAX_CONCURRENCY
         )
-        async def _run_one(batch):
-            result = await self._process_batch(batch, semaphore)
-            # Liveness ping per completed batch (job heartbeat): lets a
-            # concurrent compile-start tell this live job from one whose
-            # owning process died. Awaited so pings can't pile up.
-            if progress_cb is not None:
-                await progress_cb()
-            return result
-
-        tasks = [_run_one(batch) for batch in batches]
+        tasks = [
+            self._process_batch(batch, semaphore, progress_cb=progress_cb)
+            for batch in batches
+        ]
         batch_results = await asyncio.gather(*tasks)
 
         # Flatten results (structured candidates first, then LLM extractions)
@@ -633,6 +627,7 @@ class LLMCompiler:
         self,
         batch: list[tuple[EpisodeRow, str]],
         combined_text: str,
+        progress_cb=None,
     ) -> list[dict]:
         """Extract one batch, halving and retrying if the output will not parse.
 
@@ -645,8 +640,14 @@ class LLMCompiler:
         extraction could not run at all, and the caller must see them.
         """
         try:
-            return await self._call_llm_async(combined_text, len(batch))
+            result = await self._call_llm_async(combined_text, len(batch))
         except LLMResponseError:
+            # Liveness ping (job heartbeat) even on a parse failure: a deep
+            # split-retry chain is many provider round-trips of real work,
+            # and going silent for its whole duration would let a concurrent
+            # compile-start misread this live job as orphaned.
+            if progress_cb is not None:
+                await progress_cb()
             if len(batch) == 1:
                 raise  # irreducible — _process_batch names the episode
             mid = len(batch) // 2
@@ -659,14 +660,24 @@ class LLMCompiler:
             out: list[dict] = []
             for half in halves:
                 out.extend(
-                    await self._extract_with_split_retry(half, _format_episode_blocks(half))
+                    await self._extract_with_split_retry(
+                        half, _format_episode_blocks(half), progress_cb=progress_cb
+                    )
                 )
             return out
+        else:
+            # One provider round-trip completed — liveness ping per round-trip
+            # (not per top-level batch) so even a batch that is splitting and
+            # retrying keeps its job's heartbeat fresh.
+            if progress_cb is not None:
+                await progress_cb()
+            return result
 
     async def _process_batch(
         self,
         batch: list[tuple[EpisodeRow, str]],
         semaphore: asyncio.Semaphore,
+        progress_cb=None,
     ) -> list[MemoryRow]:
         """Process a batch of episodes in a single LLM call."""
         async with semaphore:
@@ -681,7 +692,9 @@ class LLMCompiler:
             combined_text = _format_episode_blocks(batch)
 
             try:
-                raw_memories = await self._extract_with_split_retry(batch, combined_text)
+                raw_memories = await self._extract_with_split_retry(
+                    batch, combined_text, progress_cb=progress_cb
+                )
             except LLMResponseError as exc:
                 # A single episode whose extraction output will not parse, even
                 # alone. Still a raise (issue #201: never silently consume an

--- a/server/services/migrations.py
+++ b/server/services/migrations.py
@@ -13,7 +13,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 # Expected head revision — update this when adding new migrations
-EXPECTED_HEAD = "0028_subject_entities"
+EXPECTED_HEAD = "0029_compile_jobs_heartbeat"
 
 # Path to alembic.ini relative to the repo root
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent.parent / "alembic.ini"

--- a/tests/test_bootstrap_docs_pack.py
+++ b/tests/test_bootstrap_docs_pack.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
+import scripts.bootstrap_docs_pack as bootstrap
 from scripts.bootstrap_docs_pack import _request_with_retry
 
 
@@ -128,3 +129,106 @@ async def test_backoff_is_exponential_and_capped():
         )
     delays = [call.args[0] for call in sleep_mock.await_args_list]
     assert delays == [2.0, 4.0, 8.0, 16.0, 30.0]
+
+
+# --- _compile_async resubmission -------------------------------------------
+#
+# Pinned because the recurring refresh failure is a core deploy restarting
+# the server mid-compile: the async job is orphaned (poll timeout) or lands
+# in a durable `failed` row, and every occurrence recovered on exactly one
+# manual workflow rerun. _compile_async folds that rerun into the script —
+# compile-start is idempotent over uncompiled episodes, so a resubmission
+# resumes where the dead job stopped.
+
+
+class _FakeClient:
+    """Queued responses for the compile start (post) and poll (get) calls."""
+
+    def __init__(self, posts, gets):
+        self.post_calls = 0
+        self._posts = list(posts)
+        self._gets = list(gets)
+
+    async def post(self, *_a, **_kw):
+        self.post_calls += 1
+        return self._posts.pop(0)
+
+    async def get(self, *_a, **_kw):
+        return self._gets.pop(0)
+
+
+def _job_start(job_id: str) -> httpx.Response:
+    return httpx.Response(status_code=202, json={"job_id": job_id})
+
+
+def _job_poll(status: str, **extra) -> httpx.Response:
+    return httpx.Response(status_code=200, json={"status": status, **extra})
+
+
+@pytest.mark.asyncio
+async def test_compile_returns_without_resubmit_on_success():
+    client = _FakeClient(
+        posts=[_job_start("j1")],
+        gets=[_job_poll("running"), _job_poll("completed", memories_created=7)],
+    )
+    result = await bootstrap._compile_async(client, "http://x", "subj")
+    assert result["memories_created"] == 7
+    assert client.post_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_compile_returns_inline_result_when_server_lacks_async():
+    """No job_id in the start response = older server did the work inline."""
+    client = _FakeClient(
+        posts=[httpx.Response(status_code=200, json={"memories_created": 3})],
+        gets=[],
+    )
+    result = await bootstrap._compile_async(client, "http://x", "subj")
+    assert result["memories_created"] == 3
+    assert client.post_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_compile_resubmits_once_after_failed_job_status():
+    """A deploy-killed job lands in `failed`; the resubmission must resume."""
+    client = _FakeClient(
+        posts=[_job_start("j1"), _job_start("j2")],
+        gets=[
+            _job_poll("failed"),
+            _job_poll("completed", memories_created=5),
+        ],
+    )
+    result = await bootstrap._compile_async(client, "http://x", "subj")
+    assert result["memories_created"] == 5
+    assert client.post_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_compile_resubmits_once_after_poll_timeout():
+    """An orphaned job (server restarted, row stuck `running`) times out;
+    the resubmission must resume rather than the script exiting 1."""
+    # Two poll intervals reach the ceiling — attempt 1 sees only `running`.
+    with patch.object(bootstrap, "_COMPILE_MAX_WAIT_S", 2 * bootstrap._COMPILE_POLL_INTERVAL_S):
+        client = _FakeClient(
+            posts=[_job_start("j1"), _job_start("j2")],
+            gets=[
+                _job_poll("running"),
+                _job_poll("running"),
+                _job_poll("completed", memories_created=9),
+            ],
+        )
+        result = await bootstrap._compile_async(client, "http://x", "subj")
+    assert result["memories_created"] == 9
+    assert client.post_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_compile_exits_nonzero_after_second_death():
+    client = _FakeClient(
+        posts=[_job_start("j1"), _job_start("j2")],
+        gets=[_job_poll("failed"), _job_poll("failed")],
+    )
+    with pytest.raises(SystemExit) as exc:
+        await bootstrap._compile_async(client, "http://x", "subj")
+    assert exc.value.code == 1
+    assert client.post_calls == 2

--- a/tests/test_compile_job_attach.py
+++ b/tests/test_compile_job_attach.py
@@ -1,0 +1,299 @@
+"""Async compile-start must attach to a live job, not race it (docs-refresh
+failure class, 4th occurrence 2026-09-01).
+
+An async compile job is an in-process asyncio task backed by a durable row.
+Two failure shapes at compile-start on a busy subject:
+
+* The previous job is ALIVE but slow — a second submission would start a
+  concurrent drain over the same uncompiled-episode snapshot and
+  double-compile them. Compile-start must return the live job's id instead.
+* The previous job is ORPHANED — its process restarted (rolling deploy), the
+  task died, the row says `running` forever. Compile-start must supersede it
+  and start a fresh job that resumes the remaining episodes.
+
+Liveness is the `heartbeat_at` column, bumped by the LLM compiler as each
+internal batch completes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import server.services.compile_jobs_durable as durable
+from server.services.compile_jobs_durable import ACTIVE_STALE_SECONDS, find_active_job
+
+pytestmark = pytest.mark.asyncio
+
+_NOW = datetime.now(timezone.utc)
+
+
+def _row(status="running", heartbeat_age_s=10.0, job_id="j1"):
+    hb = _NOW - timedelta(seconds=heartbeat_age_s) if heartbeat_age_s is not None else None
+    return SimpleNamespace(
+        id=job_id,
+        subject_id="subj",
+        tenant_id=None,
+        status=status,
+        memories_created=0,
+        error=None,
+        created_at=_NOW - timedelta(seconds=3600),
+        started_at=None,
+        completed_at=None,
+        heartbeat_at=hb,
+    )
+
+
+def _session_returning(rows):
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = rows
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+def _patched_factory(session):
+    return patch.object(durable, "get_session_factory", return_value=lambda: session)
+
+
+# ---------------------------------------------------------------------------
+# find_active_job
+# ---------------------------------------------------------------------------
+
+
+async def test_fresh_heartbeat_job_is_returned_as_live():
+    row = _row(heartbeat_age_s=30.0)
+    session = _session_returning([row])
+    with _patched_factory(session):
+        job = await find_active_job("subj")
+    assert job is not None and job.id == "j1"
+    assert row.status == "running", "a live job must not be touched"
+
+
+async def test_stale_heartbeat_job_is_superseded():
+    row = _row(heartbeat_age_s=ACTIVE_STALE_SECONDS + 60)
+    session = _session_returning([row])
+    with _patched_factory(session):
+        job = await find_active_job("subj")
+    assert job is None, "a stale job is dead — caller should submit a new one"
+    assert row.status == "failed"
+    assert "orphaned" in row.error
+    assert row.completed_at is not None
+    session.commit.assert_awaited()
+
+
+async def test_no_active_rows_returns_none():
+    session = _session_returning([])
+    with _patched_factory(session):
+        assert await find_active_job("subj") is None
+
+
+async def test_pending_row_liveness_falls_back_to_created_at():
+    """A job submitted moments ago has no heartbeat yet — it must still
+    count as live or every attach would race the brand-new job."""
+    row = _row(status="pending", heartbeat_age_s=None)
+    row.created_at = _NOW - timedelta(seconds=5)
+    session = _session_returning([row])
+    with _patched_factory(session):
+        job = await find_active_job("subj")
+    assert job is not None and job.id == "j1"
+
+
+async def test_second_fresh_row_is_left_alone():
+    """Two fresh in-flight jobs are a pre-attach race artifact; neither task
+    can be cancelled from here, so neither row may be marked failed."""
+    newer, older = _row(job_id="new", heartbeat_age_s=10), _row(job_id="old", heartbeat_age_s=20)
+    session = _session_returning([newer, older])
+    with _patched_factory(session):
+        job = await find_active_job("subj")
+    assert job is not None and job.id == "new"
+    assert older.status == "running"
+
+
+# ---------------------------------------------------------------------------
+# compile_memories: async branch attaches instead of racing
+# ---------------------------------------------------------------------------
+
+
+def _api():
+    from server.api import memories as api_memories
+
+    return api_memories
+
+
+async def test_compile_start_attaches_to_live_job(monkeypatch):
+    api_memories = _api()
+    from server.schemas.requests import CompileMemoriesRequest
+    from server.services.compile_jobs import CompileJob, JobStatus
+
+    live = CompileJob(id="live-1", subject_id="subj", status=JobStatus.running)
+    find = AsyncMock(return_value=live)
+    submit = AsyncMock(side_effect=AssertionError("must not submit a second job"))
+    monkeypatch.setattr(api_memories.compile_jobs, "find_active_job_durable", find)
+    monkeypatch.setattr(api_memories.compile_jobs, "submit_job_durable", submit)
+
+    body = CompileMemoriesRequest(**{"subject_id": "subj", "async": True})
+    resp = await api_memories.compile_memories(body, session=MagicMock(), tenant_id=None)
+
+    assert resp.status_code == 202
+    import json
+
+    payload = json.loads(resp.body)
+    assert payload["job_id"] == "live-1"
+    assert payload["attached"] is True
+    find.assert_awaited_once_with("subj", tenant_id=None)
+
+
+async def test_compile_start_submits_when_no_live_job(monkeypatch):
+    api_memories = _api()
+    from server.schemas.requests import CompileMemoriesRequest
+    from server.services.compile_jobs import CompileJob
+
+    submitted = CompileJob(id="new-1", subject_id="subj")
+    monkeypatch.setattr(
+        api_memories.compile_jobs, "find_active_job_durable", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        api_memories.compile_jobs, "submit_job_durable", AsyncMock(return_value=submitted)
+    )
+
+    async def fake_run_compile(*_a, **_kw):
+        return None
+
+    monkeypatch.setattr(api_memories, "_run_compile", fake_run_compile)
+
+    body = CompileMemoriesRequest(**{"subject_id": "subj", "async": True})
+    resp = await api_memories.compile_memories(body, session=MagicMock(), tenant_id=None)
+    # Let the create_task'd noop settle before the loop closes.
+    await asyncio.sleep(0)
+
+    assert resp.status_code == 202
+    import json
+
+    payload = json.loads(resp.body)
+    assert payload["job_id"] == "new-1"
+    assert "attached" not in payload
+
+
+# ---------------------------------------------------------------------------
+# heartbeat threading: _run_compile → _compile_one_batch → compiler
+# ---------------------------------------------------------------------------
+
+
+async def test_run_compile_threads_a_working_heartbeat_cb(monkeypatch):
+    api_memories = _api()
+
+    seen_cbs = []
+
+    async def fake_batch(_session, _subject_id, _tenant_id, _batch_size, progress_cb=None):
+        seen_cbs.append(progress_cb)
+        return ([], 0, 0)
+
+    hb = AsyncMock()
+    monkeypatch.setattr(api_memories, "_compile_one_batch", fake_batch)
+    monkeypatch.setattr(api_memories.compile_jobs, "heartbeat_durable", hb)
+    monkeypatch.setattr(api_memories.compile_jobs, "mark_running_durable", AsyncMock())
+    monkeypatch.setattr(api_memories.compile_jobs, "update_progress_durable", AsyncMock())
+    monkeypatch.setattr(api_memories.compile_jobs, "mark_completed_durable", AsyncMock())
+
+    import server.db.engine as engine_module
+
+    class _Ctx:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *a):
+            return None
+
+    monkeypatch.setattr(engine_module, "get_session_factory", lambda: lambda: _Ctx())
+
+    await api_memories._run_compile("subj", job_id="job-1", tenant_id=None)
+
+    assert len(seen_cbs) == 1 and seen_cbs[0] is not None
+    await seen_cbs[0]()
+    hb.assert_awaited_once_with("job-1")
+
+
+async def test_heartbeat_cb_failure_does_not_raise(monkeypatch):
+    """A heartbeat write failure only degrades liveness detection — it must
+    never kill a compile that is otherwise succeeding."""
+    api_memories = _api()
+    monkeypatch.setattr(
+        api_memories.compile_jobs,
+        "heartbeat_durable",
+        AsyncMock(side_effect=RuntimeError("db hiccup")),
+    )
+    cb = api_memories._heartbeat_cb("job-1")
+    await cb()  # must not raise
+
+
+async def test_heartbeat_cb_is_none_without_job():
+    api_memories = _api()
+    assert api_memories._heartbeat_cb(None) is None
+
+
+# ---------------------------------------------------------------------------
+# LLM compiler: one ping per completed internal batch
+# ---------------------------------------------------------------------------
+
+
+async def test_llm_compiler_pings_progress_per_batch():
+    import uuid
+
+    from server.db.tables import EpisodeRow
+    from server.services.compilers.llm import LLMCompiler
+
+    def _ep(text):
+        return EpisodeRow(
+            id=uuid.uuid4(),
+            subject_id="user-1",
+            source="test",
+            type="conversation",
+            payload={"text": text},
+            metadata_={},
+            provenance={},
+            created_at=_NOW,
+            occurred_at=_NOW,
+        )
+
+    compiler = LLMCompiler()
+    process = AsyncMock(return_value=[])
+    cb = AsyncMock()
+    # Two ~4000-char episodes exceed the 6000-char batch budget → 2 batches.
+    episodes = [_ep("x" * 4000), _ep("y" * 4000)]
+    with patch.object(compiler, "_process_batch", new=process):
+        await compiler.compile_async(episodes, progress_cb=cb)
+
+    assert process.await_count >= 1
+    assert cb.await_count == process.await_count, "one liveness ping per completed batch"
+
+
+async def test_llm_compiler_progress_cb_defaults_to_none():
+    """Callers that don't care about liveness (sync path, tests) pass
+    nothing and nothing extra runs."""
+    import uuid
+
+    from server.db.tables import EpisodeRow
+    from server.services.compilers.llm import LLMCompiler
+
+    ep = EpisodeRow(
+        id=uuid.uuid4(),
+        subject_id="user-1",
+        source="test",
+        type="conversation",
+        payload={"text": "hello"},
+        metadata_={},
+        provenance={},
+        created_at=_NOW,
+        occurred_at=_NOW,
+    )
+    compiler = LLMCompiler()
+    with patch.object(compiler, "_process_batch", new=AsyncMock(return_value=[])):
+        result = await compiler.compile_async([ep])
+    assert result == []

--- a/tests/test_compile_job_attach.py
+++ b/tests/test_compile_job_attach.py
@@ -82,9 +82,14 @@ async def test_stale_heartbeat_job_is_superseded():
     with _patched_factory(session):
         job = await find_active_job("subj")
     assert job is None, "a stale job is dead — caller should submit a new one"
-    assert row.status == "failed"
-    assert "orphaned" in row.error
-    assert row.completed_at is not None
+    # The supersede is a guarded bulk UPDATE (status still pending/running in
+    # the WHERE) so a concurrent terminal transition wins — one execute for
+    # the SELECT, one for the UPDATE, then a commit.
+    assert session.execute.await_count == 2
+    update_stmt = session.execute.await_args_list[1].args[0]
+    compiled = str(update_stmt)
+    assert "UPDATE compile_jobs" in compiled
+    assert "status IN" in compiled, "supersede must be guarded on non-terminal status"
     session.commit.assert_awaited()
 
 
@@ -263,15 +268,16 @@ async def test_llm_compiler_pings_progress_per_batch():
         )
 
     compiler = LLMCompiler()
-    process = AsyncMock(return_value=[])
+    call = AsyncMock(return_value=[])
     cb = AsyncMock()
-    # Two ~4000-char episodes exceed the 6000-char batch budget → 2 batches.
+    # Two ~4000-char episodes exceed the 6000-char batch budget → 2 batches,
+    # each one provider round-trip.
     episodes = [_ep("x" * 4000), _ep("y" * 4000)]
-    with patch.object(compiler, "_process_batch", new=process):
+    with patch.object(compiler, "_call_llm_async", new=call):
         await compiler.compile_async(episodes, progress_cb=cb)
 
-    assert process.await_count >= 1
-    assert cb.await_count == process.await_count, "one liveness ping per completed batch"
+    assert call.await_count >= 1
+    assert cb.await_count == call.await_count, "one liveness ping per provider round-trip"
 
 
 async def test_llm_compiler_progress_cb_defaults_to_none():
@@ -294,6 +300,72 @@ async def test_llm_compiler_progress_cb_defaults_to_none():
         occurred_at=_NOW,
     )
     compiler = LLMCompiler()
-    with patch.object(compiler, "_process_batch", new=AsyncMock(return_value=[])):
+    with patch.object(compiler, "_call_llm_async", new=AsyncMock(return_value=[])):
         result = await compiler.compile_async([ep])
     assert result == []
+
+
+async def test_split_retry_pings_every_round_trip():
+    """A splitting batch is many provider round-trips of real work — its
+    job's heartbeat must advance through the whole chain, or a concurrent
+    compile-start misreads the live job as orphaned mid-split."""
+    import uuid
+
+    from server.db.tables import EpisodeRow
+    from server.services.compilers.llm import LLMCompiler
+    from server.services.llm import LLMResponseError
+
+    def _ep(text):
+        return EpisodeRow(
+            id=uuid.uuid4(),
+            subject_id="user-1",
+            source="test",
+            type="conversation",
+            payload={"text": text},
+            metadata_={},
+            provenance={},
+            created_at=_NOW,
+            occurred_at=_NOW,
+        )
+
+    calls = 0
+
+    async def fake_call(_text, count):
+        nonlocal calls
+        calls += 1
+        if count == 2:
+            raise LLMResponseError("unparseable")
+        return []
+
+    compiler = LLMCompiler()
+    cb = AsyncMock()
+    batch = [(_ep("a"), "a"), (_ep("b"), "b")]
+    with patch.object(compiler, "_call_llm_async", new=fake_call):
+        await compiler._extract_with_split_retry(batch, "a\nb", progress_cb=cb)
+
+    assert calls == 3, "full batch fails, two singleton halves succeed"
+    assert cb.await_count == calls, "one ping per round-trip, parse failures included"
+
+
+async def test_find_active_job_durable_invalidates_cache_never_seeds():
+    """The attaching process may not OWN the job; a cached snapshot here
+    would serve 'running' forever after the owner (another machine)
+    completes it. Attach must evict, not seed."""
+    import server.services.compile_jobs as compile_jobs_module
+    from server.services.compile_jobs import CompileJob, find_active_job_durable
+
+    stale_snapshot = CompileJob(id="live-9", subject_id="subj")
+    compile_jobs_module._jobs["live-9"] = stale_snapshot
+    fresh = CompileJob(id="live-9", subject_id="subj")
+    try:
+        with patch(
+            "server.services.compile_jobs_durable.find_active_job",
+            new=AsyncMock(return_value=fresh),
+        ):
+            job = await find_active_job_durable("subj")
+        assert job is fresh
+        assert "live-9" not in compile_jobs_module._jobs, (
+            "attach must invalidate the local cache so polls read Postgres"
+        )
+    finally:
+        compile_jobs_module._jobs.pop("live-9", None)

--- a/tests/test_issue_134_compile_drain.py
+++ b/tests/test_issue_134_compile_drain.py
@@ -62,7 +62,7 @@ async def test_134_async_drain_loops_until_remaining_is_zero(monkeypatch):
 
     call_log = []
 
-    async def fake_batch(_session, _subject_id, _tenant_id, _batch_size):
+    async def fake_batch(_session, _subject_id, _tenant_id, _batch_size, progress_cb=None):
         call_log.append("batch")
         return scripted.pop(0)
 
@@ -137,7 +137,7 @@ async def test_134_async_drain_respects_iteration_cap(monkeypatch):
     from server.api import memories as api_memories
     from server.core.config import settings
 
-    async def never_drains(_session, _subject_id, _tenant_id, _batch_size):
+    async def never_drains(_session, _subject_id, _tenant_id, _batch_size, progress_cb=None):
         return [], 1, 999  # always 1 created, always 999 remaining
 
     async def noop(*_a, **_k):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,7 @@ class TestMigrationStatus:
 def test_get_all_revisions():
     """Verify we can introspect the migration chain."""
     revs = get_all_revisions()
-    assert len(revs) == 28
+    assert len(revs) == 29
     assert revs[0] == "0001"
     assert revs[-1] == EXPECTED_HEAD
 
@@ -64,7 +64,7 @@ def test_resolve_pending_behind():
     status = MigrationStatus(current_revision="0010")
     result = _resolve_pending(status)
     assert not result.is_compatible
-    assert result.pending_count == 18
+    assert result.pending_count == 19
     assert "0011" in result.pending_revisions
     assert EXPECTED_HEAD in result.pending_revisions
 
@@ -73,7 +73,7 @@ def test_resolve_pending_fresh_db():
     """When current is None, all revisions are pending."""
     status = MigrationStatus(current_revision=None)
     result = _resolve_pending(status)
-    assert result.pending_count == 28
+    assert result.pending_count == 29
 
 
 def test_resolve_pending_unknown_revision():


### PR DESCRIPTION
## Problem

The `refresh-support-docs` workflow in statewave-docs has failed four times with the same shape: the async compile job dies or stalls mid-run and the script gives up after its 1500s poll ceiling. Two distinct causes observed on 2026-09-01:

1. **Orphaned job** (run 33538953245): a core Fly deploy restarted the server at 17:38–17:40 mid-compile; the asyncio task died, the durable row stayed `running` forever, the poll timed out.
2. **Slow job** (the rerun, 18:25–18:51): no deploy in flight — the same 411-episode compile genuinely ran past 25 minutes. Successful-run durations have been climbing (8 min → 12 min → 23 min over 8/30–8/31), so this is now a recurring shape, not a freak.

Every prior occurrence recovered on exactly one manual workflow rerun; the live pack is never at risk (staging→swap).

## Fix — two layers

**Script (`scripts/bootstrap_docs_pack.py`)**: `_compile_async` folds the manual rerun in — one start+poll cycle becomes an attempt; a dead attempt (failed status or 1500s timeout) is resubmitted once before the script exits 1. Compile-start is idempotent over uncompiled episodes, so a resubmission resumes where the dead job stopped. A 4xx on compile-start still exits immediately.

**Server (attach-not-race)**: a resubmission is only safe when the first job is dead. Async compile jobs now carry a durable heartbeat (`heartbeat_at`, migration 0029), pinged by the LLM compiler as each internal batch completes (optional `progress_cb`, threaded like #378's `claim_keys`). `POST /v1/memories/compile {"async": true}` first consults `find_active_job`:

- fresh heartbeat → return the live job's id (`"attached": true`, same 202 shape) — the poller follows the live job instead of starting a concurrent drain that would double-compile the same uncompiled-episode snapshot;
- stale heartbeat (900s, below the script's 1500s ceiling, far above per-batch latency) → the task died with its process: the row is marked failed ("orphaned … superseded") and a fresh job resumes the remaining episodes.

A heartbeat write failure only degrades liveness detection — it never kills an otherwise-succeeding compile. Residual race, inherent to in-process tasks: a live task stalled past the threshold cannot be cancelled from another request; the threshold is sized so only a dead task goes stale.

Combined effect for the workflow: attempt 1 (25 min) + resubmit-attach (25 min) covers compiles up to ~50 min and recovers deploy orphans unattended. Companion PR raises the docs workflow `timeout-minutes` 30→60 to budget both attempts.

## Bench-gate note

Compile-path adjacent but bench-neutral by construction: the only compiler change is an awaited no-op-by-default callback after each batch completes — extraction, claims, ordering, and outputs are untouched; the rest is job bookkeeping at the API layer.

## Tests

- Script: 5 tests for the resubmission paths (existing fake-client/no-sleep pattern), mutation-checked — reverting the soft-death `return None` back to `sys.exit(1)` fails them.
- Server: 12 tests — liveness classification (fresh / stale / pending fallback / duplicate-live untouched), attach vs submit at the endpoint, heartbeat threading through `_run_compile`, heartbeat failure isolation, one ping per LLM batch, `progress_cb` defaulting to None.
- Full unit suite 1024 passed; integration suite 285 passed; `alembic upgrade head` verified against Postgres (column lands); ruff clean.

## Post-review hardening (third commit)

An adversarial review pass found four issues, all fixed: (1) **attach evicts the process-local job cache instead of seeding it** — prod runs two warm machines, and a seeded snapshot on the non-owning machine would serve "running" forever after the owner completes (the one blocker); (2) the orphan supersede is a guarded bulk UPDATE (`status IN (pending, running)` in the WHERE) so a concurrent terminal transition wins instead of being flipped to failed; (3) the liveness ping moved to per-provider-round-trip so a deep #375 split-retry chain can't go silent past the staleness threshold while alive; (4) the script's swap gate now verifies the **exported staging content**, not the last attempt's `memories_created` — a resumed attempt that finished a nearly-done job legitimately reports ~0 while staging holds the full pack.

Documented residual gap: a job that dies in the last 900s of the poll window still reads as live at resubmission and only the *following* compile-start supersedes it — accepted over the risk of superseding a live-but-quiet job.

Suite after hardening: 1026 unit + 285 integration passed, ruff clean.
