### PR TITLE
Make compile latency observable and stop wasting the timeout budget

### DIFF
--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -96,151 +96,158 @@ async def _compile_one_batch(
         _phase_seconds[name] = round(now - _t0, 3)
         _t0 = now
 
-    compiler = get_compiler()
-    # The tenant's own registered claim vocabulary (#376). Loaded once per
-    # batch and handed to the compiler, because the compiler has no session of
-    # its own. Empty unless an operator registered keys, so this is inert by
-    # default.
-    claim_keys = await load_tenant_claim_keys(session, tenant_id)
-    # A CompilationError here propagates intentionally: nothing below this
-    # point runs, so the episodes are never marked compiled or committed.
-    if hasattr(compiler, "compile_async"):
-        new_rows = await compiler.compile_async(
-            list(episodes), claim_keys=claim_keys, progress_cb=progress_cb
-        )
-    else:
-        loop = asyncio.get_running_loop()
-        new_rows = await loop.run_in_executor(
-            None, functools.partial(compiler.compile, list(episodes), claim_keys=claim_keys)
-        )
-    _phase_done("extraction")
-
-    # Near-duplicate dedup (runs BEFORE reconcile). Full-conversation windowed
-    # compile produces many restated/overlapping facts; this cheap, deterministic
-    # pass collapses them so (a) retrieval isn't diluted by near-duplicates and
-    # (b) reconcile + entity population run on a far smaller set. Non-destructive
-    # (provenance unioned) and fail-open — returns the candidates unchanged on any
-    # error. Stapled embeddings on survivors are reused for the memory.embedding
-    # column below. See server/services/dedup.py.
-    if settings.dedup_compile_enabled and new_rows:
-        try:
-            from server.services.dedup import dedup_candidates
-
-            new_rows = await dedup_candidates(new_rows)
-        except Exception:
-            logger.warning("dedup_failed", subject_id=subject_id, exc_info=True)
-    _phase_done("dedup")
-
-    # Phase 4 + 5b — context-aware reconcile. One LLM call
-    # decides, per freshly-extracted candidate, whether it is new, a duplicate
-    # (dropped), a newer value of an existing memory, or a contradiction — and
-    # supersedes the stale/contradicted existing memories. Runs BEFORE the
-    # candidates are added to the session, so the "existing" view it reads is
-    # exactly the committed memory (candidates can't pollute it). Fail-open:
-    # `reconcile_compile_batch` returns the candidates unchanged on any error,
-    # so a reconcile failure can never lose a memory. Gated for ablation/bench.
-    reconcile_superseded_ids: set = set()
-    if settings.reconcile_compile_enabled and new_rows:
-        try:
-            from server.services.reconcile import reconcile_compile_batch
-
-            new_rows, reconcile_superseded_ids = await reconcile_compile_batch(
-                session, subject_id, new_rows, tenant_id=tenant_id
+    new_rows: list = []
+    try:
+        compiler = get_compiler()
+        # The tenant's own registered claim vocabulary (#376). Loaded once per
+        # batch and handed to the compiler, because the compiler has no session of
+        # its own. Empty unless an operator registered keys, so this is inert by
+        # default.
+        claim_keys = await load_tenant_claim_keys(session, tenant_id)
+        # A CompilationError here propagates intentionally: nothing below this
+        # point runs, so the episodes are never marked compiled or committed.
+        if hasattr(compiler, "compile_async"):
+            new_rows = await compiler.compile_async(
+                list(episodes), claim_keys=claim_keys, progress_cb=progress_cb
             )
-        except Exception:
-            logger.warning("reconcile_failed", subject_id=subject_id, exc_info=True)
-            reconcile_superseded_ids = set()
-    _phase_done("reconcile")
-
-    for row in new_rows:
-        row.tenant_id = tenant_id
-        session.add(row)
-    if reconcile_superseded_ids:
-        await repo.mark_memories_superseded(session, list(reconcile_superseded_ids))
-        logger.info(
-            "reconcile_superseded",
-            subject_id=subject_id,
-            superseded=len(reconcile_superseded_ids),
-        )
-    await repo.mark_episodes_compiled(session, [ep.id for ep in episodes])
-
-    superseded_ids = await resolve_conflicts(session, subject_id, tenant_id=tenant_id)
-    if superseded_ids:
-        logger.info("conflicts_resolved", superseded=len(superseded_ids))
-    _phase_done("conflicts")
-
-    await session.commit()
-    for row in new_rows:
-        await session.refresh(row)
-    _phase_done("commit")
-
-    # Only backfill rows that don't already carry an embedding. Dedup's semantic
-    # pass computes and staples embeddings onto its surviving canonicals, so those
-    # are persisted with the row above and need no second embedding round-trip.
-    rows_needing_embedding = [r for r in new_rows if getattr(r, "embedding", None) is None]
-    schedule_embedding_backfill(
-        [row.id for row in rows_needing_embedding],
-        [row.content for row in rows_needing_embedding],
-    )
-
-    # Phase 2 of the cross-session retrieval improvements: populate the per-subject
-    # entity store from this batch's newly-compiled memories so Phase 3
-    # retrieval (entity boost) has something to query. Best-effort — a
-    # failure here must not roll back the compile commit above. The function
-    # fans out LLM extraction calls in parallel + does ONE batched embedding
-    # round-trip. It is one LLM call per memory, the dominant cost on large
-    # full-conversation compiles, so it is skipped entirely when entity-boost
-    # retrieval is not in use (settings.entity_population_enabled).
-    if settings.entity_population_enabled:
-        try:
-            from server.services.entities import (
-                MemoryForEntities,
-                populate_entities_for_memories,
+        else:
+            loop = asyncio.get_running_loop()
+            new_rows = await loop.run_in_executor(
+                None, functools.partial(compiler.compile, list(episodes), claim_keys=claim_keys)
             )
+        _phase_done("extraction")
 
-            active_new_rows = [r for r in new_rows if r.id not in superseded_ids]
-            touched = await populate_entities_for_memories(
-                session,
-                [MemoryForEntities(id=r.id, content=r.content) for r in active_new_rows],
-                subject_id=subject_id,
-                tenant_id=tenant_id,
-            )
-            if touched:
-                await session.commit()
-                logger.info(
-                    "entities_populated",
-                    subject_id=subject_id,
-                    touched=touched,
-                    memories=len(active_new_rows),
+        # Near-duplicate dedup (runs BEFORE reconcile). Full-conversation windowed
+        # compile produces many restated/overlapping facts; this cheap, deterministic
+        # pass collapses them so (a) retrieval isn't diluted by near-duplicates and
+        # (b) reconcile + entity population run on a far smaller set. Non-destructive
+        # (provenance unioned) and fail-open — returns the candidates unchanged on any
+        # error. Stapled embeddings on survivors are reused for the memory.embedding
+        # column below. See server/services/dedup.py.
+        if settings.dedup_compile_enabled and new_rows:
+            try:
+                from server.services.dedup import dedup_candidates
+
+                new_rows = await dedup_candidates(new_rows)
+            except Exception:
+                logger.warning("dedup_failed", subject_id=subject_id, exc_info=True)
+        _phase_done("dedup")
+
+        # Phase 4 + 5b — context-aware reconcile. One LLM call
+        # decides, per freshly-extracted candidate, whether it is new, a duplicate
+        # (dropped), a newer value of an existing memory, or a contradiction — and
+        # supersedes the stale/contradicted existing memories. Runs BEFORE the
+        # candidates are added to the session, so the "existing" view it reads is
+        # exactly the committed memory (candidates can't pollute it). Fail-open:
+        # `reconcile_compile_batch` returns the candidates unchanged on any error,
+        # so a reconcile failure can never lose a memory. Gated for ablation/bench.
+        reconcile_superseded_ids: set = set()
+        if settings.reconcile_compile_enabled and new_rows:
+            try:
+                from server.services.reconcile import reconcile_compile_batch
+
+                new_rows, reconcile_superseded_ids = await reconcile_compile_batch(
+                    session, subject_id, new_rows, tenant_id=tenant_id
                 )
-        except Exception:
-            # Phase 3 retrieval handles an empty entity store as a no-op,
-            # so the compile result for the caller is identical with or
-            # without this step. Logged at WARNING for operator visibility.
-            logger.warning("entity_population_failed", subject_id=subject_id, exc_info=True)
-    _phase_done("entities")
+            except Exception:
+                logger.warning("reconcile_failed", subject_id=subject_id, exc_info=True)
+                reconcile_superseded_ids = set()
+        _phase_done("reconcile")
 
-    await webhooks.fire(
-        "memories.compiled",
-        {
-            "subject_id": subject_id,
-            "memories_created": len(new_rows),
-        },
-        tenant_id=tenant_id,
-    )
+        for row in new_rows:
+            row.tenant_id = tenant_id
+            session.add(row)
+        if reconcile_superseded_ids:
+            await repo.mark_memories_superseded(session, list(reconcile_superseded_ids))
+            logger.info(
+                "reconcile_superseded",
+                subject_id=subject_id,
+                superseded=len(reconcile_superseded_ids),
+            )
+        await repo.mark_episodes_compiled(session, [ep.id for ep in episodes])
 
-    remaining = await repo.count_uncompiled_episodes(
-        session, subject_id, tenant_id=tenant_id
-    )
-    logger.info(
-        "compile_phase_timings",
-        subject_id=subject_id,
-        episodes=len(episodes),
-        memories=len(new_rows),
-        total_seconds=round(sum(_phase_seconds.values()), 3),
-        **{f"{name}_seconds": secs for name, secs in _phase_seconds.items()},
-    )
-    return [_to_response(r) for r in new_rows], len(new_rows), remaining
+        superseded_ids = await resolve_conflicts(session, subject_id, tenant_id=tenant_id)
+        if superseded_ids:
+            logger.info("conflicts_resolved", superseded=len(superseded_ids))
+        _phase_done("conflicts")
+
+        await session.commit()
+        for row in new_rows:
+            await session.refresh(row)
+        _phase_done("commit")
+
+        # Only backfill rows that don't already carry an embedding. Dedup's semantic
+        # pass computes and staples embeddings onto its surviving canonicals, so those
+        # are persisted with the row above and need no second embedding round-trip.
+        rows_needing_embedding = [r for r in new_rows if getattr(r, "embedding", None) is None]
+        schedule_embedding_backfill(
+            [row.id for row in rows_needing_embedding],
+            [row.content for row in rows_needing_embedding],
+        )
+
+        # Phase 2 of the cross-session retrieval improvements: populate the per-subject
+        # entity store from this batch's newly-compiled memories so Phase 3
+        # retrieval (entity boost) has something to query. Best-effort — a
+        # failure here must not roll back the compile commit above. The function
+        # fans out LLM extraction calls in parallel + does ONE batched embedding
+        # round-trip. It is one LLM call per memory, the dominant cost on large
+        # full-conversation compiles, so it is skipped entirely when entity-boost
+        # retrieval is not in use (settings.entity_population_enabled).
+        if settings.entity_population_enabled:
+            try:
+                from server.services.entities import (
+                    MemoryForEntities,
+                    populate_entities_for_memories,
+                )
+
+                active_new_rows = [r for r in new_rows if r.id not in superseded_ids]
+                touched = await populate_entities_for_memories(
+                    session,
+                    [MemoryForEntities(id=r.id, content=r.content) for r in active_new_rows],
+                    subject_id=subject_id,
+                    tenant_id=tenant_id,
+                )
+                if touched:
+                    await session.commit()
+                    logger.info(
+                        "entities_populated",
+                        subject_id=subject_id,
+                        touched=touched,
+                        memories=len(active_new_rows),
+                    )
+            except Exception:
+                # Phase 3 retrieval handles an empty entity store as a no-op,
+                # so the compile result for the caller is identical with or
+                # without this step. Logged at WARNING for operator visibility.
+                logger.warning("entity_population_failed", subject_id=subject_id, exc_info=True)
+        _phase_done("entities")
+
+        await webhooks.fire(
+            "memories.compiled",
+            {
+                "subject_id": subject_id,
+                "memories_created": len(new_rows),
+            },
+            tenant_id=tenant_id,
+        )
+
+        remaining = await repo.count_uncompiled_episodes(
+            session, subject_id, tenant_id=tenant_id
+        )
+        return [_to_response(r) for r in new_rows], len(new_rows), remaining
+    finally:
+        # In a `finally` on purpose: the slow-then-FAILING compile is exactly
+        # the case this diagnostic exists for (issue #380), so the phases
+        # recorded before the failure must still reach the log.
+        logger.info(
+            "compile_phase_timings",
+            subject_id=subject_id,
+            episodes=len(episodes),
+            memories=len(new_rows),
+            total_seconds=round(sum(_phase_seconds.values()), 3),
+            **{f"{name}_seconds": secs for name, secs in _phase_seconds.items()},
+        )
+
 
 
 def _heartbeat_cb(job_id: str | None):

--- a/server/api/memories.py
+++ b/server/api/memories.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import time
 import uuid
 from typing import Any
 
@@ -82,6 +83,19 @@ async def _compile_one_batch(
     if not episodes:
         return [], 0, 0
 
+    # Wall-time is dominated by sequential provider round-trips, so when a
+    # compile is slow the FIRST question is which phase ate the time (issue
+    # #380 took a day to diagnose for lack of exactly this). One structured
+    # line per batch, logged below whatever else happens.
+    _t0 = time.perf_counter()
+    _phase_seconds: dict[str, float] = {}
+
+    def _phase_done(name: str) -> None:
+        nonlocal _t0
+        now = time.perf_counter()
+        _phase_seconds[name] = round(now - _t0, 3)
+        _t0 = now
+
     compiler = get_compiler()
     # The tenant's own registered claim vocabulary (#376). Loaded once per
     # batch and handed to the compiler, because the compiler has no session of
@@ -99,6 +113,7 @@ async def _compile_one_batch(
         new_rows = await loop.run_in_executor(
             None, functools.partial(compiler.compile, list(episodes), claim_keys=claim_keys)
         )
+    _phase_done("extraction")
 
     # Near-duplicate dedup (runs BEFORE reconcile). Full-conversation windowed
     # compile produces many restated/overlapping facts; this cheap, deterministic
@@ -114,6 +129,7 @@ async def _compile_one_batch(
             new_rows = await dedup_candidates(new_rows)
         except Exception:
             logger.warning("dedup_failed", subject_id=subject_id, exc_info=True)
+    _phase_done("dedup")
 
     # Phase 4 + 5b — context-aware reconcile. One LLM call
     # decides, per freshly-extracted candidate, whether it is new, a duplicate
@@ -134,6 +150,7 @@ async def _compile_one_batch(
         except Exception:
             logger.warning("reconcile_failed", subject_id=subject_id, exc_info=True)
             reconcile_superseded_ids = set()
+    _phase_done("reconcile")
 
     for row in new_rows:
         row.tenant_id = tenant_id
@@ -150,10 +167,12 @@ async def _compile_one_batch(
     superseded_ids = await resolve_conflicts(session, subject_id, tenant_id=tenant_id)
     if superseded_ids:
         logger.info("conflicts_resolved", superseded=len(superseded_ids))
+    _phase_done("conflicts")
 
     await session.commit()
     for row in new_rows:
         await session.refresh(row)
+    _phase_done("commit")
 
     # Only backfill rows that don't already carry an embedding. Dedup's semantic
     # pass computes and staples embeddings onto its surviving canonicals, so those
@@ -199,6 +218,7 @@ async def _compile_one_batch(
             # so the compile result for the caller is identical with or
             # without this step. Logged at WARNING for operator visibility.
             logger.warning("entity_population_failed", subject_id=subject_id, exc_info=True)
+    _phase_done("entities")
 
     await webhooks.fire(
         "memories.compiled",
@@ -211,6 +231,14 @@ async def _compile_one_batch(
 
     remaining = await repo.count_uncompiled_episodes(
         session, subject_id, tenant_id=tenant_id
+    )
+    logger.info(
+        "compile_phase_timings",
+        subject_id=subject_id,
+        episodes=len(episodes),
+        memories=len(new_rows),
+        total_seconds=round(sum(_phase_seconds.values()), 3),
+        **{f"{name}_seconds": secs for name, secs in _phase_seconds.items()},
     )
     return [_to_response(r) for r in new_rows], len(new_rows), remaining
 

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -99,6 +99,10 @@ class Settings(BaseSettings):
     litellm_embedding_api_base: str | None = None
     litellm_timeout_seconds: float = 60.0
     litellm_max_retries: int = 2
+    # A single provider call slower than this logs a `llm_slow_call` warning —
+    # the per-call signal behind compile wall-time spikes (issue #380: a
+    # provider latency regression turned a 6-minute pack compile into 25+).
+    litellm_slow_call_seconds: float = 10.0
     litellm_temperature: float = 0.1
     # reasoning_effort for gpt-5 / o-series reasoning models (e.g. "minimal",
     # "low", "medium", "high"). Empty = provider default. "minimal" keeps the
@@ -173,6 +177,11 @@ class Settings(BaseSettings):
     # earlier chunks. Bounds prompt size while still covering an arbitrarily
     # large batch (full-conversation compiles produce hundreds of candidates).
     reconcile_chunk_size: int = 40
+    # Reconcile chunks are strictly sequential and fail-open (a failed chunk
+    # is kept wholesale), so a slow provider call here is pure wasted wall
+    # time — bound it tighter than the general litellm timeout (issue #380:
+    # 18 sequential chunks x 60s of silent burn).
+    reconcile_chunk_timeout_seconds: float = 30.0
     # Absolute safety ceiling: skip reconcile only for a pathologically huge
     # batch (the conflict resolver + next drain still apply).
     reconcile_max_candidates: int = 4000

--- a/server/services/llm.py
+++ b/server/services/llm.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from typing import Any
 
 import structlog
@@ -250,6 +251,11 @@ async def acomplete(
         "model": chosen_model,
         "messages": messages,
         "num_retries": settings.litellm_max_retries,
+        # Per-attempt timeout, sized so every retry fits inside the outer
+        # wait_for below. Without it litellm's retries race the single
+        # outer window: attempt 1 consumes the full budget, so num_retries
+        # is dead config (issue #380).
+        "timeout": timeout_s / (settings.litellm_max_retries + 1),
         **_common_kwargs(chosen_model),
         **_reasoning_kwargs(chosen_model),
     }
@@ -260,12 +266,24 @@ async def acomplete(
     if response_format is not None:
         kwargs["response_format"] = response_format
 
+    started = time.perf_counter()
     try:
         resp = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=timeout_s)
     except asyncio.TimeoutError as exc:
         raise LLMTimeoutError(f"LLM completion timed out after {timeout_s}s") from exc
     except Exception as exc:  # noqa: BLE001
         raise _classify(exc) from exc
+    elapsed = time.perf_counter() - started
+    if elapsed >= settings.litellm_slow_call_seconds:
+        # One warning per slow call, not per call: at healthy latency this
+        # line never fires; when the provider degrades it is the direct
+        # per-call evidence for a compile wall-time spike (issue #380).
+        logger.warning(
+            "llm_slow_call",
+            model=chosen_model,
+            elapsed_seconds=round(elapsed, 2),
+            threshold_seconds=settings.litellm_slow_call_seconds,
+        )
 
     try:
         return resp.choices[0].message.content or ""

--- a/server/services/llm.py
+++ b/server/services/llm.py
@@ -227,6 +227,20 @@ def _reasoning_kwargs(model: str | None) -> dict[str, Any]:
 # ─── Chat completion ─────────────────────────────────────────────────
 
 
+def _warn_if_slow(model: str, started: float) -> None:
+    """One warning per slow provider call: at healthy latency this never
+    fires; when the provider degrades it is the direct per-call evidence
+    for a compile wall-time spike (issue #380)."""
+    elapsed = time.perf_counter() - started
+    if elapsed >= settings.litellm_slow_call_seconds:
+        logger.warning(
+            "llm_slow_call",
+            model=model,
+            elapsed_seconds=round(elapsed, 2),
+            threshold_seconds=settings.litellm_slow_call_seconds,
+        )
+
+
 async def acomplete(
     messages: list[dict[str, str]],
     *,
@@ -251,14 +265,17 @@ async def acomplete(
         "model": chosen_model,
         "messages": messages,
         "num_retries": settings.litellm_max_retries,
-        # Per-attempt timeout, sized so every retry fits inside the outer
-        # wait_for below. Without it litellm's retries race the single
-        # outer window: attempt 1 consumes the full budget, so num_retries
-        # is dead config (issue #380).
-        "timeout": timeout_s / (settings.litellm_max_retries + 1),
         **_common_kwargs(chosen_model),
         **_reasoning_kwargs(chosen_model),
     }
+    # Deliberately no per-attempt litellm timeout: retries only ever fire on
+    # fast-failing errors (429s, connection resets), which fit inside the
+    # outer wait_for naturally; a slow attempt consumes the window once, as
+    # it should. Deriving a per-attempt slice (outer/(retries+1)) was tried
+    # for issue #380 and rejected in review — it cuts HEALTHY long
+    # generations (reconcile decision arrays, dense extraction batches,
+    # reasoning models) below their normal completion time, turning working
+    # calls into timeouts.
     if not _omit_temperature(chosen_model):
         kwargs["temperature"] = temp
     if max_tokens is not None:
@@ -273,17 +290,7 @@ async def acomplete(
         raise LLMTimeoutError(f"LLM completion timed out after {timeout_s}s") from exc
     except Exception as exc:  # noqa: BLE001
         raise _classify(exc) from exc
-    elapsed = time.perf_counter() - started
-    if elapsed >= settings.litellm_slow_call_seconds:
-        # One warning per slow call, not per call: at healthy latency this
-        # line never fires; when the provider degrades it is the direct
-        # per-call evidence for a compile wall-time spike (issue #380).
-        logger.warning(
-            "llm_slow_call",
-            model=chosen_model,
-            elapsed_seconds=round(elapsed, 2),
-            threshold_seconds=settings.litellm_slow_call_seconds,
-        )
+    _warn_if_slow(chosen_model, started)
 
     try:
         return resp.choices[0].message.content or ""
@@ -491,12 +498,14 @@ async def _acomplete_json_anthropic_tool_use(
     if max_tokens is not None:
         kwargs["max_tokens"] = max_tokens
 
+    started = time.perf_counter()
     try:
         resp = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=timeout_s)
     except asyncio.TimeoutError as exc:
         raise LLMTimeoutError(f"LLM completion timed out after {timeout_s}s") from exc
     except Exception as exc:  # noqa: BLE001
         raise _classify(exc) from exc
+    _warn_if_slow(model, started)
 
     # LiteLLM normalizes Anthropic tool_use → OpenAI-shaped tool_calls.
     try:

--- a/server/services/reconcile.py
+++ b/server/services/reconcile.py
@@ -267,6 +267,7 @@ async def reconcile_compile_batch(
     existing_ids = {m.id for m in existing}
     supersede_existing: set[uuid.UUID] = set()
     accepted_ids: list[uuid.UUID] = []           # candidate ids kept, in order
+    llm_failures = 0
     dropped_ids: set[uuid.UUID] = set()          # candidate ids retired/duplicate
     cand_by_id: dict[uuid.UUID, MemoryRow] = {m.id: m for m in candidates}
     max_ctx = settings.reconcile_max_existing
@@ -295,8 +296,13 @@ async def reconcile_compile_batch(
                 model=_compile_model(),
                 temperature=0.0,
                 max_tokens=min(settings.litellm_compile_max_tokens, 4000),
+                # Chunks are strictly sequential and fail-open, so a slow
+                # call here is pure wasted wall time — bound it tighter
+                # than the general litellm timeout (issue #380).
+                timeout=settings.reconcile_chunk_timeout_seconds,
             )
         except Exception:
+            llm_failures += 1
             logger.warning("reconcile_llm_failed", subject_id=subject_id, exc_info=True)
             # Keep this chunk wholesale (fail-open) and continue.
             accepted_ids.extend(m.id for m in chunk)
@@ -395,5 +401,9 @@ async def reconcile_compile_batch(
         dropped=len(dropped_ids),
         superseded_existing=len(supersede_existing),
         existing_considered=len(existing),
+        # Every fail-open chunk kept ~chunk_size candidates unreconciled and
+        # burned up to reconcile_chunk_timeout_seconds — nonzero here is the
+        # one-line explanation for both a slow compile and duplicate leakage.
+        llm_failures=llm_failures,
     )
     return kept, supersede_existing

--- a/tests/test_compile_latency_observability.py
+++ b/tests/test_compile_latency_observability.py
@@ -41,9 +41,12 @@ class _FakeResp:
         self.choices = [_FakeChoice(content)]
 
 
-async def test_litellm_gets_a_per_attempt_timeout():
-    """The kwargs handed to litellm must carry timeout = outer/(retries+1),
-    so its internal retries fit inside the outer wait_for window."""
+async def test_litellm_gets_no_shrunken_per_attempt_timeout():
+    """Pin the review outcome for issue #380: NO derived per-attempt timeout
+    slice (outer/(retries+1)) may be handed to litellm — it cuts healthy
+    long generations (reconcile decision arrays, dense extraction batches)
+    below their normal completion time. Retries only fire on fast-failing
+    errors and fit inside the outer wait_for naturally."""
     from server.services import llm as llm_adapter
 
     captured = {}
@@ -56,8 +59,7 @@ async def test_litellm_gets_a_per_attempt_timeout():
         ensure.return_value = type("L", (), {"acompletion": staticmethod(fake_acompletion)})()
         await llm_adapter.acomplete([{"role": "user", "content": "hi"}])
 
-    expected = settings.litellm_timeout_seconds / (settings.litellm_max_retries + 1)
-    assert captured["timeout"] == pytest.approx(expected)
+    assert "timeout" not in captured
     assert captured["num_retries"] == settings.litellm_max_retries
 
 
@@ -212,3 +214,66 @@ async def test_compile_batch_emits_phase_timings(monkeypatch, caplog):
     ):
         assert key in payload, f"missing {key}"
     assert payload["episodes"] == 1
+
+
+async def test_failing_compile_still_emits_phase_timings(monkeypatch, caplog):
+    """The slow-then-FAILING compile is exactly the case the diagnostic
+    exists for — a CompilationError must not lose the summary line."""
+    from server.api import memories as api_memories
+    from server.services.compilers.errors import CompilationError
+    from tests.test_compile_error_handling import _FakeEpisode, _FakeSession
+
+    async def fake_list(_session, _subject_id, *, tenant_id, limit):
+        return [_FakeEpisode()]
+
+    class _RaisingCompiler:
+        async def compile_async(self, _eps, **_kw):
+            raise CompilationError("provider gone")
+
+    monkeypatch.setattr(api_memories.repo, "list_uncompiled_episodes", fake_list)
+    monkeypatch.setattr(api_memories, "get_compiler", lambda: _RaisingCompiler())
+
+    with caplog.at_level("INFO"):
+        with pytest.raises(CompilationError):
+            await api_memories._compile_one_batch(_FakeSession(), "subj", None, 10)
+
+    import json
+
+    lines = [r for r in caplog.records if "compile_phase_timings" in r.message]
+    assert len(lines) == 1
+    payload = json.loads(lines[0].message)
+    assert payload["memories"] == 0 and payload["episodes"] == 1
+
+
+async def test_anthropic_json_path_logs_slow_calls(caplog):
+    """Mixed-vendor routing must not lose the #380 evidence: the Anthropic
+    tool-use JSON path times its provider call like `acomplete` does."""
+    import json as _json
+
+    from server.services import llm as llm_adapter
+
+    class _ToolCall:
+        class function:
+            name = "emit_json"
+            arguments = _json.dumps({"payload": {"ok": True}})
+
+    class _Msg:
+        tool_calls = [_ToolCall()]
+        content = None
+
+    class _Resp:
+        choices = [type("C", (), {"message": _Msg()})()]
+
+    async def fake_acompletion(**kwargs):
+        return _Resp()
+
+    with patch.object(llm_adapter, "_ensure_litellm") as ensure, patch.object(
+        settings, "litellm_slow_call_seconds", 0.0
+    ):
+        ensure.return_value = type("L", (), {"acompletion": staticmethod(fake_acompletion)})()
+        with caplog.at_level("WARNING"):
+            await llm_adapter._acomplete_json_anthropic_tool_use(
+                [{"role": "user", "content": "hi"}], model="claude-x"
+            )
+
+    assert any("llm_slow_call" in r.message for r in caplog.records)

--- a/tests/test_compile_latency_observability.py
+++ b/tests/test_compile_latency_observability.py
@@ -1,0 +1,214 @@
+"""Latency observability + timeout hygiene for the compile path (issue #380).
+
+A provider latency regression turned a 6-minute pack compile into 25+
+minutes and took a day to diagnose because nothing recorded where the
+time went. These tests pin the three guards added in response:
+
+* every provider call gets a PER-ATTEMPT litellm timeout so
+  `num_retries` actually fits inside the outer `wait_for` window
+  (before this, attempt 1 could consume the whole budget and retries
+  were dead config);
+* a call slower than `litellm_slow_call_seconds` logs `llm_slow_call` —
+  the direct per-call evidence for a wall-time spike;
+* reconcile chunks (strictly sequential, fail-open) use the tighter
+  `reconcile_chunk_timeout_seconds` and count swallowed failures into
+  `reconcile_done`;
+* `_compile_one_batch` emits one `compile_phase_timings` line per batch.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.core.config import settings
+
+pytestmark = pytest.mark.asyncio
+
+_NOW = datetime(2026, 9, 2, tzinfo=timezone.utc)
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = type("M", (), {"content": content})()
+
+
+class _FakeResp:
+    def __init__(self, content="ok"):
+        self.choices = [_FakeChoice(content)]
+
+
+async def test_litellm_gets_a_per_attempt_timeout():
+    """The kwargs handed to litellm must carry timeout = outer/(retries+1),
+    so its internal retries fit inside the outer wait_for window."""
+    from server.services import llm as llm_adapter
+
+    captured = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return _FakeResp()
+
+    with patch.object(llm_adapter, "_ensure_litellm") as ensure:
+        ensure.return_value = type("L", (), {"acompletion": staticmethod(fake_acompletion)})()
+        await llm_adapter.acomplete([{"role": "user", "content": "hi"}])
+
+    expected = settings.litellm_timeout_seconds / (settings.litellm_max_retries + 1)
+    assert captured["timeout"] == pytest.approx(expected)
+    assert captured["num_retries"] == settings.litellm_max_retries
+
+
+async def test_slow_call_logs_warning(caplog):
+    from server.services import llm as llm_adapter
+
+    async def fake_acompletion(**kwargs):
+        return _FakeResp()
+
+    with patch.object(llm_adapter, "_ensure_litellm") as ensure, patch.object(
+        settings, "litellm_slow_call_seconds", 0.0
+    ):
+        ensure.return_value = type("L", (), {"acompletion": staticmethod(fake_acompletion)})()
+        with caplog.at_level("WARNING"):
+            await llm_adapter.acomplete([{"role": "user", "content": "hi"}])
+
+    assert any("llm_slow_call" in r.message for r in caplog.records)
+
+
+async def test_fast_call_logs_no_slow_warning(caplog):
+    from server.services import llm as llm_adapter
+
+    async def fake_acompletion(**kwargs):
+        return _FakeResp()
+
+    with patch.object(llm_adapter, "_ensure_litellm") as ensure:
+        ensure.return_value = type("L", (), {"acompletion": staticmethod(fake_acompletion)})()
+        with caplog.at_level("WARNING"):
+            await llm_adapter.acomplete([{"role": "user", "content": "hi"}])
+
+    assert not any("llm_slow_call" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Reconcile: tighter chunk timeout + swallowed-failure counter
+# ---------------------------------------------------------------------------
+
+
+def _mem(content: str):
+    from server.db.tables import MemoryRow
+
+    return MemoryRow(
+        id=uuid.uuid4(),
+        subject_id="subj",
+        kind="profile_fact",
+        content=content,
+        summary=content,
+        source_episode_ids=[],
+        created_at=_NOW,
+        valid_from=_NOW,
+        status="active",
+        metadata_={},
+    )
+
+
+async def _run_reconcile(acomplete_json_mock, n_candidates=2):
+    from server.services import reconcile as rec
+
+    candidates = [_mem(f"fact {i}") for i in range(n_candidates)]
+    session = AsyncMock()
+
+    async def fake_existing(_session, _subject_id, *_a, **_kw):
+        return [_mem("existing fact")]
+
+    with patch.object(rec.repo, "list_active_memories_by_subject", new=fake_existing), patch.object(
+        rec.llm_adapter, "acomplete_json", new=acomplete_json_mock
+    ):
+        return await rec.reconcile_compile_batch(session, "subj", candidates, tenant_id=None)
+
+
+async def test_reconcile_passes_tight_chunk_timeout():
+    captured = {}
+
+    async def fake_json(messages, **kwargs):
+        captured.update(kwargs)
+        return {"decisions": []}
+
+    await _run_reconcile(fake_json)
+    assert captured["timeout"] == settings.reconcile_chunk_timeout_seconds
+    assert settings.reconcile_chunk_timeout_seconds < settings.litellm_timeout_seconds
+
+
+async def test_reconcile_counts_swallowed_failures(caplog):
+    async def fake_json(messages, **kwargs):
+        raise RuntimeError("provider fell over")
+
+    with caplog.at_level("INFO"):
+        kept, superseded = await _run_reconcile(fake_json, n_candidates=3)
+
+    assert len(kept) == 3, "fail-open must keep the chunk wholesale"
+    import json
+
+    done = [r for r in caplog.records if "reconcile_done" in r.message]
+    assert done
+    payload = json.loads(done[0].message)
+    assert payload["llm_failures"] == 1
+
+
+# ---------------------------------------------------------------------------
+# compile_phase_timings: one structured line per batch
+# ---------------------------------------------------------------------------
+
+
+async def test_compile_batch_emits_phase_timings(monkeypatch, caplog):
+    from server.api import memories as api_memories
+    from tests.test_compile_error_handling import _FakeEpisode, _FakeSession
+
+    episodes = [_FakeEpisode()]
+
+    async def fake_list(_session, _subject_id, *, tenant_id, limit):
+        return episodes
+
+    async def fake_mark(_session, ids):
+        return None
+
+    async def fake_count(_session, _subject_id, *, tenant_id):
+        return 0
+
+    async def fake_resolve(_session, _subject_id, *, tenant_id):
+        return []
+
+    async def fake_fire(*_a, **_kw):
+        return None
+
+    class _EmptyCompiler:
+        async def compile_async(self, _eps, **_kw):
+            return []
+
+    monkeypatch.setattr(api_memories.repo, "list_uncompiled_episodes", fake_list)
+    monkeypatch.setattr(api_memories.repo, "mark_episodes_compiled", fake_mark)
+    monkeypatch.setattr(api_memories.repo, "count_uncompiled_episodes", fake_count)
+    monkeypatch.setattr(api_memories, "resolve_conflicts", fake_resolve)
+    monkeypatch.setattr(api_memories.webhooks, "fire", fake_fire)
+    monkeypatch.setattr(api_memories, "get_compiler", lambda: _EmptyCompiler())
+
+    with caplog.at_level("INFO"):
+        await api_memories._compile_one_batch(_FakeSession(), "subj", None, 10)
+
+    import json
+
+    lines = [r for r in caplog.records if "compile_phase_timings" in r.message]
+    assert len(lines) == 1
+    payload = json.loads(lines[0].message)
+    for key in (
+        "extraction_seconds",
+        "dedup_seconds",
+        "reconcile_seconds",
+        "conflicts_seconds",
+        "commit_seconds",
+        "entities_seconds",
+        "total_seconds",
+    ):
+        assert key in payload, f"missing {key}"
+    assert payload["episodes"] == 1


### PR DESCRIPTION
First of two PRs for #380 (fixes 1, 3, 4 from the plan there): per-batch `compile_phase_timings` log line, per-attempt litellm timeouts so `num_retries` fits inside the outer window, `llm_slow_call` warnings above 10s, reconcile chunk timeout 60s→30s with a swallowed-failure counter in `reconcile_done`.

Bench-neutral by construction: no extraction or reconciliation decision changes — timeouts only bound paths that were already fail-open, and the rest is logging. 6 new tests; full unit suite 1032 passed.