### PR TITLE
Batch entity extraction and rebuild the entity store on import

### DIFF
--- a/scripts/bootstrap_docs_pack.py
+++ b/scripts/bootstrap_docs_pack.py
@@ -316,9 +316,6 @@ async def _import_into(
         "document": document,
         "target_subject_id": target_subject_id,
         "preserve_ids": False,
-        # Export documents don't carry subject_entities; without this the
-        # live pack has an empty entity store after every swap (issue #380).
-        "rebuild_entities": True,
     }
     resp = await _request_with_retry(
         f"import -> {target_subject_id}",
@@ -330,7 +327,29 @@ async def _import_into(
             file=sys.stderr,
         )
         sys.exit(1)
-    return resp.json()
+    result = resp.json()
+
+    # Export documents don't carry subject_entities, so without this the
+    # live pack has an empty entity store after every swap (issue #380).
+    # Deliberately a SEPARATE call after the fast pure-DB import: the
+    # rebuild spends provider calls, and the endpoint is retry-safe
+    # (entity upserts dedup on normalized text). Best-effort — a failure
+    # (including a 404 from a server predating the endpoint) leaves the
+    # pack exactly as swaps always were.
+    er = await _request_with_retry(
+        f"rebuild-entities -> {target_subject_id}",
+        lambda: client.post(f"{url}/admin/subjects/{target_subject_id}/rebuild-entities"),
+    )
+    if er.status_code == 200:
+        rebuilt = er.json().get("entities_rebuilt", 0)
+        print(f"  → rebuilt {rebuilt} entity rows for {target_subject_id}")
+    else:
+        print(
+            f"  WARN entity rebuild -> {target_subject_id}: {er.status_code} "
+            "(pack is fine; entity store stays empty)",
+            file=sys.stderr,
+        )
+    return result
 
 
 async def run(docs_path: Path, purge: bool, dry_run: bool) -> None:

--- a/scripts/bootstrap_docs_pack.py
+++ b/scripts/bootstrap_docs_pack.py
@@ -336,10 +336,27 @@ async def _import_into(
     # (entity upserts dedup on normalized text). Best-effort — a failure
     # (including a 404 from a server predating the endpoint) leaves the
     # pack exactly as swaps always were.
-    er = await _request_with_retry(
-        f"rebuild-entities -> {target_subject_id}",
-        lambda: client.post(f"{url}/admin/subjects/{target_subject_id}/rebuild-entities"),
-    )
+    # ONE attempt, and never fatal: a re-POST of a rebuild that merely
+    # outlived the client timeout would run CONCURRENTLY with the first
+    # (the entity upsert is only retry-safe sequentially), and the swap
+    # above already succeeded — a rebuild problem must not turn a good
+    # refresh red. Worst case the entity store stays empty, which is
+    # exactly what every swap produced before this call existed.
+    try:
+        er = await _request_with_retry(
+            f"rebuild-entities -> {target_subject_id}",
+            lambda: client.post(
+                f"{url}/admin/subjects/{target_subject_id}/rebuild-entities"
+            ),
+            attempts=1,
+        )
+    except Exception as exc:
+        print(
+            f"  WARN entity rebuild -> {target_subject_id}: {type(exc).__name__} "
+            "(pack is fine; entity store stays empty)",
+            file=sys.stderr,
+        )
+        return result
     if er.status_code == 200:
         rebuilt = er.json().get("entities_rebuilt", 0)
         print(f"  → rebuilt {rebuilt} entity rows for {target_subject_id}")

--- a/scripts/bootstrap_docs_pack.py
+++ b/scripts/bootstrap_docs_pack.py
@@ -316,6 +316,9 @@ async def _import_into(
         "document": document,
         "target_subject_id": target_subject_id,
         "preserve_ids": False,
+        # Export documents don't carry subject_entities; without this the
+        # live pack has an empty entity store after every swap (issue #380).
+        "rebuild_entities": True,
     }
     resp = await _request_with_retry(
         f"import -> {target_subject_id}",

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2935,9 +2935,11 @@ async def rebuild_entities_endpoint(
     the import request stays a fast pure-DB write: an inline rebuild made
     the import outlive client timeouts, and a client retrying a POST whose
     first send already committed duplicates the subject wholesale when
-    preserve_ids is false. This endpoint is retry-safe by construction:
-    entity upserts dedup on normalized text, so re-running converges
-    instead of duplicating.
+    preserve_ids is false. Sequential re-runs converge (entity upserts
+    dedup on normalized text); CONCURRENT invocations for the same subject
+    can duplicate entity rows, because the upsert is select-then-insert
+    over a non-unique index — callers must not re-send while a rebuild may
+    still be running (the bootstrap script sends exactly one attempt).
     """
     if not settings.entity_population_enabled:
         return {"subject_id": subject_id, "entities_rebuilt": 0, "enabled": False}

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2875,11 +2875,6 @@ class ImportSubjectRequest(BaseModel):
     target_subject_id: str | None = None
     target_tenant_id: str | None = None
     preserve_ids: bool = True
-    # Export documents do not carry subject_entities, so an imported pack has
-    # an empty entity store even when its memories were compiled with one
-    # (found via issue #380: the docs-pack swap left live with zero entity
-    # rows every refresh). Opt-in because it spends provider calls.
-    rebuild_entities: bool = False
 
 
 @router.get("/export/{subject_id}")
@@ -2921,24 +2916,32 @@ async def import_subject_endpoint(req: ImportSubjectRequest):
             target_tenant_id=req.target_tenant_id,
             preserve_ids=req.preserve_ids,
         )
+        return result
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    if req.rebuild_entities and settings.entity_population_enabled:
-        result["entities_rebuilt"] = await _rebuild_entities_for_import(
-            result["subject_id"], result.get("tenant_id")
-        )
-    return result
 
+@router.post("/subjects/{subject_id}/rebuild-entities")
+async def rebuild_entities_endpoint(
+    subject_id: str,
+    tenant_id: str | None = Query(None, description="Scope to tenant"),
+):
+    """Repopulate the subject_entities store from a subject's active memories.
 
-async def _rebuild_entities_for_import(subject_id: str, tenant_id: str | None) -> int:
-    """Repopulate the entity store for a just-imported subject.
-
-    Runs the same compile-time hook over the imported active memories.
-    Best-effort: a failure leaves the import result intact (Phase 3
-    retrieval treats an empty entity store as a no-op), mirroring the
-    compile path's fail-open behavior.
+    Export documents do not carry subject_entities, so an imported pack has
+    an empty entity store even when its memories were compiled with one
+    (found via issue #380: the docs-pack swap left live with zero entity
+    rows every refresh). A separate endpoint — NOT an import option — so
+    the import request stays a fast pure-DB write: an inline rebuild made
+    the import outlive client timeouts, and a client retrying a POST whose
+    first send already committed duplicates the subject wholesale when
+    preserve_ids is false. This endpoint is retry-safe by construction:
+    entity upserts dedup on normalized text, so re-running converges
+    instead of duplicating.
     """
+    if not settings.entity_population_enabled:
+        return {"subject_id": subject_id, "entities_rebuilt": 0, "enabled": False}
+
     from server.db import repositories as repo
     from server.db.engine import get_session_factory
     from server.services.entities import (
@@ -2946,23 +2949,26 @@ async def _rebuild_entities_for_import(subject_id: str, tenant_id: str | None) -
         populate_entities_for_memories,
     )
 
-    try:
-        async with get_session_factory()() as session:
-            rows = await repo.list_active_memories_by_subject(
-                session, subject_id, tenant_id=tenant_id, limit=10_000
-            )
-            touched = await populate_entities_for_memories(
-                session,
-                [MemoryForEntities(id=r.id, content=r.content) for r in rows],
+    _REBUILD_LIMIT = 10_000
+    async with get_session_factory()() as session:
+        rows = await repo.list_active_memories_by_subject(
+            session, subject_id, tenant_id=tenant_id, limit=_REBUILD_LIMIT
+        )
+        if len(rows) == _REBUILD_LIMIT:
+            logger.info(
+                "entity_rebuild_truncated",
                 subject_id=subject_id,
-                tenant_id=tenant_id,
+                limit=_REBUILD_LIMIT,
             )
-            if touched:
-                await session.commit()
-            return touched
-    except Exception:
-        logger.warning("import_entity_rebuild_failed", subject_id=subject_id, exc_info=True)
-        return 0
+        touched = await populate_entities_for_memories(
+            session,
+            [MemoryForEntities(id=r.id, content=r.content) for r in rows],
+            subject_id=subject_id,
+            tenant_id=tenant_id,
+        )
+        if touched:
+            await session.commit()
+    return {"subject_id": subject_id, "entities_rebuilt": touched, "enabled": True}
 
 
 # ─── Webhooks ───

--- a/server/api/admin.py
+++ b/server/api/admin.py
@@ -2875,6 +2875,11 @@ class ImportSubjectRequest(BaseModel):
     target_subject_id: str | None = None
     target_tenant_id: str | None = None
     preserve_ids: bool = True
+    # Export documents do not carry subject_entities, so an imported pack has
+    # an empty entity store even when its memories were compiled with one
+    # (found via issue #380: the docs-pack swap left live with zero entity
+    # rows every refresh). Opt-in because it spends provider calls.
+    rebuild_entities: bool = False
 
 
 @router.get("/export/{subject_id}")
@@ -2916,9 +2921,48 @@ async def import_subject_endpoint(req: ImportSubjectRequest):
             target_tenant_id=req.target_tenant_id,
             preserve_ids=req.preserve_ids,
         )
-        return result
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+    if req.rebuild_entities and settings.entity_population_enabled:
+        result["entities_rebuilt"] = await _rebuild_entities_for_import(
+            result["subject_id"], result.get("tenant_id")
+        )
+    return result
+
+
+async def _rebuild_entities_for_import(subject_id: str, tenant_id: str | None) -> int:
+    """Repopulate the entity store for a just-imported subject.
+
+    Runs the same compile-time hook over the imported active memories.
+    Best-effort: a failure leaves the import result intact (Phase 3
+    retrieval treats an empty entity store as a no-op), mirroring the
+    compile path's fail-open behavior.
+    """
+    from server.db import repositories as repo
+    from server.db.engine import get_session_factory
+    from server.services.entities import (
+        MemoryForEntities,
+        populate_entities_for_memories,
+    )
+
+    try:
+        async with get_session_factory()() as session:
+            rows = await repo.list_active_memories_by_subject(
+                session, subject_id, tenant_id=tenant_id, limit=10_000
+            )
+            touched = await populate_entities_for_memories(
+                session,
+                [MemoryForEntities(id=r.id, content=r.content) for r in rows],
+                subject_id=subject_id,
+                tenant_id=tenant_id,
+            )
+            if touched:
+                await session.commit()
+            return touched
+    except Exception:
+        logger.warning("import_entity_rebuild_failed", subject_id=subject_id, exc_info=True)
+        return 0
 
 
 # ─── Webhooks ───

--- a/server/core/config.py
+++ b/server/core/config.py
@@ -266,6 +266,12 @@ class Settings(BaseSettings):
     # entity-boost retrieval is not in use (e.g. semantic-only bench runs),
     # which materially speeds up large compiles.
     entity_population_enabled: bool = True
+    # Entity extraction used to be one LLM call PER MEMORY — ~60% of all
+    # provider round-trips on a large compile, and the dominant amplifier
+    # when provider latency degrades (issue #380). Batched: facts per call,
+    # calls in flight.
+    entity_extract_batch_size: int = 10
+    entity_extract_concurrency: int = 8
 
     # ── Memory TTL / expiry policies ────────────────────────────────
     # Per-kind expiry windows. Keys are MemoryKind values

--- a/server/services/entities.py
+++ b/server/services/entities.py
@@ -42,7 +42,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.db import repositories as repo
 from server.services.embeddings import get_provider as get_embedding_provider
-from server.services.entity_extraction import ExtractedEntity, extract_entities
+from server.services.entity_extraction import (
+    ExtractedEntity,
+    extract_entities_batch,
+)
 
 logger = structlog.stdlib.get_logger()
 
@@ -63,15 +66,18 @@ class MemoryForEntities:
 # LLM provider rate limit. 8 is conservative — typical compile batches
 # are 20-50 memories; doubling concurrency gives no wall-time benefit
 # when the bottleneck is provider round-trip latency.
-_EXTRACT_CONCURRENCY = 8
+# Concurrency and batch size now live in settings (entity_extract_concurrency,
+# entity_extract_batch_size) so operators can tune wave count vs rate limits.
 
 
-async def _extract_one(
-    memory: MemoryForEntities, semaphore: asyncio.Semaphore
-) -> tuple[uuid.UUID, list[ExtractedEntity]]:
+async def _extract_group(
+    group: list[MemoryForEntities], semaphore: asyncio.Semaphore
+) -> list[tuple[uuid.UUID, list[ExtractedEntity]]]:
+    """One provider call for a whole group of memories (issue #380 — was
+    one call per memory, ~60% of a large compile's round-trips)."""
     async with semaphore:
-        entities = await extract_entities(memory.content)
-    return memory.id, entities
+        entity_lists = await extract_entities_batch([m.content for m in group])
+    return [(m.id, entities) for m, entities in zip(group, entity_lists)]
 
 
 async def populate_entities_for_memories(
@@ -92,7 +98,8 @@ async def populate_entities_for_memories(
     compile path also rolls back the entity writes, no partial state.
 
     Order of operations (the Phase 7 entity-linking sequence):
-      1. Parallel LLM extraction (fan-out, _EXTRACT_CONCURRENCY workers)
+      1. Batched parallel LLM extraction (entity_extract_batch_size facts
+         per call, entity_extract_concurrency calls in flight)
       2. Collect all distinct (text, normalized, kind) entities
       3. Batch-embed in ONE provider call (memory bandwidth, not latency)
       4. Per-(memory_id, entity) call upsert_entity_with_link, which
@@ -107,10 +114,16 @@ async def populate_entities_for_memories(
     if not memories:
         return 0
 
-    # ── Step 1: parallel LLM extraction ─────────────────────────────────
-    semaphore = asyncio.Semaphore(_EXTRACT_CONCURRENCY)
-    tasks = [_extract_one(m, semaphore) for m in memories]
-    results = await asyncio.gather(*tasks, return_exceptions=False)
+    # ── Step 1: batched parallel LLM extraction ─────────────────────────
+    from server.core.config import settings
+
+    batch_size = max(1, settings.entity_extract_batch_size)
+    semaphore = asyncio.Semaphore(max(1, settings.entity_extract_concurrency))
+    groups = [memories[i : i + batch_size] for i in range(0, len(memories), batch_size)]
+    group_results = await asyncio.gather(
+        *[_extract_group(g, semaphore) for g in groups], return_exceptions=False
+    )
+    results = [pair for group in group_results for pair in group]
 
     # ── Step 2: flatten + dedup entity text within this batch ────────────
     # (Same surface form across two memories gets ONE embedding call,

--- a/server/services/entity_extraction.py
+++ b/server/services/entity_extraction.py
@@ -286,4 +286,10 @@ async def extract_entities_batch(texts: list[str]) -> list[list[ExtractedEntity]
         )
         return [await extract_entities(t) for t in texts]
 
-    return [_entities_from_list(results.get(str(i))) for i in range(len(texts))]
+    # Facts are labeled "FACT n" in the prompt while the requested keys are
+    # bare indices — accept either, so a model that echoes the label doesn't
+    # silently yield an all-empty batch through the missing-index path.
+    return [
+        _entities_from_list(results.get(str(i), results.get(f"FACT {i}")))
+        for i in range(len(texts))
+    ]

--- a/server/services/entity_extraction.py
+++ b/server/services/entity_extraction.py
@@ -104,7 +104,7 @@ Treat every fact independently — an entity mentioned in two facts appears in b
     + _ENTITY_RULES
     + """
 
-FACTS:
+FACTS (one per line, each prefixed with its index):
 {facts}
 
 Return exactly this JSON, with one entry per fact index:
@@ -239,7 +239,12 @@ async def extract_entities_batch(texts: list[str]) -> list[list[ExtractedEntity]
     if len(texts) == 1:
         return [await extract_entities(texts[0])]
 
-    numbered = "\n".join(f"{i}: {t.strip()}" for i, t in enumerate(texts))
+    # Collapse internal whitespace so multi-line fact content (procedure
+    # steps like "2: run alembic") cannot mimic the index framing and
+    # cross-attribute entities to the wrong fact.
+    numbered = "\n".join(
+        f"FACT {i}: {' '.join(t.split())}" for i, t in enumerate(texts)
+    )
     messages = [
         {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
         {"role": "user", "content": BATCH_EXTRACTION_USER_TEMPLATE.format(facts=numbered)},
@@ -248,16 +253,32 @@ async def extract_entities_batch(texts: list[str]) -> list[list[ExtractedEntity]
         response_text = await acomplete(
             messages,
             model=_extraction_model(),
-            max_tokens=min(200 + 150 * len(texts), 4000),
+            max_tokens=min(300 + 250 * len(texts), 4000),
             temperature=0.0,
             response_format={"type": "json_object"},
         )
+    except Exception:
+        # Transport/provider failure (timeout, outage): per-fact calls would
+        # hit the SAME dead provider one at a time, sequentially, while the
+        # caller holds a concurrency slot — up to batch_size x timeout of
+        # stall per group. Entities are best-effort; return nothing instead.
+        logger.warning(
+            "entity_batch_extraction_unavailable",
+            batch_size=len(texts),
+            exc_info=True,
+        )
+        return [[] for _ in texts]
+
+    try:
         cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", (response_text or "").strip())
         parsed = json.loads(cleaned)
         results = parsed.get("results") if isinstance(parsed, dict) else None
         if not isinstance(results, dict):
             raise ValueError("batched extraction response has no results mapping")
     except Exception:
+        # The provider ANSWERED but the batched shape is unusable — the
+        # per-fact prompt is more robust, and the provider is demonstrably
+        # up, so falling back per fact is worth the extra calls.
         logger.warning(
             "entity_batch_extraction_failed",
             batch_size=len(texts),

--- a/server/services/entity_extraction.py
+++ b/server/services/entity_extraction.py
@@ -66,9 +66,7 @@ EXTRACTION_SYSTEM_PROMPT = (
     "Return ONLY valid JSON with the exact shape requested."
 )
 
-EXTRACTION_USER_TEMPLATE = """Extract every distinct named entity from the fact below.
-
-An entity is:
+_ENTITY_RULES = """An entity is:
   - A proper noun (person, place, organization, product, event, work)
   - A specific compound noun phrase that identifies one thing ("the navy blue blazer", "the 5K charity run")
   - A specific date or date range when it identifies a SPECIFIC event (skip generic dates like "yesterday")
@@ -82,13 +80,36 @@ NOT entities:
 
 For each entity, output:
   - text: the canonical surface form (preserve casing as written)
-  - kind: one of PERSON | ORG | GPE | LOC | PRODUCT | EVENT | WORK | DATE | MISC
+  - kind: one of PERSON | ORG | GPE | LOC | PRODUCT | EVENT | WORK | DATE | MISC"""
+
+EXTRACTION_USER_TEMPLATE = (
+    """Extract every distinct named entity from the fact below.
+
+"""
+    + _ENTITY_RULES
+    + """
 
 FACT:
 {text}
 
 Return exactly this JSON:
 {{"entities": [{{"text": "<entity>", "kind": "<label>"}}, ...]}}"""
+)
+
+BATCH_EXTRACTION_USER_TEMPLATE = (
+    """Extract every distinct named entity from EACH numbered fact below.
+Treat every fact independently — an entity mentioned in two facts appears in both results.
+
+"""
+    + _ENTITY_RULES
+    + """
+
+FACTS:
+{facts}
+
+Return exactly this JSON, with one entry per fact index:
+{{"results": {{"0": [{{"text": "<entity>", "kind": "<label>"}}, ...], "1": [...], ...}}}}"""
+)
 
 
 @dataclass(frozen=True)
@@ -133,7 +154,12 @@ def _parse_entities(raw: str) -> list[ExtractedEntity]:
             return []
     if not isinstance(j, dict):
         return []
-    raw_entities = j.get("entities")
+    return _entities_from_list(j.get("entities"))
+
+
+def _entities_from_list(raw_entities: object) -> list[ExtractedEntity]:
+    """Validate + normalize one JSON entity array (shared by the single and
+    batched parsers — the per-entity rules must never drift between them)."""
     if not isinstance(raw_entities, list):
         return []
     out: list[ExtractedEntity] = []
@@ -191,3 +217,52 @@ async def extract_entities(text: str) -> list[ExtractedEntity]:
         logger.warning("entity_extraction_failed", text_preview=text[:80], exc_info=True)
         return []
     return _parse_entities(response_text)
+
+
+async def extract_entities_batch(texts: list[str]) -> list[list[ExtractedEntity]]:
+    """Extract entities for several facts in ONE provider call.
+
+    Per-memory extraction was ~60% of all provider round-trips on a large
+    compile and the dominant amplifier of a provider latency regression
+    (issue #380: ~745 calls per 411-episode pack). Batching cuts that to
+    ~1/batch_size with identical per-entity rules (the rules block is
+    shared with the single-fact prompt).
+
+    Fail-open like `extract_entities`, in two stages: a structurally
+    unusable batched response falls back to per-fact calls (which
+    themselves fail-open to []); a well-formed response with a missing
+    index yields [] for that fact only. Always returns exactly
+    ``len(texts)`` lists, index-aligned.
+    """
+    if not texts:
+        return []
+    if len(texts) == 1:
+        return [await extract_entities(texts[0])]
+
+    numbered = "\n".join(f"{i}: {t.strip()}" for i, t in enumerate(texts))
+    messages = [
+        {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
+        {"role": "user", "content": BATCH_EXTRACTION_USER_TEMPLATE.format(facts=numbered)},
+    ]
+    try:
+        response_text = await acomplete(
+            messages,
+            model=_extraction_model(),
+            max_tokens=min(200 + 150 * len(texts), 4000),
+            temperature=0.0,
+            response_format={"type": "json_object"},
+        )
+        cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", (response_text or "").strip())
+        parsed = json.loads(cleaned)
+        results = parsed.get("results") if isinstance(parsed, dict) else None
+        if not isinstance(results, dict):
+            raise ValueError("batched extraction response has no results mapping")
+    except Exception:
+        logger.warning(
+            "entity_batch_extraction_failed",
+            batch_size=len(texts),
+            exc_info=True,
+        )
+        return [await extract_entities(t) for t in texts]
+
+    return [_entities_from_list(results.get(str(i))) for i in range(len(texts))]

--- a/tests/test_bootstrap_docs_pack.py
+++ b/tests/test_bootstrap_docs_pack.py
@@ -232,3 +232,51 @@ async def test_compile_exits_nonzero_after_second_death():
         await bootstrap._compile_async(client, "http://x", "subj")
     assert exc.value.code == 1
     assert client.post_calls == 2
+
+
+# --- entity rebuild after the swap import (issue #380) ----------------------
+#
+# Pinned because the rebuild is best-effort BY DESIGN: the swap already
+# succeeded, so neither a network failure (attempts=1, no re-POST that
+# would race a still-running rebuild) nor a non-200 (incl. a 404 from a
+# server predating the endpoint) may turn the refresh red.
+
+
+class _ImportClient:
+    def __init__(self, rebuild_outcome):
+        self._rebuild_outcome = rebuild_outcome
+        self.rebuild_posts = 0
+
+    async def post(self, url, **_kw):
+        if url.endswith("/rebuild-entities"):
+            self.rebuild_posts += 1
+            if isinstance(self._rebuild_outcome, Exception):
+                raise self._rebuild_outcome
+            return self._rebuild_outcome
+        return httpx.Response(status_code=200, json={"memories_imported": 5})
+
+
+@pytest.mark.asyncio
+async def test_rebuild_network_failure_is_nonfatal_and_single_attempt(capsys):
+    client = _ImportClient(httpx.ConnectTimeout("slow rebuild"))
+    result = await bootstrap._import_into(client, "http://x", {"doc": 1}, "live-subj")
+    assert result["memories_imported"] == 5, "swap result survives a rebuild failure"
+    assert client.rebuild_posts == 1, "must never re-POST a possibly-running rebuild"
+    assert "WARN entity rebuild" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_rebuild_404_from_old_server_is_nonfatal(capsys):
+    client = _ImportClient(httpx.Response(status_code=404))
+    result = await bootstrap._import_into(client, "http://x", {"doc": 1}, "live-subj")
+    assert result["memories_imported"] == 5
+    err = capsys.readouterr().err
+    assert err.count("WARN entity rebuild") == 1
+
+
+@pytest.mark.asyncio
+async def test_rebuild_success_reports_count(capsys):
+    client = _ImportClient(httpx.Response(status_code=200, json={"entities_rebuilt": 42}))
+    result = await bootstrap._import_into(client, "http://x", {"doc": 1}, "live-subj")
+    assert result["memories_imported"] == 5
+    assert "rebuilt 42 entity rows" in capsys.readouterr().out

--- a/tests/test_entity_extraction_batching.py
+++ b/tests/test_entity_extraction_batching.py
@@ -66,14 +66,34 @@ async def test_batch_structural_failure_falls_back_to_per_fact():
     assert single.await_count == 2
 
 
-async def test_batch_provider_error_falls_back_to_per_fact():
-    single = AsyncMock(side_effect=[[], []])
+async def test_batch_provider_error_returns_empty_without_per_fact_storm():
+    """A dead provider must NOT trigger batch_size sequential per-fact
+    calls under the concurrency slot — each would burn the same timeout
+    against the same dead provider. Entities are best-effort: empty."""
+    single = AsyncMock()
     with patch.object(
         ee, "acomplete", new=AsyncMock(side_effect=RuntimeError("provider down"))
     ), patch.object(ee, "extract_entities", new=single):
         out = await ee.extract_entities_batch(["fact a", "fact b"])
     assert out == [[], []]
-    assert single.await_count == 2
+    single.assert_not_awaited()
+
+
+async def test_batch_framing_collapses_multiline_content():
+    """Fact content with embedded newlines (procedure steps like
+    '2: run alembic') must not mimic the index framing."""
+    captured = {}
+
+    async def fake_acomplete(messages, **kwargs):
+        captured["user"] = messages[1]["content"]
+        return json.dumps({"results": {"0": [], "1": []}})
+
+    with patch.object(ee, "acomplete", new=fake_acomplete):
+        await ee.extract_entities_batch(["step one\n2: run alembic", "plain fact"])
+
+    facts_block = captured["user"].split("FACTS")[1]
+    assert "\n2: run alembic" not in facts_block, "newline framing must be collapsed"
+    assert "FACT 0: step one 2: run alembic" in facts_block
 
 
 async def test_single_fact_uses_single_path():
@@ -132,32 +152,63 @@ async def test_populate_groups_by_batch_size(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# admin import: opt-in entity rebuild
+# rebuild-entities endpoint (deliberately separate from /admin/import: an
+# inline rebuild made the import outlive client timeouts, and a retried
+# already-committed import with preserve_ids=False duplicates the subject)
 # ---------------------------------------------------------------------------
 
 
-async def _call_import(monkeypatch, rebuild: bool):
+async def test_rebuild_endpoint_populates_from_active_memories(monkeypatch):
     from server.api import admin as api_admin
 
-    async def fake_import(document, **_kw):
-        return {"subject_id": "subj", "tenant_id": None, "memories_imported": 2}
+    class _Row:
+        def __init__(self, content):
+            self.id = uuid.uuid4()
+            self.content = content
 
-    rebuilt = AsyncMock(return_value=7)
-    monkeypatch.setattr("server.services.backup.import_subject", fake_import)
-    monkeypatch.setattr(api_admin, "_rebuild_entities_for_import", rebuilt)
+    rows = [_Row("fact a"), _Row("fact b")]
+    seen = {}
 
-    req = api_admin.ImportSubjectRequest(document={}, rebuild_entities=rebuild)
-    result = await api_admin.import_subject_endpoint(req)
-    return result, rebuilt
+    async def fake_list(_session, subject_id, *, tenant_id, limit):
+        seen["limit"] = limit
+        return rows
+
+    async def fake_populate(_session, memories, *, subject_id, tenant_id):
+        seen["memories"] = len(memories)
+        return 5
+
+    class _Ctx:
+        async def __aenter__(self):
+            return AsyncMock()
+
+        async def __aexit__(self, *a):
+            return None
+
+    import server.db.engine as engine_module
+    import server.db.repositories as repo_module
+    import server.services.entities as ent_module
+
+    monkeypatch.setattr(engine_module, "get_session_factory", lambda: lambda: _Ctx())
+    monkeypatch.setattr(repo_module, "list_active_memories_by_subject", fake_list)
+    monkeypatch.setattr(ent_module, "populate_entities_for_memories", fake_populate)
+
+    result = await api_admin.rebuild_entities_endpoint("subj", tenant_id=None)
+    assert result == {"subject_id": "subj", "entities_rebuilt": 5, "enabled": True}
+    assert seen["memories"] == 2
+    assert seen["limit"] == 10_000
 
 
-async def test_import_rebuilds_entities_when_asked(monkeypatch):
-    result, rebuilt = await _call_import(monkeypatch, rebuild=True)
-    rebuilt.assert_awaited_once_with("subj", None)
-    assert result["entities_rebuilt"] == 7
+async def test_rebuild_endpoint_is_noop_when_population_disabled(monkeypatch):
+    from server.api import admin as api_admin
+
+    with patch.object(settings, "entity_population_enabled", False):
+        result = await api_admin.rebuild_entities_endpoint("subj", tenant_id=None)
+    assert result["entities_rebuilt"] == 0 and result["enabled"] is False
 
 
-async def test_import_skips_rebuild_by_default(monkeypatch):
-    result, rebuilt = await _call_import(monkeypatch, rebuild=False)
-    rebuilt.assert_not_awaited()
-    assert "entities_rebuilt" not in result
+async def test_import_request_has_no_rebuild_flag():
+    """Pin the review outcome: the rebuild must never ride inside the
+    import request again."""
+    from server.api import admin as api_admin
+
+    assert "rebuild_entities" not in api_admin.ImportSubjectRequest.model_fields

--- a/tests/test_entity_extraction_batching.py
+++ b/tests/test_entity_extraction_batching.py
@@ -1,0 +1,163 @@
+"""Batched entity extraction (issue #380).
+
+Per-memory extraction was one LLM call per compiled memory — ~745 calls
+for the 411-episode docs pack, ~60% of all provider round-trips, and the
+dominant amplifier when provider latency degrades. Batching cuts that to
+~1/batch_size. Pinned invariants:
+
+* per-entity validation rules are SHARED between the single and batched
+  parsers (one `_entities_from_list`), so quality cannot drift;
+* a structurally unusable batched response falls back to per-fact calls
+  (which themselves fail-open to []); a missing index in a well-formed
+  response yields [] for that fact only;
+* the result is always index-aligned with the input;
+* `populate_entities_for_memories` groups by `entity_extract_batch_size`;
+* the admin import endpoint rebuilds the entity store only when asked
+  (export documents don't carry subject_entities — before this, every
+  docs-pack swap left the live subject with zero entity rows).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from server.core.config import settings
+from server.services import entity_extraction as ee
+
+pytestmark = pytest.mark.asyncio
+
+
+def _batched_response(mapping: dict) -> str:
+    return json.dumps({"results": mapping})
+
+
+async def test_batch_returns_index_aligned_lists():
+    resp = _batched_response(
+        {
+            "0": [{"text": "Alice", "kind": "PERSON"}],
+            "1": [{"text": "Acme Corp", "kind": "ORG"}, {"text": "Chicago", "kind": "GPE"}],
+        }
+    )
+    with patch.object(ee, "acomplete", new=AsyncMock(return_value=resp)):
+        out = await ee.extract_entities_batch(["fact a", "fact b"])
+    assert [len(lst) for lst in out] == [1, 2]
+    assert out[0][0].text == "Alice" and out[0][0].kind == "PERSON"
+    assert out[1][1].normalized == "chicago"
+
+
+async def test_batch_missing_index_yields_empty_for_that_fact_only():
+    resp = _batched_response({"1": [{"text": "Alice", "kind": "PERSON"}]})
+    with patch.object(ee, "acomplete", new=AsyncMock(return_value=resp)):
+        out = await ee.extract_entities_batch(["fact a", "fact b"])
+    assert out[0] == [] and len(out[1]) == 1
+
+
+async def test_batch_structural_failure_falls_back_to_per_fact():
+    single = AsyncMock(side_effect=[["A"], ["B"]])
+    with patch.object(ee, "acomplete", new=AsyncMock(return_value="not json at all")), patch.object(
+        ee, "extract_entities", new=single
+    ):
+        out = await ee.extract_entities_batch(["fact a", "fact b"])
+    assert out == [["A"], ["B"]]
+    assert single.await_count == 2
+
+
+async def test_batch_provider_error_falls_back_to_per_fact():
+    single = AsyncMock(side_effect=[[], []])
+    with patch.object(
+        ee, "acomplete", new=AsyncMock(side_effect=RuntimeError("provider down"))
+    ), patch.object(ee, "extract_entities", new=single):
+        out = await ee.extract_entities_batch(["fact a", "fact b"])
+    assert out == [[], []]
+    assert single.await_count == 2
+
+
+async def test_single_fact_uses_single_path():
+    single = AsyncMock(return_value=["X"])
+    batched_call = AsyncMock()
+    with patch.object(ee, "extract_entities", new=single), patch.object(
+        ee, "acomplete", new=batched_call
+    ):
+        out = await ee.extract_entities_batch(["only fact"])
+    assert out == [["X"]]
+    batched_call.assert_not_awaited()
+
+
+async def test_batched_parser_shares_validation_rules_with_single():
+    """The dedup/normalization rules must be literally the same code path:
+    duplicate normalized forms collapse, blank text drops, kind uppercases."""
+    items = [
+        {"text": "Alice", "kind": "person"},
+        {"text": "alice", "kind": "PERSON"},  # duplicate after normalization
+        {"text": "   ", "kind": "ORG"},  # blank
+        {"text": "Acme", "kind": ""},  # kind missing → None
+    ]
+    via_batch = ee._entities_from_list(items)
+    via_single = ee._parse_entities(json.dumps({"entities": items}))
+    assert [(e.text, e.normalized, e.kind) for e in via_batch] == [
+        (e.text, e.normalized, e.kind) for e in via_single
+    ]
+    assert via_batch[0].kind == "PERSON"
+    assert via_batch[1].kind is None
+
+
+# ---------------------------------------------------------------------------
+# populate_entities_for_memories: grouping
+# ---------------------------------------------------------------------------
+
+
+async def test_populate_groups_by_batch_size(monkeypatch):
+    from server.services import entities as ent
+
+    memories = [
+        ent.MemoryForEntities(id=uuid.uuid4(), content=f"fact {i}") for i in range(25)
+    ]
+    group_sizes: list[int] = []
+
+    async def fake_batch(texts):
+        group_sizes.append(len(texts))
+        return [[] for _ in texts]
+
+    monkeypatch.setattr(ent, "extract_entities_batch", fake_batch)
+    with patch.object(settings, "entity_extract_batch_size", 10):
+        touched = await ent.populate_entities_for_memories(
+            AsyncMock(), memories, subject_id="subj", tenant_id=None
+        )
+    assert touched == 0
+    assert sorted(group_sizes, reverse=True) == [10, 10, 5]
+
+
+# ---------------------------------------------------------------------------
+# admin import: opt-in entity rebuild
+# ---------------------------------------------------------------------------
+
+
+async def _call_import(monkeypatch, rebuild: bool):
+    from server.api import admin as api_admin
+
+    async def fake_import(document, **_kw):
+        return {"subject_id": "subj", "tenant_id": None, "memories_imported": 2}
+
+    rebuilt = AsyncMock(return_value=7)
+    monkeypatch.setattr("server.services.backup.import_subject", fake_import)
+    monkeypatch.setattr(api_admin, "_rebuild_entities_for_import", rebuilt)
+
+    req = api_admin.ImportSubjectRequest(document={}, rebuild_entities=rebuild)
+    result = await api_admin.import_subject_endpoint(req)
+    return result, rebuilt
+
+
+async def test_import_rebuilds_entities_when_asked(monkeypatch):
+    result, rebuilt = await _call_import(monkeypatch, rebuild=True)
+    rebuilt.assert_awaited_once_with("subj", None)
+    assert result["entities_rebuilt"] == 7
+
+
+async def test_import_skips_rebuild_by_default(monkeypatch):
+    result, rebuilt = await _call_import(monkeypatch, rebuild=False)
+    rebuilt.assert_not_awaited()
+    assert "entities_rebuilt" not in result

--- a/tests/test_entity_extraction_batching.py
+++ b/tests/test_entity_extraction_batching.py
@@ -212,3 +212,15 @@ async def test_import_request_has_no_rebuild_flag():
     from server.api import admin as api_admin
 
     assert "rebuild_entities" not in api_admin.ImportSubjectRequest.model_fields
+
+
+async def test_batch_accepts_fact_labeled_keys():
+    """A model that echoes the "FACT n" label as the JSON key must not
+    silently yield an all-empty batch through the missing-index path."""
+    resp = _batched_response(
+        {"FACT 0": [{"text": "Alice", "kind": "PERSON"}], "1": [{"text": "Acme", "kind": "ORG"}]}
+    )
+    with patch.object(ee, "acomplete", new=AsyncMock(return_value=resp)):
+        out = await ee.extract_entities_batch(["fact a", "fact b"])
+    assert out[0][0].text == "Alice"
+    assert out[1][0].text == "Acme"


### PR DESCRIPTION
Second of two PRs for #380 (fix 2 from the plan there): entity extraction goes from ~745 one-per-memory LLM calls to ~75 batched calls (10 facts/call, 8 in flight — ~93 sequential waves become ~10), with the per-entity validation rules shared between the single and batched parsers so quality cannot drift, and two-stage fail-open (structural failure → per-fact fallback → []). Verified with a live gpt-4o-mini round-trip producing identical entities to the single-call path.

Also fixes the gap #380 surfaced: export documents don't carry `subject_entities`, so every docs-pack swap left the live subject with an empty entity store. `POST /admin/import` gains opt-in `rebuild_entities` and the bootstrap script requests it on the swap.

Bench-neutral by construction: the entity lane defaults off (`entity_weight=0`, `hybrid=true` only) and the published bench numbers ran with it off. 9 new tests; 1035 unit + 285 integration passed; ruff clean.