### PR TITLE
fix(tests): use explicit UTF-8 file I/O

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,8 @@ authorized the contribution before submitting.
 ## Code style
 
 - Python 3.11+, formatted with `ruff` (settings in `pyproject.toml`).
+- Source files are UTF-8; test and script file I/O must specify `encoding="utf-8"`
+  so contributor tooling behaves consistently on Windows.
 - Type hints on public APIs.
 - Match the surrounding code's conventions; prefer small, composable
   functions; prefer clear names over comments.

--- a/scripts/eval/eval_docs_support.py
+++ b/scripts/eval/eval_docs_support.py
@@ -331,7 +331,7 @@ def emit_json(summary: EvalSummary, path: str) -> None:
             for r in summary.results
         ],
     }
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
     print(f"\nSnapshot written to {path}")
 

--- a/tests/test_admin_clone.py
+++ b/tests/test_admin_clone.py
@@ -191,7 +191,7 @@ def test_clone_response_shape_does_not_carry_legacy_copied_keys():
     """
     from pathlib import Path
 
-    src = Path(mp.__file__).read_text()
+    src = Path(mp.__file__).read_text(encoding="utf-8")
     assert '"copied_episodes"' not in src
     assert '"copied_memories"' not in src
     assert '"copied_sources"' not in src

--- a/tests/test_docs_loader.py
+++ b/tests/test_docs_loader.py
@@ -179,7 +179,7 @@ def test_to_episode_provenance_has_hash_and_pack_version():
 
 def test_load_docs_raises_on_missing_manifest_entry(tmp_path: Path):
     # Only place one of the manifest files
-    (tmp_path / "README.md").write_text("# Hi\n\nbody\n")
+    (tmp_path / "README.md").write_text("# Hi\n\nbody\n", encoding="utf-8")
     with pytest.raises(FileNotFoundError) as exc_info:
         load_docs(tmp_path, manifest=("README.md", "does-not-exist.md"))
     assert "does-not-exist.md" in str(exc_info.value)
@@ -190,7 +190,7 @@ def test_load_docs_loads_full_manifest(tmp_path: Path):
     for rel in MANIFEST:
         full = tmp_path / rel
         full.parent.mkdir(parents=True, exist_ok=True)
-        full.write_text(f"# {rel}\n\nbody for {rel}\n")
+        full.write_text(f"# {rel}\n\nbody for {rel}\n", encoding="utf-8")
     sections = load_docs(tmp_path)
     # One section per stub doc (each has exactly one heading with body)
     assert len(sections) == len(MANIFEST)

--- a/tests/test_no_raw_tokenization.py
+++ b/tests/test_no_raw_tokenization.py
@@ -20,7 +20,9 @@ def test_no_raw_lower_split_outside_shared_tokenizer():
     for path in _SERVER.rglob("*.py"):
         if path in _ALLOWED:
             continue
-        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
             if ".lower().split()" in line:
                 offenders.append(f"{path.relative_to(_SERVER.parent)}:{lineno}")
     assert not offenders, (

--- a/tests/test_route_limits_invariant.py
+++ b/tests/test_route_limits_invariant.py
@@ -35,7 +35,7 @@ def _iter_param_defaults(func: ast.AsyncFunctionDef | ast.FunctionDef):
 def _violations() -> list[str]:
     bad: list[str] = []
     for path in sorted(_API_DIR.glob("*.py")):
-        tree = ast.parse(path.read_text())
+        tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
                 continue

--- a/tests/test_tenant_scoping_invariant.py
+++ b/tests/test_tenant_scoping_invariant.py
@@ -29,7 +29,7 @@ _ALLOWED_UNSCOPED: set[str] = set()
 
 
 def _subject_scoped_without_tenant() -> set[str]:
-    tree = ast.parse(_REPOSITORIES.read_text())
+    tree = ast.parse(_REPOSITORIES.read_text(encoding="utf-8"))
     out: set[str] = set()
     for node in tree.body:
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):


### PR DESCRIPTION
## Description

Makes all five identified source-file reads/writes explicitly UTF-8 so invariant and eval tooling no longer depends on the Windows locale codec.

## Related Issue

Closes #350

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Test improvement

## Changes Made

- Added `encoding="utf-8"` at every listed boundary.
- Documented the cross-platform file-I/O rule in `CONTRIBUTING.md`.

## Testing

- [x] Unit tests pass locally
- [x] Integration tests pass locally

### Test Commands Run

```bash
uv run ruff check .
uv run pytest -q
```

The full run reached 1,334 passed and 5 skipped; only three live-stack smoke tests failed because the API service was intentionally not running. PostgreSQL-backed tests used the repository Docker database, which was stopped afterward.

## Checklist

- [x] Coding standards and self-review complete
- [x] Documentation updated
- [x] No breaking changes
